### PR TITLE
Fix replay gui nil problem

### DIFF
--- a/lib/roby/log/gui/chronicle.rb
+++ b/lib/roby/log/gui/chronicle.rb
@@ -684,7 +684,7 @@ module Roby
                 if chronicle.current_time == chronicle.history_widget.current_time
                     return
                 end
-
+                chronicle.current_time = chronicle.history_widget.current_time if !chronicle.current_time
                 new_time = chronicle.current_time + PLAY_STEP
                 if new_time >= chronicle.history_widget.current_time
                     new_time = chronicle.history_widget.current_time


### PR DESCRIPTION
This commits workarounds some problems that the
chronicle.current_time is nil in some cases when i jumping
around in the logfiles and cause a crash otherwise
