### PR TITLE
Fixed calculation of numeric values

### DIFF
--- a/lib/roby/coordination/calculus.rb
+++ b/lib/roby/coordination/calculus.rb
@@ -27,7 +27,15 @@ module Roby
             end
             Binary = Struct.new :op, :left, :right do
                 def evaluate(variables)
-                    left.evaluate(variables).send(op, right.evaluate(variables))
+                    if right.respond_to?(:evaluate) and left.respond_to?(:evaluate)
+                        left.evaluate(variables).send(op, right.evaluate(variables))
+                    elsif right.respond_to?(:evaluate)
+                        left.send(op, right.evaluate(variables))
+                    elsif left.respond_to?(:evaluate)
+                        left.evaluate(variables).send(op, right)
+                    else
+                        left.send(op,right)
+                    end
                 end
                 include Build
             end


### PR DESCRIPTION
Numeric values in the past could only calculated if the left-side was
a numeric value. This results for more complex calulation in the error
that "evaluation" function for Fixnums undefined was. This commit enables
the caluation for any constallaton.