### PR TITLE
add lib/yard-roby.rb to load the Roby-specific YARD extensions

### DIFF
--- a/lib/yard-roby.rb
+++ b/lib/yard-roby.rb
@@ -1,0 +1,1 @@
+require 'roby/yard'


### PR DESCRIPTION
This allows Roby apps to load these roby extensions as a YARD plugin
(e.g. with YARD's --plugin command line option)