### PR TITLE
coordination: replace Roby::Variable with real values

### DIFF
--- a/lib/roby/coordination/models/task_from_as_plan.rb
+++ b/lib/roby/coordination/models/task_from_as_plan.rb
@@ -20,7 +20,19 @@ module Roby
                     # Called by the state machine implementation to create a Roby::Task
                     # instance that will perform the state's actions
                     def instanciate(plan, variables = Hash.new)
-                        plan.add(task = instanciation_object.as_plan)
+                        # replace Model::Variable with real values
+                        new_args= instanciation_object.arguments.select do |k,v|
+                            v.kind_of?(Variable) && variables.include?(k)
+                        end
+                        new_args = new_args.map_value do |k, v|
+                            variables[v.name]
+                        end
+                        task = if(new_args.empty?)
+                                   instanciation_object.as_plan
+                               else
+                                   instanciation_object.dup.with_arguments(new_args).as_plan
+                               end
+                        plan.add(task)
                         task
                     end
 


### PR DESCRIPTION
I am not sure if this is the right spot and I also do not like to dup the hole object only to not overwrite the Variable for the next call. 

This allows to use with_arguments in code blocks given to action_script
or action_state_machine.

    describe('...').optional_arg('speed','speed in m/s',0.1)
    action_state_machine('move') do
        Compositions::Control::MoveForward.use(odometry_def,control_def).with_arguments(:speed=> speed)
        ...
    end