### PR TITLE
Fix host option

### DIFF
--- a/lib/roby/app.rb
+++ b/lib/roby/app.rb
@@ -537,18 +537,24 @@ module Roby
         #
         # When added, a :host entry will be added to the provided options hash
         def self.host_options(parser, options)
+            options[:host] ||= Roby.app.shell_interface_host || 'localhost'
+            options[:port] ||= Roby.app.shell_interface_port || Interface::DEFAULT_PORT
+
             parser.on('--host URL', String, "sets the host to connect to as hostname[:PORT]") do |url|
-                options[:host] = url
+                if url =~ /(.*):(\d+)$/
+                    options[:host] = $1
+                    options[:port] = Integer($2)
+                else
+                    options[:host] = url
+                end
             end
             parser.on('--vagrant NAME[:PORT]', String, "connect to a vagrant VM") do |vagrant_name|
                 require 'roby/app/vagrant'
-                vagrant_name, port = vagrant_name.split(':')
-                host = Roby::App::Vagrant.resolve_ip(vagrant_name)
-                if port
-                    options[:host] = "#{host}:#{port}"
-                else
-                    options[:host] = host
+                if vagrant_name =~ /(.*):(\d+)$/
+                    vagrant_name, port = $1, Integer($2)
                 end
+                options[:host] = Roby::App::Vagrant.resolve_ip(vagrant_name)
+                options[:port] = port
             end
         end
 

--- a/lib/roby/app/scripts.rb
+++ b/lib/roby/app/scripts.rb
@@ -18,13 +18,14 @@ module Roby
                 attr_reader :app
                 attr_reader :host
 
-                def initialize(app = Roby.app)
+                def initialize(app = Roby.app,
+                               default_host: app.shell_interface_host || 'localhost',
+                               default_port: app.shell_interface_port || Interface::DEFAULT_PORT)
                     @app = app
-                    @host_options = Hash.new
+                    @host_options = Hash[host: default_host, port: default_port]
                 end
 
                 def setup_option_parser(parser)
-                    @host_options = Hash.new
                     Roby::Application.host_options(parser, @host_options)
                 end
 
@@ -41,17 +42,7 @@ module Roby
                 end
 
                 def host
-                    remote_url = @host_options[:host] || app.shell_interface_host || 'localhost'
-                    if remote_url !~ /:\d+$/
-                        remote_url += ":#{app.shell_interface_port.to_s}"
-                    end
-
-                    match = /(.*):(\d+)$/.match(remote_url)
-                    if !match
-                        raise ArgumentError, "malformed URL #{remote_url}"
-                    end
-
-                    return match[1], Integer(match[2])
+                    return *@host_options.values_at(:host, :port)
                 end
 
                 def run(*args, banner: "",

--- a/lib/roby/app/scripts/shell.rb
+++ b/lib/roby/app/scripts/shell.rb
@@ -7,39 +7,28 @@ app.guess_app_dir
 app.shell
 app.single
 app.load_config_yaml
+app.base_setup
 
 require 'pp'
 
-remote_url = nil
 silent = false
 opt = OptionParser.new do |opt|
-    opt.on('--host URL', String, "sets the host to connect to") do |url|
-	remote_url = url
-    end
     opt.on '--silent', 'disable notifications (can also be controlled in the shell itself)' do
         silent = true
     end
 end
+
+host_options = Hash.new
+Roby::Application.host_options(opt, host_options)
 opt.parse! ARGV
 
-error = Roby.display_exception do
-    app.base_setup
-
-    if !remote_url
-        remote_url = "#{app.shell_interface_host}:#{app.shell_interface_port}"
-    elsif remote_url !~ /:\d+$/
-        remote_url += ":#{app.shell_interface_port}"
-    end
-end
-if error
-    exit(1)
-end
+host, port = host_options.values_at(:host, :port)
 
 require 'irb'
 require 'irb/ext/save-history'
-IRB.setup(remote_url)
+IRB.setup("#{host}:#{port}")
 IRB.conf[:INSPECT_MODE] = false
-IRB.conf[:IRB_NAME]     = remote_url
+IRB.conf[:IRB_NAME]     = "#{host}:#{port}"
 IRB.conf[:USE_READLINE] = true
 IRB.conf[:PROMPT_MODE]  = :ROBY
 IRB.conf[:AUTO_INDENT] = true
@@ -57,10 +46,8 @@ IRB.conf[:PROMPT][:ROBY] = {
 
 __main_remote_interface__ = 
     begin
-        remote_url =~ /^(.*):(\d+)$/
-        remote_host, remote_port = $1, Integer($2)
-        Roby::Interface::ShellClient.new("#{remote_host}:#{remote_port}") do
-            Roby::Interface.connect_with_tcp_to(remote_host, remote_port)
+        Roby::Interface::ShellClient.new("#{host}:#{port}") do
+            Roby::Interface.connect_with_tcp_to(host, port)
         end
     rescue Interrupt
         Roby::Interface.warn "Interrupted by user"

--- a/lib/roby/interface/tcp.rb
+++ b/lib/roby/interface/tcp.rb
@@ -99,8 +99,10 @@ module Roby
             Client.new(DRobyChannel.new(socket, true, marshaller: DRoby::Marshal.new(auto_create_plans: true)),
                        "#{addr[2]}:#{addr[1]}")
 
-        rescue Errno::ECONNREFUSED
-            raise ConnectionError, "failed to connect to #{host}:#{port}"
+        rescue Errno::ECONNREFUSED => e
+            raise ConnectionError, "failed to connect to #{host}:#{port}: #{e.message}", e.backtrace
+        rescue SocketError => e
+            raise e, "cannot connect to host '#{host}' port '#{port}': #{e.message}", e.backtrace
         rescue ::Exception
             if socket && !socket.closed?
                 socket.close

--- a/test/test_app.rb
+++ b/test/test_app.rb
@@ -735,6 +735,30 @@ module Roby
                 assert_equal Hash['test' => true], app.log_read_metadata
             end
         end
+
+        describe ".host_options" do
+            before do
+                @opt = OptionParser.new
+            end
+            it "sets the host/port pair if both are given" do
+                Application.host_options(@opt, options = Hash[host: 'test', port: 666])
+                @opt.parse(['--host=bla:90'])
+                assert_equal 'bla', options[:host]
+                assert_equal 90, options[:port]
+            end
+            it "sets only the host and leaves the port if no port is given" do
+                Application.host_options(@opt, options = Hash[host: 'test', port: 666])
+                @opt.parse(['--host=bla'])
+                assert_equal 'bla', options[:host]
+                assert_equal 666, options[:port]
+            end
+            it "does not modify the options if no --host argument is given" do
+                Application.host_options(@opt, options = Hash[host: 'test', port: 666])
+                @opt.parse([])
+                assert_equal 'test', options[:host]
+                assert_equal 666, options[:port]
+            end
+        end
     end
 end
 


### PR DESCRIPTION
This is required to be able to connect the various Roby/Syskit tools (including the IDE) to a syskit instance started on a non-standard port.