### PR TITLE
droby: move the droby-related Actions::Models::Actions#proxy and #proxy! methods to their proper place

### DIFF
--- a/lib/roby/actions/models/action.rb
+++ b/lib/roby/actions/models/action.rb
@@ -208,17 +208,6 @@ module Roby
                 end
             end
 
-            def proxy(peer)
-                result = self.dup
-                result.proxy!(peer, arguments)
-                result
-            end
-
-            def proxy!(peer, arguments)
-                @returned_type = returned_type.proxy(peer)
-                @arguments = arguments.proxy(peer)
-            end
-
             def to_action_model
                 self
             end

--- a/lib/roby/droby/v5/droby_dump.rb
+++ b/lib/roby/droby/v5/droby_dump.rb
@@ -602,6 +602,17 @@ module Roby
                             # This is a cached value, invalidate it
                             @returned_task_type = nil
                         end
+
+                        def proxy(peer)
+                            result = self.dup
+                            result.proxy!(peer)
+                            result
+                        end
+
+                        def proxy!(peer)
+                            @returned_type = peer.local_object(returned_type)
+                            @arguments = peer.local_object(arguments)
+                        end
                     end
 
                     module MethodActionDumper


### PR DESCRIPTION
A.k.a into the droby-specific parts