### PR TITLE
interface: improve error codepaths related to Server (closes #64)

### DIFF
--- a/lib/roby/app.rb
+++ b/lib/roby/app.rb
@@ -618,6 +618,11 @@ module Roby
         #
         # @return [Integer]
         attr_accessor :shell_interface_port
+        # Whether an unexpected (non-comm-related) failure in the shell should
+        # cause an abort
+        #
+        # The default is yes
+        attr_predicate :shell_abort_on_exception?, true
         # The {Interface} bound to this app
         # @return [Interface]
         attr_reader :shell_interface
@@ -647,6 +652,7 @@ module Roby
             @shell_interface = nil
             @shell_interface_host = nil
             @shell_interface_port = Interface::DEFAULT_PORT
+            @shell_abort_on_exception = true
 
 	    @automatic_testing = true
             @registered_exceptions = []
@@ -1663,7 +1669,9 @@ module Roby
             if @shell_interface
                 raise RuntimeError, "there is already a shell interface started, call #stop_shell_interface first"
             end
-            @shell_interface = Interface::TCPServer.new(self, host: shell_interface_host, port: shell_interface_port)
+            @shell_interface = Interface::TCPServer.new(
+                self, host: shell_interface_host, port: shell_interface_port)
+            shell_interface.abort_on_exception = shell_abort_on_exception?
             if shell_interface_port != Interface::DEFAULT_PORT
                 Robot.info "shell interface started on port #{shell_interface_port}"
             else

--- a/lib/roby/execution_engine.rb
+++ b/lib/roby/execution_engine.rb
@@ -201,6 +201,11 @@ module Roby
         # 
         # Internal structure used to store a poll block definition provided to
         # #every or #add_propagation_handler
+        #
+        # @!macro poll_options
+        #   @option [Symbol] on_error if :raise (the default), pass exceptions
+        #     to the caller. If :ignore, do nothing. If :disable, remove the
+        #     poll block
         class PollBlockDefinition
             ON_ERROR = [:raise, :ignore, :disable]
 
@@ -2333,8 +2338,8 @@ module Roby
         # @yieldparam [Array<Roby::Task>] tasks the tasks that are involved in this exception
         #
         # @return [Object] an ID that can be used as argument to {#remove_exception_listener}
-	def on_exception(description: 'exception listener', &block)
-            handler = PollBlockDefinition.new(description, block, on_error: :disable)
+	def on_exception(description: 'exception listener', on_error: :disable, &block)
+            handler = PollBlockDefinition.new(description, block, on_error: on_error)
 	    exception_listeners << handler
 	    handler
 	end

--- a/lib/roby/interface/droby_channel.rb
+++ b/lib/roby/interface/droby_channel.rb
@@ -99,10 +99,8 @@ module Roby
                                end
                 marshaller.local_object(unmarshalled)
 
-            rescue Errno::ECONNRESET, EOFError, IOError
+            rescue SystemCallError, EOFError, IOError
                 raise ComError, "closed communication"
-            rescue Errno::EPIPE
-                raise ComError, "broken communication channel"
             end
 
             # Write one ruby object (usually an array) as a marshalled packet and
@@ -131,7 +129,7 @@ module Roby
                 if @write_buffer.size > max_write_buffer_size
                     raise ComError, "droby_channel reached an internal buffer size of #{@write_buffer.size}, which is bigger than the limit of #{max_write_buffer_size}, bailing out"
                 end
-            rescue Errno::EPIPE, IOError, Errno::ECONNRESET
+            rescue SystemCallError, IOError, EOFError
                 raise ComError, "broken communication channel"
             rescue RuntimeError => e
                 # Workaround what seems to be a Ruby bug ...

--- a/lib/roby/interface/interface.rb
+++ b/lib/roby/interface/interface.rb
@@ -489,7 +489,7 @@ module Roby
             # @see ExecutionEngine#on_exception
             def on_exception(&block)
                 execution_engine.execute do
-                    execution_engine.on_exception do |kind, exception, tasks|
+                    execution_engine.on_exception(on_error: :raise) do |kind, exception, tasks|
                         involved_job_ids = tasks.map do |t|
                             job_id_of_task(t)
                         end.compact.to_set

--- a/test/interface/test_droby_channel.rb
+++ b/test/interface/test_droby_channel.rb
@@ -93,6 +93,20 @@ module Roby
                     io_w.close
                     assert_raises(ComError) { channel.read_packet }
                 end
+                it "raises ComError if writing the socket raises SystemCallError a.k.a. any of the Errno constants" do
+                    io_r, io_w = Socket.pair(:UNIX, :STREAM, 0)
+                    flexmock(io_w).should_receive(:write_nonblock).and_raise(SystemCallError.new("test", 0))
+                    channel = DRobyChannel.new(io_w, true)
+                    io_r.close
+                    assert_raises(ComError) { channel.write_packet([]) }
+                end
+                it "raises ComError if reading the socket raises SystemCallError a.k.a. any of the Errno constants" do
+                    io_r, io_w = Socket.pair(:UNIX, :STREAM, 0)
+                    flexmock(io_r).should_receive(:read_nonblock).and_raise(SystemCallError.new("test", 0))
+                    channel = DRobyChannel.new(io_r, true)
+                    io_w.close
+                    assert_raises(ComError) { channel.read_packet }
+                end
             end
 
             describe "packet transmission" do

--- a/test/interface/test_server.rb
+++ b/test/interface/test_server.rb
@@ -1,0 +1,344 @@
+require 'roby/test/self'
+
+module Roby
+    module Interface
+        describe Server do
+
+            describe "remote calls" do
+                attr_reader :interface, :server, :client_channel
+                before do
+                    @interface = Interface.new(Roby::Application.new)
+                    interface.app.execution_engine.display_exceptions = false
+
+                    client_io, server_io = Socket.pair(:UNIX, :STREAM, 0)
+                    server_channel = DRobyChannel.new(server_io, false)
+                    @client_channel = DRobyChannel.new(client_io, true)
+                    @server = Server.new(server_channel, interface)
+                    flexmock(@server)
+                end
+
+                after do
+                    client_channel.close
+                    server.close
+                end
+            
+                it "passes call and arguments, and replies with the result of the call" do
+                    flexmock(server).should_receive(:test_call).
+                        explicitly.once.with(24).and_return([42])
+                    client_channel.write_packet([[], :test_call, 24])
+                    server.poll
+                    assert_equal [:reply, [42]], client_channel.read_packet
+                end
+            
+                it "properly handles if the argument is a Hash" do
+                    flexmock(server).should_receive(:test_call).
+                        explicitly.once.with(Hash.new).and_return(42)
+                    client_channel.write_packet([[], :test_call, Hash.new])
+                    server.poll
+                    assert_equal [:reply, 42], client_channel.read_packet
+                end
+
+                it "properly handles if the reply is a Hash" do
+                    flexmock(server).should_receive(:test_call).
+                        explicitly.once.with(24).and_return(Hash.new)
+                    client_channel.write_packet([[], :test_call, 24])
+                    server.poll
+                    assert_equal [:reply, Hash.new], client_channel.read_packet
+                end
+
+                it "replies with :bad_call and the exception if the call raises" do
+                    flexmock(server).should_receive(:test_call).
+                        explicitly.and_raise(ArgumentError.exception("test message"))
+                    client_channel.write_packet([[], :test_call, 24])
+                    server.poll
+                    type, exception = client_channel.read_packet
+                    assert_equal :bad_call, type
+                    assert_kind_of ArgumentError, exception
+                    assert_equal "test message", exception.message
+                end
+            
+                it "processes all calls from a batch and returns all their return values" do
+                    flexmock(server).should_receive(:test_call).
+                        explicitly.once.with(24).and_return([42])
+                    flexmock(server).should_receive(:test_call).
+                        explicitly.once.with(12).and_return([24])
+                    client_channel.write_packet([[], :process_batch, [[[], :test_call, 24], [[], :test_call, 12]]])
+                    server.poll
+                    assert_equal [:reply, [[42], [24]]], client_channel.read_packet
+                end
+
+                it "replies with :bad_call and the exception if any of the calls raises" do
+                    flexmock(server).should_receive(:test_call).
+                        explicitly.once.with(24).and_return([42])
+                    flexmock(server).should_receive(:test_call).
+                        explicitly.and_raise(ArgumentError.exception('test message'))
+                    client_channel.write_packet([[], :process_batch, [[[], :test_call, 24], [[], :test_call, 12]]])
+                    server.poll
+                    type, exception = client_channel.read_packet
+                    assert_equal :bad_call, type
+                    assert_kind_of ArgumentError, exception
+                    assert_equal "test message", exception.message
+                end
+            end
+
+            describe "error handling" do
+                attr_reader :interface, :server, :server_io, :error_m
+                before do
+                    @interface = Interface.new(Roby::Application.new)
+                    interface.app.execution_engine.display_exceptions = false
+                    @server_io = flexmock
+                    @server = Server.new(@server_io, interface)
+                    flexmock(@server)
+                    @error_m = Class.new(Exception)
+                end
+
+                describe "abort_on_exception: true" do
+                    before do
+                        server.abort_on_exception = true
+                    end
+
+                    def self.handler_error_behaviour(&block)
+                        it "propagates non-ComError exceptions" do
+                            server_io.should_receive(:write_packet).and_raise(error_m)
+                            instance_eval(&block)
+                            assert_raises(error_m) { server.poll }
+                        end
+
+                        it "defers ComError exceptions" do
+                            server_io.should_receive(:write_packet).and_raise(ComError)
+                            instance_eval(&block)
+                            assert_raises(ComError) { server.poll }
+                        end
+                    end
+
+                    describe "the on_cycle_end handler" do
+                        handler_error_behaviour { interface.notify_cycle_end }
+                    end
+
+                    describe "the notification handler" do
+                        handler_error_behaviour { interface.app.notify "bla", "blu", "blo" }
+                    end
+
+                    describe "the job handler" do
+                        handler_error_behaviour do
+                            interface.job_notify JOB_MONITORED, 10, 'test'
+                            interface.push_pending_job_notifications
+                        end
+                    end
+
+                    describe "the exception handler" do
+                        handler_error_behaviour do
+                            interface.app.execution_engine.notify_exception \
+                                "test", error_m, []
+                        end
+                    end
+
+                    it "passes a non-ComError if read_packet raises" do
+                        server_io.should_receive(:read_packet).
+                            and_raise(error_m.exception("test message"))
+                        msg = assert_raises(error_m) { server.poll }
+                        assert_match /test message/, msg.message
+                    end
+
+                    it "passes a ComError from #read_packet as-is" do
+                        server_io.should_receive(:read_packet).
+                            and_raise(ComError.exception("test message"))
+                        msg = assert_raises(ComError) { server.poll }
+                        assert_equal "test message", msg.message
+                    end
+
+                    def self.request_handling_behaviour
+                        it "raises ComError if a bad_call feedback fails" do
+                            e = Exception.exception 'test message'
+                            server.should_receive(:process_call).
+                                with([], :test).and_raise(e)
+                            server_io.should_receive(:write_packet).
+                                with([:bad_call, e]).
+                                and_raise(error_m.exception("test message"))
+
+                            msg = assert_raises(error_m) { server.poll }
+                            assert_match "test message", msg.message
+                        end
+
+                        it "passes a ComError raised by writing a bad_call as-is" do
+                            e = Exception.exception 'test message'
+                            server.should_receive(:process_call).
+                                with([], :test).and_raise(e)
+                            server_io.should_receive(:write_packet).
+                                with([:bad_call, e]).
+                                and_raise(ComError.exception("test message"))
+
+                            msg = assert_raises(ComError) { server.poll }
+                            assert_equal "test message", msg.message
+                        end
+
+                        it "raises ComError if writing the reply fails" do
+                            server_io.should_receive(:write_packet).
+                                with([:reply, @ret]).
+                                and_raise(error_m.exception("test message"))
+
+                            msg = assert_raises(error_m) { server.poll }
+                            assert_match "test message", msg.message
+                        end
+
+                        it "passes a ComError raised by sending a reply as-is" do
+                            server_io.should_receive(:write_packet).
+                                with([:reply, @ret]).
+                                and_raise(ComError.exception("test message"))
+
+                            msg = assert_raises(ComError) { server.poll }
+                            assert_equal "test message", msg.message
+                        end
+                    end
+
+                    describe "while handling a request" do
+                        before do
+                            server_io.should_receive(:read_packet).
+                                and_return([[], :test])
+                            server.should_receive(:process_call).
+                                with([], :test).
+                                and_return(@ret = flexmock).by_default
+                        end
+                        request_handling_behaviour
+                    end
+
+                    describe "while handling a batch" do
+                        before do
+                            server_io.should_receive(:read_packet).
+                                and_return([[], :process_batch, [[[], :test]]])
+                            server.should_receive(:process_call).
+                                with([], :test).
+                                and_return(ret = flexmock).by_default
+                            @ret = [ret]
+                        end
+                        request_handling_behaviour
+                    end
+                end
+
+                describe "abort_on_exception: false" do
+                    before do
+                        server.abort_on_exception = false
+                    end
+
+                    def self.handler_error_behaviour(&block)
+                        it "defers non-ComError exceptions and turns them into ComError in #poll" do
+                            server_io.should_receive(:write_packet).and_raise(error_m)
+                            instance_eval(&block)
+                            assert_raises(ComError) { server.poll }
+                        end
+
+                        it "defers ComError exceptions" do
+                            server_io.should_receive(:write_packet).and_raise(ComError)
+                            instance_eval(&block)
+                            assert_raises(ComError) { server.poll }
+                        end
+                    end
+
+                    describe "the on_cycle_end handler" do
+                        handler_error_behaviour { interface.notify_cycle_end }
+                    end
+
+                    describe "the notification handler" do
+                        handler_error_behaviour { interface.app.notify "bla", "blu", "blo" }
+                    end
+
+                    describe "the job handler" do
+                        handler_error_behaviour do
+                            interface.job_notify JOB_MONITORED, 10, 'test'
+                            interface.push_pending_job_notifications
+                        end
+                    end
+
+                    describe "the exception handler" do
+                        handler_error_behaviour do
+                            interface.app.execution_engine.notify_exception \
+                                "test", error_m, []
+                        end
+                    end
+
+                    it "passes a non-ComError if read_packet raises" do
+                        server_io.should_receive(:read_packet).
+                            and_raise(error_m.exception("test message"))
+                        msg = assert_raises(ComError) { server.poll }
+                        assert_match /test message/, msg.message
+                    end
+
+                    it "passes a ComError from #read_packet as-is" do
+                        server_io.should_receive(:read_packet).
+                            and_raise(ComError.exception("test message"))
+                        msg = assert_raises(ComError) { server.poll }
+                        assert_equal "test message", msg.message
+                    end
+
+                    def self.request_handling_behaviour
+                        it "raises ComError if a bad_call feedback fails" do
+                            e = Exception.exception 'test message'
+                            server.should_receive(:process_call).
+                                with([], :test).and_raise(e)
+                            server_io.should_receive(:write_packet).
+                                with([:bad_call, e]).
+                                and_raise(error_m.exception("test message"))
+
+                            msg = assert_raises(ComError) { server.poll }
+                            assert_match "test message", msg.message
+                        end
+
+                        it "passes a ComError raised by writing a bad_call as-is" do
+                            e = Exception.exception 'test message'
+                            server.should_receive(:process_call).
+                                with([], :test).and_raise(e)
+                            server_io.should_receive(:write_packet).
+                                with([:bad_call, e]).
+                                and_raise(ComError.exception("test message"))
+
+                            msg = assert_raises(ComError) { server.poll }
+                            assert_equal "test message", msg.message
+                        end
+
+                        it "raises ComError if writing the reply fails" do
+                            server_io.should_receive(:write_packet).
+                                with([:reply, @ret]).
+                                and_raise(error_m.exception("test message"))
+
+                            msg = assert_raises(ComError) { server.poll }
+                            assert_match "test message", msg.message
+                        end
+
+                        it "passes a ComError raised by sending a reply as-is" do
+                            server_io.should_receive(:write_packet).
+                                with([:reply, @ret]).
+                                and_raise(ComError.exception("test message"))
+
+                            msg = assert_raises(ComError) { server.poll }
+                            assert_equal "test message", msg.message
+                        end
+                    end
+
+                    describe "while handling a request" do
+                        before do
+                            server_io.should_receive(:read_packet).
+                                and_return([[], :test])
+                            server.should_receive(:process_call).
+                                with([], :test).
+                                and_return(@ret = flexmock).by_default
+                        end
+                        request_handling_behaviour
+                    end
+
+                    describe "while handling a batch" do
+                        before do
+                            server_io.should_receive(:read_packet).
+                                and_return([[], :process_batch, [[[], :test]]])
+                            server.should_receive(:process_call).
+                                with([], :test).
+                                and_return(ret = flexmock).by_default
+                            @ret = [ret]
+                        end
+                        request_handling_behaviour
+                    end
+                end
+            end
+        end
+    end
+end
+


### PR DESCRIPTION
DRobyChannel now catches and interprets any SystemCallError as a
communication failure error.

Moreover, one can now set Server#abort_on_exception to false so that
any error in the read/write codepaths only cause a disconnection but
not a full Roby abort. The app-wide setting is in
Roby.app.shell_abort_on_exception.