### PR TITLE
coordination: fix definition of the 'start_state' argument in action state machines

### DIFF
--- a/lib/roby/actions/models/action.rb
+++ b/lib/roby/actions/models/action.rb
@@ -131,6 +131,7 @@ module Roby
 
             # Documents a new optional argument to the method
             def optional_arg(name, doc = nil, default = nil)
+                doc = doc.to_str if doc
                 arg = Argument.new(name.to_s, doc, false)
                 arg.default = default
                 arguments << arg

--- a/lib/roby/actions/models/interface_base.rb
+++ b/lib/roby/actions/models/interface_base.rb
@@ -242,7 +242,7 @@ module Roby
                 if action_model.has_arg?("start_state")
                     raise ArgumentError, "A argument \"start_state\" has defined for the statemachine, but this keyword is reserved"
                 end
-                action_model.optional_arg("start_state", default: nil)
+                action_model.optional_arg("start_state", "name of the state in which the state machine should start", nil)
                 create_and_register_coordination_action(name, Coordination::ActionStateMachine, action_model: action_model, &block)
             end
 

--- a/test/coordination/models/test_action_state_machine.rb
+++ b/test/coordination/models/test_action_state_machine.rb
@@ -27,7 +27,7 @@ describe Roby::Coordination::Models::ActionStateMachine do
     end
 
     def state_machine(name, &block)
-        action_m.state_machine(name) do
+        action_m.action_state_machine(name) do
             def start_task(task)
                 tasks = super
                 tasks.each do |t|
@@ -44,6 +44,17 @@ describe Roby::Coordination::Models::ActionStateMachine do
             start(state(Roby::Task))
         end
         assert action_m.find_action_by_name('state_machine_action')
+    end
+
+    it "defines the 'start_state' argument" do
+        state_machine('state_machine_action') do
+            start(state(Roby::Task))
+        end
+        machine = action_m.find_action_by_name('state_machine_action')
+        state_arg = machine.arguments.find { |arg| arg.name == 'start_state' }
+        assert_equal 'name of the state in which the state machine should start', state_arg.doc
+        refute state_arg.required
+        assert_nil state_arg.default
     end
 
     describe "#transition" do


### PR DESCRIPTION
The arguments were given wrongly, interpreting the { default: nil } hash
as the argument's documentation. Ensure that documentation is always a
string to avoid these problems in the future