### PR TITLE
droby: fix model marshalling in interaction with coordination models

### DIFF
--- a/lib/roby/actions/models/coordination_action.rb
+++ b/lib/roby/actions/models/coordination_action.rb
@@ -49,18 +49,6 @@ module Roby
                     planner.planned_task
                 end
 
-                def proxy(peer)
-                    interface_model = @action_interface_model.proxy(peer)
-                    if action = interface_model.find_action_by_name(name)
-                        return action
-                    else
-                        action = super
-                        action.coordination_model =
-                            interface_model.create_coordination_model(action, Coordination::Actions) {}
-                        action
-                    end
-                end
-
                 def to_s
                     "#{action_interface_model.name}.#{name}[#{coordination_model}]"
                 end
@@ -68,4 +56,3 @@ module Roby
         end
     end
 end
-

--- a/lib/roby/droby/v5/droby_dump.rb
+++ b/lib/roby/droby/v5/droby_dump.rb
@@ -687,6 +687,23 @@ module Roby
                     module CoordinationActionDumper
                         include MethodActionDumper
 
+                        def proxy(peer)
+                            interface_model = @action_interface_model.proxy(peer)
+                            if action = interface_model.find_action_by_name(name)
+                                # Load the return type and the default values, we must
+                                # make sure that any dumped droby-identifiable object
+                                # is loaded nonetheless
+                                peer.local_model(returned_type)
+                                arguments.each { |arg| peer.local_object(arg.default) }
+                                return action
+                            else
+                                action = super
+                                action.coordination_model =
+                                    interface_model.create_coordination_model(action, Coordination::Actions) {}
+                                action
+                            end
+                        end
+
                         def droby_dump!(peer)
                             super
                             @coordination_model = nil


### PR DESCRIPTION
The coordination models will return an existing action on their
interface model. This means that the e.g. return type is marshalled on
the sending side, but not unmarshalled on the receiving side. Make sure
it is, and make sure that arguments are unmarshalled as well.