### PR TITLE
interface: extend async call api

### DIFF
--- a/lib/roby/interface/async/interface.rb
+++ b/lib/roby/interface/async/interface.rb
@@ -140,6 +140,21 @@ module Roby
                     @new_job_listeners = Array.new
                 end
 
+                # Schedules an async call on the client
+                #
+                # @see Client#async_call
+                def async_call(path, m, *args, &block)
+                    raise 'client not connected' unless connected?
+                    client.async_call(path, m, *args, &block)
+                end
+
+                # Checks whether an async call is still pending
+                #
+                # @see Client#async_call_pending?
+                def async_call_pending?(call)
+                    connected? && client.async_call_pending?(call)
+                end
+
                 # Start a connection attempt
                 def attempt_connection
                     @connection_future = Concurrent::Future.new do

--- a/lib/roby/interface/client.rb
+++ b/lib/roby/interface/client.rb
@@ -324,6 +324,7 @@ module Roby
             # @param [Symbol] m command or action name. Actions are always
             #   formatted as action_name!
             # @param [Object] args the command or action arguments
+            # @return [Object] an Object associated with the call @see async_call_pending?
             def async_call(path, m, *args, &block)
                 raise RuntimeError, "no callback block given" unless block_given?
                 if m.to_s =~ /(.*)!$/
@@ -336,8 +337,18 @@ module Roby
                     end
                 end
                 io.write_packet([path, m, *args])
-                pending_async_calls << { block: block, path: path,
-                                         m: m, args: args }
+                pending_async_calls << { block: block, path: path, m: m, args: args }
+                pending_async_calls.last.freeze
+            end
+
+            # @api private
+            #
+            # Whether the async call is still pending
+            # @param [Object] call the Object associated with the call
+            # @return [Boolean] true if the async call is pending,
+            #   false otherwise
+            def async_call_pending?(a_call)
+                pending_async_calls.any? { |item| item.equal?(a_call) }
             end
 
             # @api private


### PR DESCRIPTION
Expose the api through Roby::Interface::Async::Interface
Add method to check whether an async call is still pending