### PR TITLE
fix Tasks::ExternalProcess so that it can be created without arguments

### DIFF
--- a/lib/roby/tasks/external_process.rb
+++ b/lib/roby/tasks/external_process.rb
@@ -32,14 +32,15 @@ module Roby
             ##
             # :attr_reader:
             # The working directory. If not set, the current directory is used.
-            argument :working_directory
+            argument :working_directory, default: nil
 
             # Redirection specification. See #redirect_output
             attr_reader :redirection
 
-            def initialize(arguments)
-                arguments[:working_directory] ||= nil
-                            arguments[:command_line] = [arguments[:command_line]] unless arguments[:command_line].kind_of?(Array)
+            def initialize(arguments = Hash.new)
+                if arg = arguments[:command_line]
+                    arguments[:command_line] = [arg] if !arg.kind_of?(Array)
+                end
                 super(arguments)
             end
 

--- a/test/tasks/test_external_process.rb
+++ b/test/tasks/test_external_process.rb
@@ -12,6 +12,10 @@ class TC_Tasks_ExternalProcess < Minitest::Test
         end
     end
 
+    def test_initialize_may_be_called_without_arguments
+        Tasks::ExternalProcess.new
+    end
+
     def run_task(task)
         expect_execution { task.start! }.to { emit task.success_event }
     end


### PR DESCRIPTION
This is needed so that ExternalProcess can be used as a toplevel task.