### PR TITLE
tasks: improve Tasks::Thread

### DIFF
--- a/lib/roby/tasks/thread.rb
+++ b/lib/roby/tasks/thread.rb
@@ -63,13 +63,20 @@ module Roby
             end
         end
 
-        event :start do |context|
-            start_event.emit
+        # @api private
+        #
+        # Start the underlying thread and the monitoring objects
+        def start_thread
             @interruption_event = Concurrent::Event.new
             @thread = ::Thread.new do
 		::Thread.current.priority = 0
                 instance_eval(&self.class.implementation_block)
             end
+        end
+
+        event :start do |context|
+            start_thread
+            start_event.emit
         end
 
 	poll do


### PR DESCRIPTION
- cleanup the task to use Concurrent::Event instead of booleans
- allow subclasses to delay the emission of the start event
- make a difference between one-shot computation and permanent execution, to improve error handling in the latter case