### PR TITLE
ui: fix interface job tracking bugs

### DIFF
--- a/lib/roby/actions/models/coordination_action.rb
+++ b/lib/roby/actions/models/coordination_action.rb
@@ -46,7 +46,7 @@ module Roby
                     planner = Roby::Actions::Task.new(
                         Hash[action_model: self,
                              action_arguments: arguments].merge(job_id))
-                    planner.planned_task
+                    planner.planning_result_task
                 end
 
                 def to_s

--- a/lib/roby/actions/models/method_action.rb
+++ b/lib/roby/actions/models/method_action.rb
@@ -77,7 +77,7 @@ module Roby
                     planner = Roby::Actions::Task.new(
                         Hash[action_model: self,
                              action_arguments: arguments].merge(job_id))
-                    planner.planned_task
+                    planner.planning_result_task
                 end
 
                 def to_s

--- a/lib/roby/actions/task.rb
+++ b/lib/roby/actions/task.rb
@@ -46,7 +46,7 @@ module Roby
                 end
             end
 
-            def planned_task
+            def planning_result_task
                 if success? || result
                     result
                 elsif task = planned_tasks.find { true }
@@ -91,7 +91,7 @@ module Roby
                     result_task.planned_by transaction[self]
                 end
 
-                if placeholder = planned_task
+                if placeholder = planning_result_task
                     placeholder = transaction[placeholder]
                     transaction.replace(placeholder, result_task)
                     placeholder.remove_planning_task transaction[self]

--- a/lib/roby/task_structure/planned_by.rb
+++ b/lib/roby/task_structure/planned_by.rb
@@ -10,7 +10,9 @@ module Roby::TaskStructure
             # Returns the first child enumerated by planned_tasks. This is a
             # convenience method that can be used if it is known that the planning
             # task is only planning for one single task (a pretty common case)
-            def planned_task; planned_tasks.find { true } end
+            def planned_task
+                each_in_neighbour_merged(PlannedBy, intrusive: true).first
+            end
             # The set of tasks which are planned by this one
             def planned_tasks; parent_objects(PlannedBy) end
             # Set +task+ as the planning task of +self+

--- a/test/task_structure/test_planned_by.rb
+++ b/test/task_structure/test_planned_by.rb
@@ -70,6 +70,18 @@ module Roby
                 end
             end
 
+            it "wraps the planned_task within a transaction on first access" do
+                # Note: we only check #planned_task. #planning_task is provided
+                # by the single_child support in relations, and tested there.
+                plan = Roby::Plan.new
+                plan.add(planned_task = Roby::Task.new)
+                planned_task.planned_by(planning_task = Roby::Task.new)
+                plan.in_transaction do |trsc|
+                    assert_equal planned_task, trsc[planning_task].
+                        planned_task.__getobj__
+                end
+            end
+
             def test_as_plan
                 model = Tasks::Simple.new_submodel do
                     def self.as_plan


### PR DESCRIPTION
Among other things, this fixes issues in the IDE such as:
- actions that are alive and being executed but are shown as FINALIZED
- planning failed errors that would show up as FINALIZED, and not have the exception shown
- jobs that would not show up at all (when added within a transaction)