### PR TITLE
interface: make sure UI event notifications are MT-safe

### DIFF
--- a/lib/roby/interface/droby_channel.rb
+++ b/lib/roby/interface/droby_channel.rb
@@ -132,9 +132,9 @@ module Roby
                 push_write_data(packet.to_s)
             end
 
-            def reset_thread_guard
-                @write_thread = nil
-                @read_thread = nil
+            def reset_thread_guard(read_thread = nil, write_thread = nil)
+                @write_thread = read_thread
+                @read_thread = write_thread
             end
 
             # Push queued data


### PR DESCRIPTION
UI events are meant to be sent from various places in the system,
and are really meant to be forwarded to the outside interfaces.
It's not reasonable to require that they are all generated from
the event loop.

This fixes an actual bug where file watching in Syskit would send
an UI event (conf file change) which would then end up writing packets
in the wrong thread.