### PR TITLE
app: fix resource leak on restart due to not calling #clear

### DIFF
--- a/lib/roby/app.rb
+++ b/lib/roby/app.rb
@@ -1927,9 +1927,6 @@ module Roby
         ensure
             shutdown
             @thread = nil
-            if restarting?
-                Kernel.exec *@restart_cmdline
-            end
         end
 
         def join
@@ -1953,7 +1950,15 @@ module Roby
             !!@thread
         end
 
-        # Whether {#run} should exec a new process on quit or not
+        # Restarts the same app
+        # 
+        # Simply execs the same command line
+        def restart!
+            Kernel.exec *@restart_cmdline
+        end
+
+        # Indicates to whomever is managing this app that {#restart} should be
+        # called
         def restarting?
             !!@restarting
         end

--- a/lib/roby/app/scripts/run.rb
+++ b/lib/roby/app/scripts/run.rb
@@ -170,6 +170,10 @@ error = Roby.display_exception(STDERR) do
         app.cleanup
     end
 end
-if error
+
+if app.restarting?
+    app.restart!
+elsif error
     exit 1
 end
+

--- a/lib/roby/coordination/models/base.rb
+++ b/lib/roby/coordination/models/base.rb
@@ -173,4 +173,3 @@ module Roby
         end
     end
 end
-


### PR DESCRIPTION
Syskit for instance needs to start/connect to the process server
in #setup (since we get the models from the process servers). The
current codepath was not cleaning this, which was leaking one
process server at each restart.