### PR TITLE
app: define #quit on Application

### DIFF
--- a/lib/roby/app.rb
+++ b/lib/roby/app.rb
@@ -1988,6 +1988,11 @@ module Roby
                     end
                 else cmdline
                 end
+            quit
+        end
+
+        # Quit the application
+        def quit
             plan.execution_engine.quit
         end
 


### PR DESCRIPTION
Application has now #restart, it is being weird to have to quit
on the engine but restart on the application. Since restarting
is really done at the application-level, add #quit to Application
as well.