### PR TITLE
improve handling of delayed arguments during merge

### DIFF
--- a/lib/roby/executable_plan.rb
+++ b/lib/roby/executable_plan.rb
@@ -186,9 +186,9 @@ module Roby
             end
 
             relations.each do |rel|
-                if name = rel.child_name
-                    parent.send("adding_#{rel.child_name}", child, info)
-                    child.send("adding_#{rel.child_name}_parent", parent, info)
+                if (name = rel.child_name)
+                    parent.send("adding_#{name}", child, info)
+                    child.send("adding_#{name}_parent", parent, info)
                 end
             end
 
@@ -216,9 +216,9 @@ module Roby
                     execution_engine.event_ordering.clear
                 end
 
-                if name = rel.child_name
-                    parent.send("added_#{rel.child_name}", child, info)
-                    child.send("added_#{rel.child_name}_parent", parent, info)
+                if (name = rel.child_name)
+                    parent.send("added_#{name}", child, info)
+                    child.send("added_#{name}_parent", parent, info)
                 end
             end
 
@@ -268,9 +268,9 @@ module Roby
             end
 
             relations.each do |rel|
-                if name = rel.child_name
-                    parent.send("removing_#{rel.child_name}", child)
-                    child.send("removing_#{rel.child_name}_parent", parent)
+                if (name = rel.child_name)
+                    parent.send("removing_#{name}", child)
+                    child.send("removing_#{name}_parent", parent)
                 end
             end
 
@@ -292,9 +292,9 @@ module Roby
         #   has been removed
         def removed_edge(parent, child, relations)
             relations.each do |rel|
-                if name = rel.child_name
-                    parent.send("removed_#{rel.child_name}", child)
-                    child.send("removed_#{rel.child_name}_parent", parent)
+                if (name = rel.child_name)
+                    parent.send("removed_#{name}", child)
+                    child.send("removed_#{name}_parent", parent)
                 end
             end
 
@@ -305,9 +305,9 @@ module Roby
         #
         # Helper for {#updating_edge_info} and {#updated_edge_info}
         def emit_relation_change_hook(parent, child, rel, *args, prefix: nil)
-            if name = rel.child_name
-                parent.send("#{prefix}_#{rel.child_name}", child, *args)
-                child.send("#{prefix}_#{rel.child_name}_parent", parent, *args)
+            if (name = rel.child_name)
+                parent.send("#{prefix}_#{name}", child, *args)
+                child.send("#{prefix}_#{name}_parent", parent, *args)
             end
         end
 
@@ -318,8 +318,8 @@ module Roby
         # It is a helper for {#merged_plan}
         def emit_relation_graph_merge_hooks(graph, prefix: nil)
             rel = graph.class
-            if rel.child_name
-                added_child_hook  = "#{prefix}_#{rel.child_name}"
+            if (name = rel.child_name)
+                added_child_hook  = "#{prefix}_#{name}"
                 added_parent_hook = "#{added_child_hook}_parent"
                 graph.each_edge do |parent, child, info|
                     parent.send(added_child_hook, child, info)
@@ -337,8 +337,8 @@ module Roby
             list.each do |graph, parent, child, *args|
                 if !hooks.has_key?(graph)
                     rel = graph.class
-                    if rel.child_name
-                        parent_hook = "#{prefix}_#{rel.child_name}"
+                    if (name = rel.child_name)
+                        parent_hook = "#{prefix}_#{name}"
                         child_hook  = "#{parent_hook}_parent"
                         hooks[graph] = [parent_hook, child_hook]
                     else

--- a/lib/roby/relations/bidirectional_directed_adjacency_graph.rb
+++ b/lib/roby/relations/bidirectional_directed_adjacency_graph.rb
@@ -206,7 +206,7 @@ module Roby
                 else 0
                 end
             end
-            
+
             def replace(g)
                 @forward_edges_with_info.replace(g.instance_variable_get(:@forward_edges_with_info))
                 @backward_edges.replace(g.instance_variable_get(:@backward_edges))
@@ -416,7 +416,7 @@ module Roby
             # graphs.
             #
             # Each set is a Set of pairs
-            #  
+            #
             #   [source_vertex, sink_vertex]
             #
             # The vertices are vertices of +self+ for +new+ and +updated+, and
@@ -484,7 +484,7 @@ module Roby
                     end
                     seen_vertices[other_v] = nil
                 end
-            
+
                 return new, removed, updated
             end
         end

--- a/lib/roby/task.rb
+++ b/lib/roby/task.rb
@@ -1186,23 +1186,14 @@ module Roby
         # common to all tasks that would forbid a merge 
         def can_merge?(target)
             if defined?(super) && !super
-                return
-            end
-
-            if finished? || target.finished?
+                return false
+            elsif finished? || target.finished?
+                return false
+            elsif !model.can_merge?(target.model)
                 return false
             end
 
-            if !model.can_merge?(target.model)
-                return false
-            end
-
-            target.arguments.each_assigned_argument do |key, val|
-                if arguments.set?(key) && arguments[key] != val
-                    return false
-                end
-            end
-            true
+            target.arguments.can_semantic_merge?(arguments)
         end
 
         # "Simply" mark this task as terminated. This is meant to be used on

--- a/lib/roby/task_arguments.rb
+++ b/lib/roby/task_arguments.rb
@@ -47,7 +47,7 @@ module Roby
             values.keys
         end
 
-        # True if it is possible to write the given value to the given argument 
+        # True if it is possible to write the given value to the given argument
         #
         # @param [Symbol] key the argument name
         # @param [Object] value the new argument value
@@ -132,6 +132,92 @@ module Roby
 
         def each(&block)
             values.each(&block)
+        end
+
+        StaticArgumentWrapper = Struct.new :value do
+            def evaluate_delayed_argument(task)
+                value
+            end
+        end
+
+        def can_semantic_merge?(other_args)
+            values.all? do |name, arg|
+                next(true) unless other_args.has_key?(name)
+
+                other_arg = other_args.values[name]
+
+                self_delayed  = TaskArguments.delayed_argument?(arg)
+                other_delayed = TaskArguments.delayed_argument?(other_arg)
+                next(arg == other_arg) unless self_delayed || other_delayed
+
+                if self_delayed && other_delayed
+                    if !(arg.strong? ^ other_arg.strong?)
+                        arg.can_merge?(task, other_args.task,
+                            other_arg)
+                    else
+                        true
+                    end
+                elsif self_delayed
+                    if arg.strong?
+                        arg.can_merge?(task, other_args.task,
+                            StaticArgumentWrapper.new(other_arg))
+                    else
+                        true
+                    end
+                elsif other_delayed
+                    if other_arg.strong?
+                        other_arg.can_merge?(other_args.task, task,
+                            StaticArgumentWrapper.new(arg))
+                    else
+                        true
+                    end
+                end
+            end
+        end
+
+        def semantic_merge!(other_args)
+            current_values = values.dup
+            other_task = other_args.task
+            values.merge!(other_args.values) do |name, arg, other_arg|
+                self_delayed  = TaskArguments.delayed_argument?(arg)
+                other_delayed = TaskArguments.delayed_argument?(other_arg)
+
+                if self_delayed && other_delayed
+                    if !(arg.strong? ^ other_arg.strong?)
+                        arg.merge(task, other_task, other_arg)
+                    elsif arg.strong?
+                        arg
+                    else
+                        other_arg
+                    end
+                elsif self_delayed
+                    if arg.strong?
+                        arg.merge(task, other_task,
+                            StaticArgumentWrapper.new(other_arg))
+                    else
+                        other_arg
+                    end
+                elsif other_delayed
+                    if other_arg.strong?
+                        other_arg.merge(other_task, task,
+                            StaticArgumentWrapper.new(arg))
+                    else
+                        arg
+                    end
+                else
+                    arg
+                end
+            end
+            current_values.each do |k, v|
+                if (new_value = values[k]) != v
+                    task.plan.log(:task_arguments_updated, task, k, new_value)
+                end
+            end
+            (values.keys - current_values.keys).each do |new_k|
+                task.plan.log(:task_arguments_updated, task, new_k, values[new_k])
+            end
+            @static = values.each_value.none? { |v| TaskArguments.delayed_argument?(v) }
+            self
         end
 
         # Updates the given argument, regardless of whether it is allowed or not
@@ -232,7 +318,9 @@ module Roby
         def merge!(**hash)
             hash.each do |key, value|
                 if !value.droby_marshallable?
-                    raise NotMarshallable, "values used as task arguments must be marshallable, attempting to set #{key} to #{value}, which is not"
+                    raise NotMarshallable, "values used as task arguments must "\
+                        "be marshallable, attempting to set #{key} to #{value}, "\
+                        "which is not"
                 end
             end
 
@@ -242,7 +330,8 @@ module Roby
                     task.plan.log(:task_arguments_updated, task, key, new)
                     new
                 else
-                    raise ArgumentError, "cannot override task argument #{key}: trying to replace #{old} by #{new}"
+                    raise ArgumentError, "cannot override task argument #{key}: "\
+                        "trying to replace #{old} by #{new}"
                 end
             end
             @static = values.all? { |k, v| !TaskArguments.delayed_argument?(v) }
@@ -262,6 +351,22 @@ module Roby
 
         def evaluate_delayed_argument(task)
             value
+        end
+
+        def strong?
+            false
+        end
+
+        def can_merge?(task, other_task, other_arg)
+            true
+        end
+
+        def merge(task, other_task, other_arg)
+            if other_arg.kind_of?(DefaultArgument) # backward-compatible behavior
+                self
+            else
+                other_arg
+            end
         end
 
         def pretty_print(pp)
@@ -296,6 +401,22 @@ module Roby
         def of_type(expected_class)
             @expected_class = expected_class
             self
+        end
+
+        def strong?
+            true
+        end
+
+        def can_merge?(task, other_task, other_arg)
+            catch(:no_value) do
+                this_evaluated  = evaluate_delayed_argument(task)
+                other_evaluated = other_arg.evaluate_delayed_argument(other_task)
+                other_evaluated == this_evaluated
+            end
+        end
+
+        def merge(task, other_task, other_arg)
+            evaluate_delayed_argument(task)
         end
 
         def evaluate_delayed_argument(task)
@@ -366,6 +487,19 @@ module Roby
     class DelayedArgumentFromState < DelayedArgumentFromObject
         def initialize(state_object = State, weak = true)
             super(state_object, weak)
+        end
+
+        def strong?
+            true
+        end
+
+        def can_merge?(task, other_task, other_arg)
+            other_arg.object == object &&
+                other_arg.methods == methods
+        end
+
+        def merge(task, other_task, other_arg)
+            self
         end
 
         def evaluate_delayed_argument(task)

--- a/test/test_task_arguments.rb
+++ b/test/test_task_arguments.rb
@@ -182,38 +182,208 @@ describe Roby::TaskArguments do
             assert_equal [[:arg, 10]], args.each_assigned_argument.to_a
         end
     end
-end
 
-describe Roby::DelayedArgumentFromObject do
-    describe "#evaluate_delayed_argument" do
-        attr_reader :task, :arg
+    describe "#can_semantic_merge? and #semantic_merge!" do
         before do
-            task_m = Roby::Task.new_submodel { argument(:arg) }
-            @task = prepare_plan add: 1, model: task_m
-            @arg = Roby::DelayedArgumentFromObject.new(task).arg.field
+            @left_t = Roby::Task.new_submodel.new
+            @left = Roby::TaskArguments.new(@left_t)
+            @right_t = Roby::Task.new_submodel.new
+            @right = Roby::TaskArguments.new(@right_t)
         end
 
-        it "resolves to a task's arguments" do
-            task.arg = Struct.new(:field).new(10)
-            assert_equal 10, arg.evaluate_delayed_argument(task)
+        it "sets static?=true if the merges removes all delayed arguments" do
+            @left[:arg] = flexmock(evaluate_delayed_argument: nil, strong?: false)
+            @right[:arg] = 42
+            @left.semantic_merge!(@right)
+            assert @left.static?
         end
-        it "throws no_value if trying to access an unassigned argument" do
-            assert_throws(:no_value) do
-                arg.evaluate_delayed_argument(task)
+
+        it "keeps static?=false if the merges does not remove all delayed arguments" do
+            @left[:arg] = flexmock(evaluate_delayed_argument: nil, strong?: true)
+            @right[:arg] = flexmock(evaluate_delayed_argument: nil, strong?: false)
+            @left.semantic_merge!(@right)
+            refute @left.static?
+        end
+
+        it "logs a :task_arguments_updated event if the value has been changed" do
+            @left[:arg] = flexmock(
+                evaluate_delayed_argument: nil, strong?: true, merge: 42)
+            @right[:arg] = 42
+            flexmock(@left.task.plan).should_receive(:log).
+                once.with(:task_arguments_updated, @left.task, :arg, 42)
+            @left.semantic_merge!(@right)
+        end
+
+        it "does not log a :task_arguments_updated event if the value has not been changed" do
+            @left[:arg] = flexmock(evaluate_delayed_argument: nil, strong?: true)
+            @right[:arg] = flexmock(evaluate_delayed_argument: nil, strong?: false)
+            flexmock(@left.task.plan).should_receive(:log).never
+            @left.semantic_merge!(@right)
+        end
+
+        it "logs a :task_arguments_updated event for new arguments" do
+            @right[:something] = 42
+            flexmock(@left.task.plan).should_receive(:log).once.
+                with(:task_arguments_updated, @left.task, :something, 42)
+            @left.semantic_merge!(@right)
+        end
+
+        describe "non-delayed arguments" do
+            it "can merge if they are equal, and returns the value" do
+                @left[:arg] = 10
+                @right[:arg] = 10
+                assert @left.can_semantic_merge?(@right)
+                @left.semantic_merge!(@right)
+                assert_equal 10, @left[:arg]
+            end
+
+            it "can not merge if they are not equal" do
+                @left[:arg] = 10
+                @right[:arg] = 20
+                refute @left.can_semantic_merge?(@right)
             end
         end
-        it "recursively resolves task arguments" do
-            task.arg = Class.new do
-                def evaluate_delayed_argument(task); Struct.new(:field).new(10) end
-            end.new
-            assert_equal 10, arg.evaluate_delayed_argument(task)
+
+        describe "one non-delayed argument and one strong delayed argument" do
+            before do
+                @left[:arg] = flexmock(evaluate_delayed_argument: true, strong?: true)
+                @right[:arg]  = 42
+            end
+
+            it "can merge if can_merge? returns true" do
+                @left.values[:arg].should_receive(:can_merge?).
+                    with(@left_t, @right_t,
+                        ->(a) { a.evaluate_delayed_argument(nil) == 42 }).
+                    twice.and_return(true)
+                assert @left.can_semantic_merge?(@right)
+                assert @right.can_semantic_merge?(@left)
+            end
+
+            it "uses the value returned by merge" do
+                @left.values[:arg].should_receive(:merge).
+                    with(@left_t, @right_t,
+                        ->(a) { a.evaluate_delayed_argument(nil) == 42 }).
+                    once.and_return(10)
+                @left.semantic_merge!(@right)
+                assert_equal 10, @left[:arg]
+            end
+
+            it "behaves identically if the delayed argument is passed as argument" do
+                @left.values[:arg].should_receive(:merge).
+                    with(@left_t, @right_t,
+                        ->(a) { a.evaluate_delayed_argument(nil) == 42 }).
+                    once.and_return(10)
+                @right.semantic_merge!(@left)
+                assert_equal 10, @right.values[:arg]
+            end
+
+            it "returns false if can_merge? returns false" do
+                @left.values[:arg].should_receive(:can_merge?).
+                    with(@left_t, @right_t,
+                        ->(a) { a.evaluate_delayed_argument(nil) == 42 }).
+                    twice.and_return(false)
+                refute @left.can_semantic_merge?(@right)
+                refute @right.can_semantic_merge?(@left)
+            end
         end
-        it "throws no_value if trying to access a delayed task argument that cannot be resolved" do
-            task.arg = Class.new do
-                def evaluate_delayed_argument(task); throw :no_value end
-            end.new
-            assert_throws(:no_value) do
-                arg.evaluate_delayed_argument(task)
+
+        describe "one non-delayed argument and one weak delayed argument" do
+            before do
+                @left[:arg] = flexmock(evaluate_delayed_argument: true, strong?: false)
+                @right[:arg]  = 42
+            end
+
+            it "can merge" do
+                assert @left.can_semantic_merge?(@right)
+                assert @right.can_semantic_merge?(@left)
+            end
+
+            it "sets the non-delayed value merge" do
+                @left.semantic_merge!(@right)
+                assert_equal 42, @left[:arg]
+            end
+
+            it "behaves identically if the delayed argument is in the receiver" do
+                @right.semantic_merge!(@left)
+                assert_equal 42, @right.values[:arg]
+            end
+        end
+
+        describe "two strong delayed arguments" do
+            before do
+                @left[:arg]  = flexmock(evaluate_delayed_argument: true, strong?: true)
+                @right[:arg] = flexmock(evaluate_delayed_argument: true, strong?: true)
+            end
+
+            it "can merge if can_merge? returns true" do
+                @left.values[:arg].should_receive(:can_merge?).
+                    with(@left_t, @right_t, @right.values[:arg]).
+                    once.and_return(true)
+                assert @left.can_semantic_merge?(@right)
+            end
+
+            it "sets using the value returned by merge" do
+                @left.values[:arg].should_receive(:merge).
+                    with(@left_t, @right_t, @right.values[:arg]).
+                    once.and_return(42)
+                @left.semantic_merge!(@right)
+                assert_equal 42, @left.values[:arg]
+            end
+
+            it "returns false if can_merge? returns false" do
+                @left.values[:arg].should_receive(:can_merge?).
+                    with(@left_t, @right_t, @right.values[:arg]).
+                    once.and_return(false)
+                refute @left.can_semantic_merge?(@right)
+            end
+        end
+
+        describe "one strong delayed argument and one weak delayed argument" do
+            before do
+                @strong_arg = flexmock(evaluate_delayed_argument: true, strong?: true)
+                @left[:arg] = @strong_arg
+                @right[:arg] = flexmock(evaluate_delayed_argument: true, strong?: false)
+            end
+
+            it "can merge and sets to the strong argument" do
+                assert @left.can_semantic_merge?(@right)
+                @left.semantic_merge!(@right)
+                assert_equal @strong_arg, @left.values[:arg]
+            end
+
+            it "behaves identically if the strong side is the argument" do
+                assert @right.can_semantic_merge?(@left)
+                @right.semantic_merge!(@left)
+                assert_equal @strong_arg, @right.values[:arg]
+            end
+        end
+
+        describe "two weak delayed arguments" do
+            before do
+                @left[:arg] = flexmock(evaluate_delayed_argument: true, strong?: false)
+                @right[:arg] = flexmock(evaluate_delayed_argument: true, strong?: false)
+            end
+
+            it "can merge if can_merge? returns true" do
+                @left.values[:arg].should_receive(:can_merge?).
+                    with(@left_t, @right_t, @right.values[:arg]).
+                    once.and_return(true)
+                assert @left.can_semantic_merge?(@right)
+            end
+
+            it "sets using the value returned by merge" do
+                @left.values[:arg].should_receive(:merge).
+                    with(@left_t, @right_t, @right.values[:arg]).
+                    once.and_return(42)
+                @left.semantic_merge!(@right)
+                assert_equal 42, @left.values[:arg]
+            end
+
+            it "returns false if can_merge? returns false" do
+                @left.values[:arg].should_receive(:can_merge?).
+                    with(@left_t, @right_t, @right.values[:arg]).
+                    once.and_return(false)
+                refute @left.can_semantic_merge?(@right)
             end
         end
     end
@@ -235,3 +405,67 @@ describe Roby::DelayedArgumentFromObject do
     end
 end
 
+module Roby
+    describe DelayedArgumentFromObject do
+        describe "#evaluate_delayed_argument" do
+            attr_reader :task, :arg
+            before do
+                @task_m = Task.new_submodel { argument(:arg) }
+                @task = @task_m.new
+                @arg = DelayedArgumentFromObject.new(nil).arg.field
+            end
+
+            it "resolves to a task's arguments" do
+                task.arg = Struct.new(:field).new(10)
+                assert_equal 10, arg.evaluate_delayed_argument(task)
+            end
+            it "throws no_value if trying to access an unassigned argument" do
+                assert_throws(:no_value) do
+                    arg.evaluate_delayed_argument(task)
+                end
+            end
+            it "recursively resolves task arguments" do
+                task.arg = Class.new do
+                    def evaluate_delayed_argument(task); Struct.new(:field).new(10) end
+                end.new
+                assert_equal 10, arg.evaluate_delayed_argument(task)
+            end
+            it "throws no_value if trying to access a delayed task argument that cannot be resolved" do
+                task.arg = Class.new do
+                    def evaluate_delayed_argument(task); throw :no_value end
+                end.new
+                assert_throws(:no_value) do
+                    arg.evaluate_delayed_argument(task)
+                end
+            end
+
+            describe "merge behavior" do
+                it "is strong" do
+                    assert @arg.strong?
+                end
+
+                it "merges with another delayed argument that resolves to the same value" do
+                    @task.arg = Struct.new(:field).new(10)
+                    other_task = @task_m.new
+                    other_task.arg = Struct.new(:field).new(10)
+
+                    assert @arg.can_merge?(@task, other_task, @arg)
+                    assert_equal 10, @arg.merge(@task, other_task, @arg)
+                end
+
+                it "does not merge if the receiver does not resolve" do
+                    other_task = @task_m.new
+                    other_task.arg = Struct.new(:field).new(10)
+
+                    refute @arg.can_merge?(@task, other_task, @arg)
+                end
+
+                it "does not merge if the argument does not resolve" do
+                    @task.arg = Struct.new(:field).new(10)
+                    other_task = @task_m.new
+                    refute @arg.can_merge?(@task, other_task, @arg)
+                end
+            end
+        end
+    end
+end


### PR DESCRIPTION
The current policy was "all or nothing or everything". Either
1. the argument was set to an actual value, and it has to stay
   at this value forever
2. the argument was set to a delayed value, and it could be
   updated by anything
3. the argument was not set, and it could be set to anything

This was a bit of a ... limiting policy for the purpose of merging
plans (i.e. in Syskit). The functionality for which this was designed
(default arguments) worked just fine, a (1) and (2) are good policies
for it. For referenced arguments (the from(...) syntax), it leads to
merging things that ultimately point to completely different arguments.

To deal with the difference in semantic between the two types of
delayed arguments, and provide a framework to more flexibly handle
merging arguments in a plan merge system, this commit adds:
- the #strong? predicate. strong? separates the arguments are
  really meant to be arguments (true) with the ones are meant to be
  used as defaults (i.e. can be overriden, false)
- the #can_semantic_merge? predicate and #semantic_merge! operation
  that allow computing a merged argument, resulting of two existing
  arguments. I hope this can be used down the line to provide
  interesting merging range semantic in plans.