### PR TITLE
app: fix deleting created log base directories on 2.5

### DIFF
--- a/lib/roby/app.rb
+++ b/lib/roby/app.rb
@@ -795,8 +795,12 @@ module Roby
                     true
                 end
                 created_log_base_dirs.sort_by(&:length).reverse_each do |dir|
-                    # .rmdir will ignore nonempty / nonexistent directories
-                    FileUtils.rmdir(dir)
+                    # .rmdir will ignore nonempty / nonexistent directories on
+                    # 2.3 but on 2.5 you have to rescue.
+                    begin
+                        FileUtils.rmdir(dir)
+                    rescue Errno::ENOTEMPTY
+                    end
                     created_log_base_dirs.delete(dir)
                 end
                 @log_dir = nil


### PR DESCRIPTION
When a tool like the IDE is started, it attempts to delete all
directories that it had to create for its own log dir. However,
if in the meantime something like syskit run was executed, the
log directories end up not being empty

On Ruby 2.3, FileUtils.rmdir would simply ignore such directories.
2.5 raises Errno::ENOTEMPTY. Since Errno::ENOTEMPTY already exists
in 2.3 as well, let's just rescue it.