### PR TITLE
implement a built-in depend-on-other-apps mechanism

### DIFF
--- a/lib/roby.rb
+++ b/lib/roby.rb
@@ -126,6 +126,7 @@ require 'roby/actions'
 require 'roby/coordination'
 
 require 'roby/droby/enable'
+require 'roby/custom_require'
 
 module Roby
     BIN_DIR = File.expand_path(File.join("..", "bin"), __dir__)

--- a/lib/roby/app.rb
+++ b/lib/roby/app.rb
@@ -399,6 +399,29 @@ module Roby
             end
         end
 
+        def register_app(path)
+            path = File.expand_path(path, app_dir)
+            app_name = File.basename(path)
+            @search_path ||= self.search_path
+            @search_path << path
+
+            libdir = File.join(path, 'lib')
+            $LOAD_PATH << libdir if File.directory?(libdir)
+            @registered_apps[app_name] = path
+        end
+
+        def has_registered_app?(app_name)
+            @registered_apps.has_key?(app_name)
+        end
+
+        def find_registered_app_path(app_name)
+            if app_name == self.app_name
+                app_dir
+            else
+                @registered_apps[app_name]
+            end
+        end
+
         # Logging options.
         # events:: save a log of all events in the system. This log can be read using scripts/replay
         #          If this value is 'stats', only the data necessary for timing statistics is saved.
@@ -658,6 +681,8 @@ module Roby
         def initialize(plan: ExecutablePlan.new)
             @plan = plan
             @argv_set = Array.new
+
+            @registered_apps = Hash.new
 
             @auto_load_all = false
             @default_auto_load = true

--- a/lib/roby/custom_require.rb
+++ b/lib/roby/custom_require.rb
@@ -1,0 +1,26 @@
+# This is needed because of Ruby bug #9244
+module Kernel
+    alias syskit_original_require require
+    def require(path)
+        # Only deal with paths starting with models/, the other ones are
+        # unambiguous
+        if path =~ /^models\//
+            Roby.app.search_path.each do |app_dir|
+                full_path = File.join(app_dir, path)
+                if File.file?(full_path) || File.file?("#{full_path}.rb")
+                    return syskit_original_require(full_path)
+                end
+            end
+        elsif (match = /^(\w+)\/models\//.match(path))
+            app_name = match[1]
+            if (base_dir = Roby.app.find_registered_app_path(app_name))
+                full_path = File.join(File.dirname(base_dir), path)
+                if File.file?(full_path) || File.file?("#{full_path}.rb")
+                    return syskit_original_require(full_path)
+                end
+            end
+        end
+        syskit_original_require(path)
+    end
+end
+


### PR DESCRIPTION
This is hopefully the last time I have to debug issues related to
this problem. It works without requiring that we modify the LOAD_PATH
too eagerly (the way the bundle mechanism worked)

One would only have to add

~~~
Roby.app.register_app('../common_models')
~~~

to the init code to get the common models bundle once and for all,
both through the 'common_models/models' or the direct 'models/' paths