### PR TITLE
cli: allow for a separation of the log file and its index

### DIFF
--- a/lib/roby/cli/display.rb
+++ b/lib/roby/cli/display.rb
@@ -44,11 +44,11 @@ module Roby
 
             desc 'file PATH', 'inspect an existing log file'
             option :display, type: :string, desc: 'a display to open right away (relations, chronicle or all)'
-            def file(path)
+            def file(path, index_path: nil)
                 apply_common_options
 
                 with_display do |app, display|
-                    display.open(path)
+                    display.open(path, index_path: index_path)
                 end
             end
 

--- a/lib/roby/droby/logfile/reader.rb
+++ b/lib/roby/droby/logfile/reader.rb
@@ -11,8 +11,10 @@ module Roby
 
                 attr_reader :event_io
 
-                def initialize(event_io)
+                def initialize(event_io, index_path: nil)
                     @event_io = event_io
+                    @index_path = index_path ||
+                        event_io.path.gsub(/\.log$/, '') + ".idx"
                     event_io.rewind
                     options_hash = read_header
                     self.class.process_options_hash(options_hash)
@@ -82,7 +84,7 @@ module Roby
                 #
                 # @return [String]
                 def index_path
-                    event_io.path.gsub(/\.log$/, '') + ".idx"
+                    @index_path
                 end
 
                 def rebuild_index(path = index_path)
@@ -119,9 +121,9 @@ module Roby
                         @index = Index.read(path)
                     end
                 end
-                
-                def self.open(path)
-                    io = new(File.open(path))
+
+                def self.open(path, index_path: nil)
+                    io = new(File.open(path), index_path: index_path)
                     if block_given?
                         begin
                             yield(io)

--- a/lib/roby/gui/log_display.rb
+++ b/lib/roby/gui/log_display.rb
@@ -172,8 +172,8 @@ module Roby
             slots 'warn(QString)'
 
             # Opens +filename+ and reads the data from there
-            def open(filename)
-                history_widget.open(filename)
+            def open(filename, index_path: nil)
+                history_widget.open(filename, index_path: index_path)
             end
 
             # Displays the data incoming from +client+

--- a/lib/roby/gui/plan_rebuilder_widget.rb
+++ b/lib/roby/gui/plan_rebuilder_widget.rb
@@ -198,8 +198,8 @@ module Roby
             end
 
             # Opens +filename+ and reads the data from there
-            def open(filename)
-                @logfile = DRoby::Logfile::Reader.open(filename)
+            def open(filename, index_path: nil)
+                @logfile = DRoby::Logfile::Reader.open(filename, index_path: index_path)
                 self.window_title = "roby-display: #{filename}"
                 emit sourceChanged
                 analyze
@@ -226,7 +226,7 @@ module Roby
                         needs_snapshot =
                             (plan_rebuilder.has_structure_updates? ||
                              plan_rebuilder.has_event_propagation_updates?)
-                        yield(needs_snapshot, data) 
+                        yield(needs_snapshot, data)
                     end
                     plan_rebuilder.clear_integrated
                     dialog.setValue(plan_rebuilder.cycle_start_time - start_time)


### PR DESCRIPTION
This allows more high-level tools to keep the data from the caches,
helping with e.g. cleanup and backups