### PR TITLE
handle model.fullfilled_model returning an array with no class

### DIFF
--- a/lib/roby/task_structure/dependency.rb
+++ b/lib/roby/task_structure/dependency.rb
@@ -735,8 +735,11 @@ module Roby
                         [model[0]] + model[1]
                     else
                         models = self.model.fullfilled_model
-                        task_class = models.find { |m| m.kind_of?(Class) }
-                        [task_class] + models.find_all { |m| !task_class.has_ancestor?(m) }
+                        if (task_class = models.find { |m| m.kind_of?(Class) })
+                            [task_class] + models.find_all { |m| !task_class.has_ancestor?(m) }
+                        else
+                            models
+                        end
                     end
                 end
 

--- a/test/task_structure/test_dependency.rb
+++ b/test/task_structure/test_dependency.rb
@@ -634,6 +634,40 @@ module Roby
                     assert_equal [task_m], task_m.new.provided_models
                 end
 
+                it "puts the task model first" do
+                    task_m = Task.new_submodel
+                    srv_m = TaskService.new_submodel
+                    task_m.singleton_class.class_eval do
+                        define_method :fullfilled_model do
+                            [srv_m, task_m]
+                        end
+                    end
+                    assert_equal [task_m, srv_m], task_m.new.provided_models
+                end
+
+                it "filters out services that the task model provides" do
+                    task_m = Task.new_submodel
+                    srv_m = TaskService.new_submodel
+                    task_m.provides srv_m
+                    task_m.singleton_class.class_eval do
+                        define_method :fullfilled_model do
+                            [srv_m, task_m]
+                        end
+                    end
+                    assert_equal [task_m], task_m.new.provided_models
+                end
+
+                it "deals with a provided model set that has no class" do
+                    task_m = Task.new_submodel
+                    srv_m = TaskService.new_submodel
+                    task_m.singleton_class.class_eval do
+                        define_method :fullfilled_model do
+                            [srv_m]
+                        end
+                    end
+                    assert_equal [srv_m], task_m.new.provided_models
+                end
+
                 it "falls back on the models' fullfilled model" do
                     task_m = Task.new_submodel
                     sub_m  = task_m.new_submodel


### PR DESCRIPTION
Syskit allows to represent one or more data services in the plan.
Until recently, the generated task models were having
'Syskit::Component' within their fullfilled model, but they're
actually not full components and they are not returning it anymore.

Change #provided_models to handle this use case, where
models.fullfilled_model only returns services (Ruby Module) and
no task models (Ruby Class)