### PR TITLE
test: fix value returned by #run in Test::Spec

### DIFF
--- a/lib/roby/test/spec.rb
+++ b/lib/roby/test/spec.rb
@@ -181,12 +181,15 @@ module Roby
             # Filters out the test suites that are not enabled by the current
             # Roby configuration
             def run
-                time_it do
-                    capture_exceptions do
+                begin
+                    time_it do
                         self.class.roby_should_run(self, app)
-                        super
                     end
+                rescue Minitest::Skip
+                    return Minitest::Result.from(self)
                 end
+
+                super
             end
         end
     end


### PR DESCRIPTION
Minitest::Test#run is expected to return Minitest::Result instances.

Refactor to separately handling the roby_should_run call (for which
we do need to catch errors) and just call super for the rest - since
Minitest already internally wraps the call.