### PR TITLE
Provide a way to know why arguments don't get merged

### DIFF
--- a/lib/roby/task.rb
+++ b/lib/roby/task.rb
@@ -1200,7 +1200,7 @@ module Roby
                 return false
             end
 
-            target.arguments.can_semantic_merge?(arguments)
+            arguments.can_semantic_merge?(target.arguments)
         end
 
         # "Simply" mark this task as terminated. This is meant to be used on


### PR DESCRIPTION
This is useful in error reporting, for instance in Syskit when a plan can't be merged.

In addition, improve the documentation regarding the handling of task arguments,
especially w.r.t. the difference between plain and delayed argument objects.