### PR TITLE
fix exception when the same event of a task is sequentially used in two state machines

### DIFF
--- a/lib/roby/coordination/script.rb
+++ b/lib/roby/coordination/script.rb
@@ -56,7 +56,7 @@ module Roby
                     end
                     event = self.event.resolve
                     event.on do |ev|
-                        if ev.generator == self.event.resolve && !disabled?
+                        if !disabled? && (ev.generator == self.event.resolve)
                             cancel
                             script.step
                         end

--- a/lib/roby/coordination/task_script.rb
+++ b/lib/roby/coordination/task_script.rb
@@ -183,6 +183,8 @@ module Roby
             # Execute the provided block once per execution cycle, until the
             # given event is emitted
             def poll_until(event, &block)
+                raise ArgumentError, "poll_until requires a block" unless block
+
                 event, model_event = resolve_event(event)
                 model.instructions << Script::Models::PollUntil.new(model_event, block)
                 event


### PR DESCRIPTION
If during execution the same event of a task is used sequentially in two state machines, the second transition will raise an exception if the first state machine has been garbage collected.

For instance, in:

~~~
action_state_machine 'test' do
   wait = state(acquire_pose)
   done = state(another).depends_on(acquire_pose)
   transition wait.pose_acquired_event, done
   done.success_event.forward_to success_event
end
~~~

if the `acquire_pose` toplevel task is not terminated between two runs of `test`, the second run would raise an exception.