### PR TITLE
rename all templates to .rb.erb to please IDE's syntax highlighting autodection

### DIFF
--- a/lib/roby/cli/gen/actions/class.rb.erb
+++ b/lib/roby/cli/gen/actions/class.rb.erb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 <% indent, open_code, close_code = ::Roby::CLI::Gen.in_module(*class_name[0..-2]) %>
 <%= open_code %>
 <%= indent %>class <%= class_name.last %> < Roby::Actions::Interface

--- a/lib/roby/cli/gen/actions/test.rb.erb
+++ b/lib/roby/cli/gen/actions/test.rb.erb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require '<%= require_path %>'
 <% indent, open, close = ::Roby::CLI::Gen.in_module(*class_name[0..-2]) %>
 <%= open %>

--- a/lib/roby/cli/gen/class/class.rb.erb
+++ b/lib/roby/cli/gen/class/class.rb.erb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 <% indent, open_code, close_code = ::Roby::CLI::Gen.in_module(*class_name[0..-2]) %>
 <%= open_code %>
 <%= indent %>class <%= class_name.last %>

--- a/lib/roby/cli/gen/class/test.rb.erb
+++ b/lib/roby/cli/gen/class/test.rb.erb
@@ -1,6 +1,9 @@
+# frozen_string_literal: true
+
 require '<%= require_path %>'
 <% indent, open, close = ::Roby::CLI::Gen.in_module(*class_name[0..-2]) %>
 <%= open %>
 <%= indent %>describe <%= class_name.last %> do
 <%= indent %>end
 <%= close %>
+

--- a/lib/roby/cli/gen/module/module.rb.erb
+++ b/lib/roby/cli/gen/module/module.rb.erb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 <% indent, open_code, close_code = ::Roby::CLI::Gen.in_module(*module_name[0..-2]) %>
 <%= open_code %>
 <%= indent %>module <%= module_name.last %>

--- a/lib/roby/cli/gen/module/test.rb.erb
+++ b/lib/roby/cli/gen/module/test.rb.erb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require '<%= require_path %>'
 <% indent, open, close = ::Roby::CLI::Gen.in_module(*module_name[0..-2]) %>
 <%= open %>

--- a/lib/roby/cli/gen/roby_app/config/init.rb
+++ b/lib/roby/cli/gen/roby_app/config/init.rb
@@ -1,6 +1,8 @@
+# frozen_string_literal: true
+
 # This file is called to do application-global configuration. For configuration
 # specific to a robot, edit config/NAME.rb, where NAME is the robot name.
-# 
+#
 # Here are some of the most useful configuration options
 
 # Use backward-compatible naming and behaviour, when applicable
@@ -13,5 +15,5 @@ Roby.app.backward_compatible_naming = false
 # name is inferred from the base directory name (e.g. an app located in
 # bundles/flat_fish would have an app name of flat_fish and a module name of
 # FlatFish
-# 
+#
 # Roby.app.module_name = 'Override'

--- a/lib/roby/cli/gen/roby_app/config/robots/robot.rb.erb
+++ b/lib/roby/cli/gen/roby_app/config/robots/robot.rb.erb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 <% if robot_name != 'default' %>## A common pattern is to load the 'default' robot configuration
 require_relative './default'<% end %>
 
@@ -8,8 +10,9 @@ require_relative './default'<% end %>
 
 # Block evaluated at the very beginning of the Roby app initialization
 Robot.init do
-    ## You could also change the Roby search path
-    # Roby.app.search_path << "separate path"
+    ## Make models from another Roby app accessible
+    # Relative paths are resolved from the root of this app
+    # Roby.app.register_app('../separate_path')
 end
 
 # Block evaluated to load the models this robot requires

--- a/lib/roby/cli/gen/task/class.rb.erb
+++ b/lib/roby/cli/gen/task/class.rb.erb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 <% indent, open_code, close_code = ::Roby::CLI::Gen.in_module(*class_name[0..-2]) %>
 <%= open_code %>
 <%= indent %>class <%= class_name.last %> < Roby::Task
@@ -7,7 +9,7 @@
 <%= indent %>    # Declare an argument to the task. Use default: VALUE to set up a default
 <%= indent %>    # value. The default can be nil
 <%= indent %>    # argument :arg[, default: 1]
-<%= indent %>    
+<%= indent %>
 <%= indent %>    # Declare a new event. This defines updated_event which returns a
 <%= indent %>    # Roby::EventGenerator
 <%= indent %>    # event :updated

--- a/lib/roby/cli/gen/task/test.rb.erb
+++ b/lib/roby/cli/gen/task/test.rb.erb
@@ -1,7 +1,8 @@
+# frozen_string_literal: true
+
 require '<%= require_path %>'
 <% indent, open, close = ::Roby::CLI::Gen.in_module(*class_name[0..-2]) %>
 <%= open %>
 <%= indent %>describe <%= class_name.last %> do
 <%= indent %>end
 <%= close %>
-

--- a/lib/roby/cli/gen_main.rb
+++ b/lib/roby/cli/gen_main.rb
@@ -6,11 +6,19 @@ module Roby
         class GenMain < Thor
             include Thor::Actions
 
-
             namespace :gen
             source_paths << File.join(__dir__, 'gen')
 
-            desc "app [DIR]", "creates a new app scaffold in the current directory, or DIR if given"
+            no_commands do
+                def template(template_path, *args, **kw)
+                    super(template_path + '.erb', *args, **kw)
+                rescue Thor::Error
+                    super(template_path, *args, **kw)
+                end
+            end
+
+            desc 'app [DIR]', 'creates a new app scaffold in the current directory, '\
+                              'or DIR if given'
             option :quiet, type: :boolean, default: false
             def app(dir = nil, init_path: 'roby_app', robot_path: 'roby_app')
                 if dir


### PR DESCRIPTION
The old pattern will still work, to make sure gen is not broken if
we forget some files, and/or we're not breaking other packages
(e.g. Syskit) while they migrate too,.