### PR TITLE
test: provide Test::InstanceExtension to allow filtering on robot/mode/... even on non-Roby contexts

### DIFF
--- a/lib/roby/test/roby_app_helpers.rb
+++ b/lib/roby/test/roby_app_helpers.rb
@@ -105,12 +105,18 @@ module Roby
                 end
             end
 
+            # Path to the app test fixtures, that is test/app/fixtures
             def roby_app_fixture_path
                 File.expand_path(
                     File.join("..", "..", "..", 'test', "app", "fixtures"),
                     __dir__)
             end
 
+            # Create a minimal Roby application with a given list of scripts copied
+            # in scripts/
+            #
+            # @param [String] scripts list of scripts, relative to {#roby_app_fixture_path}
+            # @return [String] the path to the app root
             def roby_app_setup_single_script(*scripts)
                 dir = make_tmpdir
                 FileUtils.mkdir_p File.join(dir, 'config', 'robots')
@@ -121,7 +127,7 @@ module Roby
                     p = File.expand_path(p, roby_app_fixture_path)
                     FileUtils.cp p, File.join(dir, 'scripts')
                 end
-                return dir
+                dir
             end
 
             def roby_app_spawn(*args, silent: false, **options)
@@ -132,6 +138,12 @@ module Roby
                 pid = spawn(roby_bin, *args, chdir: app_dir, **options)
                 @spawned_pids << pid
                 return pid
+            end
+
+            def roby_app_run(*args, silent: false, **options)
+                pid = roby_app_spawn(*args, silent: silent, **options)
+                _, status = Process.waitpid2(pid)
+                status
             end
 
             def roby_app_create_logfile

--- a/test/app/fixtures/run_if.rb
+++ b/test/app/fixtures/run_if.rb
@@ -1,0 +1,27 @@
+require 'roby/test/dsl'
+
+describe 'selects tests to run based on the mode' do
+    extend Roby::Test::DSL
+
+    it 'runs this in all modes' do
+        puts "\nTEST: all"
+    end
+
+    run_on_robot 'special_robot' do
+        it 'runs this in the special_robot robot' do
+            puts "\nTEST: special_robot"
+        end
+    end
+
+    run_simulated do
+        it 'runs this not in live mode' do
+            puts "\nTEST: simulated"
+        end
+    end
+
+    run_live do
+        it 'runs this in live mode' do
+            puts "\nTEST: live"
+        end
+    end
+end

--- a/test/test/test_dsl.rb
+++ b/test/test/test_dsl.rb
@@ -1,0 +1,54 @@
+require 'roby/test/self'
+require 'roby/test/roby_app_helpers'
+require 'roby/test/dsl'
+
+module Roby
+    module Test
+        describe DSL do
+            include Roby::Test::RobyAppHelpers
+
+            it 'skips tests that are run_on_robot for a different robot' do
+                out = capture_test_output do
+                    dir = roby_app_setup_single_script 'run_if.rb'
+                    run_test dir
+                end
+                assert_equal Set['TEST: all', 'TEST: simulated'], out
+            end
+
+            it 'runs tests that are run_on_robot for the selected robot' do
+                out = capture_test_output do
+                    dir = roby_app_setup_single_script 'run_if.rb'
+                    FileUtils.touch File.join(dir, 'config', 'robots', 'special_robot.rb')
+                    run_test dir, '--robot=special_robot'
+                end
+                assert_equal Set['TEST: all', 'TEST: simulated', 'TEST: special_robot'],
+                             out
+            end
+
+            it 'skips tests that are "run_live" and runs those that are run_simulated if in live mode' do
+                out = capture_test_output do
+                    dir = roby_app_setup_single_script 'run_if.rb'
+                    run_test dir
+                end
+                assert_equal Set['TEST: all', 'TEST: simulated'], out
+            end
+
+            it 'runs tests that are "run_live" and skips those that are run_simulated if in live mode' do
+                out = capture_test_output do
+                    dir = roby_app_setup_single_script 'run_if.rb'
+                    run_test dir, '--live'
+                end
+                assert_equal Set['TEST: all', 'TEST: live'], out
+            end
+
+            def capture_test_output(&block)
+                out, _ = capture_subprocess_io(&block)
+                out.split("\n").map(&:chomp).grep(/^TEST: /).to_set
+            end
+
+            def run_test(dir, *args)
+                roby_app_run('test', *args, 'scripts/run_if.rb', chdir: dir)
+            end
+        end
+    end
+end


### PR DESCRIPTION
Describe blocks that handle Roby/Syskit models already had the ability
to define tests that should run only in certain combination(s) of settings (e.g.
particular robot, `--live`, `--interactive`).

This extends that ability to contexts that describe non-Roby classes. They
only have to `include Roby::Test::DSL`.

The roby_should_run mechanism, which is the underlying implementation
for e.g. run_interactive was currently available only on Roby/Syskit-
related tests, as e.g. composition tests or task context tests.

This makes it available also for "plain" tests. The only requirement
is that the test needs to extend Roby::Test::DSL.