### PR TITLE
shell: add a timeout on calls

### DIFF
--- a/test/interface/test_client.rb
+++ b/test/interface/test_client.rb
@@ -448,6 +448,27 @@ module Roby
                 end
             end
 
+            describe '#call' do
+                it 'returns the remote method call value' do
+                    client = open_client
+                    @interface.should_receive(:foobar).explicitly.and_return(42)
+                    result = while_polling_server do
+                        client.call([], :foobar)
+                    end
+                    assert_equal 42, result
+                end
+
+                it 'times out with the configured call timeout' do
+                    client = open_client
+                    client.call_timeout = 0.01
+                    e = assert_raises(Client::TimeoutError) do
+                        client.call([], :foobar)
+                    end
+                    assert_equal 'failed to receive expected reply within 0.01s',
+                                 e.message
+                end
+            end
+
             describe "#async_call" do
                 attr_reader :watch
                 attr_reader :async_calls_count


### PR DESCRIPTION
This ensures that client such as the shell or the IDE don't freeze
forever if Syskit has become unresponsive

I was originally going for a timeout: parameter, but it is tricky to
make the difference between a `timeout` argument to a remote call and a
timeout argument to the Client method. It would have needed a different
design from the get-go. So, go for a class-wide timeout instead.