### PR TITLE
small improvements for asynchronous tests

### DIFF
--- a/lib/roby/test/expect_execution.rb
+++ b/lib/roby/test/expect_execution.rb
@@ -84,6 +84,8 @@ module Roby
             # that is not allowed
             class InvalidContext < RuntimeError; end
 
+            attr_accessor :expect_execution_default_timeout
+
             # Declare expectations about the execution of a code block
             #
             # See the documentation of {ExpectExecution} for more details
@@ -94,8 +96,13 @@ module Roby
                 if plan.execution_engine.in_propagation_context?
                     raise InvalidContext, "cannot recursively call #expect_execution"
                 end
+
                 expectations = ExecutionExpectations.new(self, plan)
-                Context.new(self, expectations, block)
+                context = Context.new(self, expectations, block)
+                if @expect_execution_default_timeout
+                    context.timeout(@expect_execution_default_timeout)
+                end
+                context
             end
 
             # @api private

--- a/lib/roby/test/teardown_plans.rb
+++ b/lib/roby/test/teardown_plans.rb
@@ -1,13 +1,19 @@
+# frozen_string_literal: true
+
 module Roby
     module Test
         module TeardownPlans
             attr_reader :registered_plans
 
+            def initialize(name)
+                super
+                @default_teardown_poll = 0.01
+            end
+
             def register_plan(plan)
-                if !plan
-                    raise "registering nil plan"
-                end
-                (@registered_plans ||= Array.new) << plan
+                raise 'registering nil plan' unless plan
+
+                (@registered_plans ||= []) << plan
             end
 
             def clear_registered_plans
@@ -21,33 +27,37 @@ module Roby
                 registered_plans.clear
             end
 
-            def teardown_registered_plans
-                old_gc_roby_logger_level = Roby.logger.level
-                if self.registered_plans.all? { |p| p.empty? }
-                    return
-                end
+            attr_accessor :default_teardown_poll
 
-                plans = self.registered_plans.map do |p|
-                    if p.executable?
-                        [p, p.execution_engine, Set.new, Set.new]
-                    end
+            def teardown_registered_plans(teardown_poll: default_teardown_poll,
+                                          teardown_warn: 5)
+                old_gc_roby_logger_level = Roby.logger.level
+                return if registered_plans.all?(&:empty?)
+
+                plans = registered_plans.map do |p|
+                    [p, p.execution_engine, Set.new, Set.new] if p.executable?
                 end.compact
 
                 counter = 0
-                while !plans.empty?
+                teardown_warn_counter = teardown_warn / teardown_poll
+                until plans.empty?
                     plans = plans.map do |plan, engine, last_tasks, last_quarantine|
                         plan_quarantine = plan.quarantined_tasks
-                        if counter > 100
-                            Roby.warn "more than #{counter} iterations while trying to shut down #{plan} after #{self.class.name}##{name}, quarantine=#{plan_quarantine.size} tasks, tasks=#{plan.tasks.size} tasks"
+                        if counter > teardown_warn_counter
+                            Roby.warn "more than #{counter} iterations while trying "\
+                                      "to shut down #{plan} after #{self.class.name}#"\
+                                      "#{name}, quarantine=#{plan_quarantine.size} "\
+                                      "tasks, tasks=#{plan.tasks.size} tasks"
                             if last_tasks != plan.tasks
-                                Roby.warn "Known tasks:"
+                                Roby.warn 'Known tasks:'
                                 plan.tasks.each do |t|
-                                    Roby.warn "  #{t} running=#{t.running?} finishing=#{t.finishing?}"
+                                    Roby.warn "  #{t} running=#{t.running?} "\
+                                              "finishing=#{t.finishing?}"
                                 end
                                 last_tasks = plan.tasks.dup
                             end
                             if last_quarantine != plan_quarantine
-                                Roby.warn "Quarantined tasks:"
+                                Roby.warn 'Quarantined tasks:'
                                 plan_quarantine.each do |t|
                                     Roby.warn "  #{t}"
                                 end
@@ -57,44 +67,50 @@ module Roby
                         end
                         engine.killall
 
-                        quarantine_and_dependencies = plan.compute_useful_tasks(plan.quarantined_tasks)
-                        
+                        quarantine_and_dependencies =
+                            plan.compute_useful_tasks(plan.quarantined_tasks)
+
                         if quarantine_and_dependencies.size != plan.tasks.size
                             [plan, engine, last_tasks, last_quarantine]
                         end
                     end.compact
                     counter += 1
+                    sleep teardown_poll
                 end
 
                 registered_plans.each do |plan|
-                    if !plan.empty?
-                        if plan.tasks.all? { |t| t.pending? }
-                            plan.clear
-                        else
-                            Roby.warn "failed to teardown: #{plan} has #{plan.tasks.size} tasks and #{plan.free_events.size} events, #{plan.quarantined_tasks.size} of which are in quarantine"
-                            if !plan.execution_engine
-                                Roby.warn "this is most likely because this plan does not have an execution engine. Either add one or clear the plan in the tests"
-                            end
+                    plan.clear if plan.tasks.all?(&:pending?)
+
+                    unless plan.empty?
+                        Roby.warn(
+                            "failed to teardown: #{plan} has #{plan.tasks.size} "\
+                            "tasks and #{plan.free_events.size} events, "\
+                            "#{plan.quarantined_tasks.size} of which are "\
+                            'in quarantine'
+                        )
+
+                        unless plan.execution_engine
+                            Roby.warn 'this is most likely because this plan '\
+                                      'does not have an execution engine. Either '\
+                                      'add one or clear the plan in the tests'
                         end
                     end
+
                     plan.clear
-                    if engine = plan.execution_engine
+                    if (engine = plan.execution_engine)
                         engine.clear
                         engine.emitted_events.clear
                     end
 
-                    if !plan.transactions.empty?
-                        Roby.warn "  #{plan.transactions.size} transactions left attached to the plan"
-                        plan.transactions.each do |trsc|
-                            trsc.discard_transaction
-                        end
+                    unless plan.transactions.empty?
+                        Roby.warn "  #{plan.transactions.size} transactions left "\
+                                  'attached to the plan'
+                        plan.transactions.each(&:discard_transaction)
                     end
                 end
-
             ensure
                 Roby.logger.level = old_gc_roby_logger_level
             end
         end
     end
 end
-

--- a/test/test/test_expect_execution.rb
+++ b/test/test/test_expect_execution.rb
@@ -1,34 +1,56 @@
+# frozen_string_literal: true
+
 require 'roby/test/self'
 
 module Roby
     module Test
         describe ExpectExecution do
-            describe "#expect_execution" do
-                it "can be created in parallel" do
+            describe '#expect_execution' do
+                it 'can be created in parallel' do
                     first, second = nil
                     expectations0 = expect_execution { first = true }
                     expectations1 = expect_execution { second = true }
                     expectations0.to { achieve { first } }
                     expectations1.to { achieve { second } }
                 end
-                it "cannot be executed recursively within the event processing block" do
+                it 'cannot be executed recursively within the event processing block' do
                     assert_raises(ExpectExecution::InvalidContext) do
                         expect_execution do
-                            expect_execution { }
-                        end.to { }
+                            expect_execution {}
+                        end.to {}
                     end
                 end
-                it "cannot be executed recursively within the expectation block" do
+                it 'cannot be executed recursively within the expectation block' do
                     assert_raises(ExpectExecution::InvalidContext) do
                         expect_execution.to do
-                            expect_execution.to { }
+                            expect_execution.to {}
                         end
                     end
                 end
             end
 
-            describe "#add_expectations" do
-                it "adds a new expectation from within the event processing block" do
+            describe "#expect_execution_default_timeout" do
+                it 'allows setting the default timeout' do
+                    plan.add(task = Roby::Tasks::Simple.new)
+                    tics = [Time.now]
+                    self.expect_execution_default_timeout = 0.1
+                    assert_raises(Roby::Test::ExecutionExpectations::Unmet) do
+                        expect_execution.to { emit task.start_event }
+                    end
+                    tics << Time.now
+                    self.expect_execution_default_timeout = 0.5
+                    assert_raises(Roby::Test::ExecutionExpectations::Unmet) do
+                        expect_execution.to { emit task.start_event }
+                    end
+                    tics << Time.now
+
+                    assert((0.05..0.2).include?(tics[1] - tics[0]))
+                    assert((0.45..0.55).include?(tics[2] - tics[1]))
+                end
+            end
+
+            describe '#add_expectations' do
+                it 'adds a new expectation from within the event processing block' do
                     called = false
                     expect_execution do
                         add_expectations do
@@ -37,7 +59,7 @@ module Roby
                     end.to { }
                     assert called
                 end
-                it "ignores the return values of expectations added this way" do
+                it 'ignores the return values of expectations added this way' do
                     expected_ret = flexmock
                     ret = expect_execution do
                         add_expectations do

--- a/test/test/test_teardown_plans.rb
+++ b/test/test/test_teardown_plans.rb
@@ -1,0 +1,38 @@
+require 'roby/test/self'
+
+module Roby
+    module Test
+        describe TeardownPlans do
+            describe '#teardown_registered_plans' do
+                it 'warns about tasks that block the plan after teardown_warn seconds' do
+                    task_m = Roby::Task.new_submodel do
+                        event(:stop) { |event| }
+                    end
+                    plan.add(task = task_m.new)
+
+                    messages = []
+                    warn_time = nil
+                    flexmock(Roby).should_receive(:warn).and_return do |msg|
+                        warn_time ||= Time.now
+                        messages << msg
+                        execution_engine.once { task.stop_event.emit }
+                    end
+
+                    execute { task.start_event.emit }
+                    tic = Time.now
+                    teardown_registered_plans(teardown_warn: 0.1)
+                    assert((0.08..0.2).include?(warn_time - tic))
+
+                    matcher = Regexp.new(
+                        "more than \\d+ iterations while trying to shut down #{plan} "\
+                        "after .*teardown_registered_plans#test_\\d+_warns about "\
+                        "tasks that block the plan after teardown_warn "\
+                        "seconds, quarantine=0 tasks, tasks=1 tasks")
+                    assert_match matcher, messages[0]
+
+                    assert_equal "  #{task} running=true finishing=true", messages[2]
+                end
+            end
+        end
+    end
+end


### PR DESCRIPTION
So far, Roby/Syskit tests were always run in stub mode. Running them for live components
triggered some issues, mostly related to the fact that live components are handled asynchronously