### PR TITLE
app: do not resolve test exclusions w.r.t the app dir

### DIFF
--- a/lib/roby/app/scripts/test.rb
+++ b/lib/roby/app/scripts/test.rb
@@ -37,7 +37,8 @@ parser = OptionParser.new do |opt|
     end
     opt.on('--exclude PATTERN', String, 'do not run files '\
            'matching this pattern') do |pattern|
-        excluded_patterns << File.expand_path(pattern, Roby.app.app_dir)
+        pattern = "**/#{pattern}" if pattern[0, 1] != '/'
+        excluded_patterns << pattern
     end
     opt.on('--distributed', 'access remote systems while setting up '\
                             'or running the tests') do |val|


### PR DESCRIPTION
Running `roby test` in an app may run tests in dependent apps as well (e.g. in bundles/common_models). The current behavior of "anchoring" the exclusion patterns from `app_dir` made it pretty hard to use them.

This inverses the behavior: match the patterns as-is - thus allowing to exclude test files from dependent bundles - which still allows to explicitly provide a pattern with the name of a parent app to 'anchor' the pattern.