### PR TITLE
allow passing a simplecov command name through the test command line

### DIFF
--- a/lib/roby/test/self.rb
+++ b/lib/roby/test/self.rb
@@ -5,6 +5,10 @@ if ENV['TEST_ENABLE_COVERAGE'] == '1' || ENV['TEST_COVERAGE_MODE']
     mode = ENV['TEST_COVERAGE_MODE'] || 'simplecov'
     begin
         require mode
+        name_arg = ARGV.find { |arg| arg.match?(/--simplecov-name=/) }
+        if name_arg
+            SimpleCov.command_name name_arg.split('=')[1]
+        end
     rescue LoadError => e
         require 'roby'
         Roby.warn "coverage is disabled because the code coverage gem cannot be loaded: #{e.message}"


### PR DESCRIPTION
This may be used to separate the test suite in different processes
(e.g. a fast/slow suite) while keeping a common coverage report.