### PR TITLE
queries: generalize plan-iteration capabilities to all matchers

### DIFF
--- a/lib/roby/queries.rb
+++ b/lib/roby/queries.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Roby
     # Namespace for all query and matching-related functionality
     module Queries
@@ -8,6 +10,9 @@ require 'roby/queries/any'
 require 'roby/queries/none'
 require 'roby/queries/matcher_base'
 require 'roby/queries/index'
+require 'roby/queries/local_query_result'
+require 'roby/queries/plan_query_result'
+require 'roby/queries/transaction_query_result'
 require 'roby/queries/plan_object_matcher'
 require 'roby/queries/task_matcher'
 require 'roby/queries/event_generator_matcher'
@@ -20,4 +25,3 @@ require 'roby/queries/or_matcher'
 require 'roby/queries/localized_error_matcher'
 require 'roby/queries/code_error_matcher'
 require 'roby/queries/execution_exception_matcher'
-

--- a/lib/roby/queries/and_matcher.rb
+++ b/lib/roby/queries/and_matcher.rb
@@ -1,32 +1,42 @@
+# frozen_string_literal: true
+
 module Roby
     module Queries
-
-    # This task combines multiple task matching predicates through a AND boolean
-    # operator. I.e. it will match if none of the underlying predicates match.
-    class AndMatcher < MatcherBase
-        # Create a new AndMatcher object combining the given predicates.
-        def initialize(*ops)
-            @ops = ops 
-        end
-
-        # Filters as much as non-matching tasks as possible out of +task_set+,
-        # based on the information in +task_index+
-        def filter(task_set, task_index)
-            result = task_set
-            for child in @ops
-                result &= child.filter(task_set, task_index)
+        # This matcher combines multiple task matching predicates through a AND boolean
+        # operator. I.e. it will match if none of the underlying predicates match.
+        class AndMatcher < MatcherBase
+            # Create a new AndMatcher object combining the given predicates.
+            def initialize(*ops)
+                @ops = ops
             end
-            result
+
+            # Add a new predicate to the combination
+            def <<(op)
+                @ops << op
+                self
+            end
+
+            # True if the task matches at least one of the underlying predicates
+            def ===(task)
+                @ops.all? { |op| op === task }
+            end
+
+            # Version of {AndMatcher} specialized for {TaskMatcher}
+            #
+            # Do not create directly, use {TaskMatcher#&} instead
+            class Tasks < AndMatcher
+                def evaluate(plan)
+                    @ops.map { |o| o.evaluate(plan) }
+                        .inject(&:&)
+                end
+
+                # Enumerate the objects matching self in the plan
+                def each_in_plan(plan, &block)
+                    return enum_for(__method__, plan) unless block_given?
+
+                    evaluate(plan).each_in_plan(plan, &block)
+                end
+            end
         end
-
-        # Add a new predicate to the combination
-        def <<(op); @ops << op end
-
-        # True if the task matches at least one of the underlying predicates
-        def ===(task)
-            @ops.all? { |op| op === task }
-        end
-    end
-
     end
 end

--- a/lib/roby/queries/index.rb
+++ b/lib/roby/queries/index.rb
@@ -16,6 +16,12 @@ module Roby
             attr_reader :by_owner
             # Tasks that are locally owned
             attr_reader :self_owned
+            # Set of mission tasks
+            attr_reader :mission_tasks
+            # Set of permanent tasks
+            attr_reader :permanent_tasks
+            # Set of permanent events
+            attr_reader :permanent_events
 
             STATE_PREDICATES = %I[
                 pending? starting? running? finished? success? failed?
@@ -39,6 +45,9 @@ module Roby
                 @self_owned.compare_by_identity
                 @by_owner = {}
                 @by_owner.compare_by_identity
+                @mission_tasks = Set.new
+                @permanent_tasks = Set.new
+                @permanent_events = Set.new
             end
 
             def merge(source)
@@ -80,6 +89,9 @@ module Roby
                 @by_predicate.each_value(&:clear)
                 @by_owner.clear
                 @self_owned.clear
+                @mission_tasks.clear
+                @permanent_tasks.clear
+                @permanent_events.clear
             end
 
             # Add a new task to this index

--- a/lib/roby/queries/local_query_result.rb
+++ b/lib/roby/queries/local_query_result.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Roby
+    module Queries
+        class LocalQueryResult
+            attr_reader :plan
+            attr_reader :initial_set
+            attr_accessor :result_set
+
+            def initialize(plan, initial_set, result_set)
+                @plan = plan
+                @initial_set = initial_set
+                @result_set = Set.new
+                @result_set.compare_by_identity
+                @result_set.merge(result_set)
+            end
+
+            def include?(obj)
+                result_set.include?(obj)
+            end
+
+            def each(&block)
+                result_set.each(&block)
+            end
+        end
+    end
+end

--- a/lib/roby/queries/op_matcher.rb
+++ b/lib/roby/queries/op_matcher.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Roby
     module Queries
         # Base class for matchers that are built as operations over other

--- a/lib/roby/queries/or_matcher.rb
+++ b/lib/roby/queries/or_matcher.rb
@@ -1,30 +1,61 @@
+# frozen_string_literal: true
+
 module Roby
     module Queries
-
-    # Combines multiple task matching predicates through a OR boolean operator.
-    # I.e. it will match if any of the underlying predicates match.
-    class OrMatcher < MatcherBase
-        # Create a new OrMatcher object combining the given predicates.
-        def initialize(*ops)
-            @ops = ops 
-        end
-
-        # Overload of TaskMatcher#filter
-        def filter(task_set, task_index)
-            result = Set.new
-            for child in @ops
-                result.merge child.filter(task_set, task_index)
+        # Combines multiple task matching predicates through a OR boolean operator.
+        # I.e. it will match if any of the underlying predicates match.
+        class OrMatcher < MatcherBase
+            # Create a new OrMatcher object combining the given predicates.
+            def initialize(*ops)
+                @ops = ops
             end
-            result
+
+            # Add a new predicate to the combination
+            def <<(op)
+                @ops << op
+                self
+            end
+
+            def merge(other)
+                @ops.concat(other.instance_variable_get(:@ops))
+                self
+            end
+
+            def ===(task)
+                @ops.any? { |op| op === task }
+            end
+
+            # Enumerate the objects matching self in the plan
+            def each_in_plan(plan)
+                return enum_for(__method__, plan) unless block_given?
+
+                seen = Set.new
+                seen.compare_by_identity
+                @ops.each do |op|
+                    op.each_in_plan(plan) do |obj|
+                        next unless seen.add?(obj)
+
+                        yield(obj)
+                    end
+                end
+            end
+
+            # Version of {OrMatcher} specialized for {TaskMatcher}
+            #
+            # Do not create directly, use {TaskMatcher#|} instead
+            class Tasks < OrMatcher
+                def evaluate(plan)
+                    @ops.map { |o| o.evaluate(plan) }
+                        .inject(&:|)
+                end
+
+                # Enumerate the objects matching self in the plan
+                def each_in_plan(plan, &block)
+                    return enum_for(__method__, plan) unless block_given?
+
+                    evaluate(plan).each_in_plan(plan, &block)
+                end
+            end
         end
-
-        # Add a new predicate to the combination
-        def <<(op); @ops << op end
-
-        def ===(task)
-            @ops.any? { |op| op === task }
-        end
-    end
-
     end
 end

--- a/lib/roby/queries/plan_query_result.rb
+++ b/lib/roby/queries/plan_query_result.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+module Roby
+    module Queries
+        class PlanQueryResult < LocalQueryResult
+            def local_query_results
+                [self]
+            end
+
+            def each_in_plan(plan, &block)
+                if plan != self.plan
+                    raise ArgumentError,
+                          'attempting to enumerate results of a query ran '\
+                          "in #{self.plan} from #{plan}"
+                end
+
+                result_set.each(&block)
+            end
+
+            def roots(in_relation)
+                self.class.roots_of(self, in_relation)
+            end
+
+            def |(other)
+                if other.plan != plan
+                    raise ArgumentError,
+                          "cannot merge results from #{other.plan} "\
+                          "in results from #{plan}"
+                elsif !other.initial_set.equal?(initial_set)
+                    raise ArgumentError,
+                          'cannot merge results with different initial sets'
+                end
+
+                result = dup
+                result.result_set = result_set | other.result_set
+                result
+            end
+
+            def &(other)
+                if other.plan != plan
+                    raise ArgumentError,
+                          "cannot merge results from #{other.plan} "\
+                          "in results from #{plan}"
+                elsif !other.initial_set.equal?(initial_set)
+                    raise ArgumentError,
+                          'cannot merge results with different initial sets'
+                end
+
+                result = dup
+                result.result_set = result_set & other.result_set
+                result
+            end
+
+            def negate
+                result = dup
+                result.result_set = initial_set - result_set
+                result
+            end
+
+            # Called by TaskMatcher#result_set and Query#result_set to get the set
+            # of tasks matching +matcher+
+            def self.from_plan(plan, matcher) # :nodoc:
+                filtered = matcher.filter(
+                    plan.tasks, plan.task_index, initial_is_complete: true
+                )
+
+                if matcher.indexed_query?
+                    new(plan, plan.tasks, filtered)
+                else
+                    result = Set.new
+                    result.compare_by_identity
+                    filtered.each { |task| result << task if matcher === task }
+                    new(plan, plan.tasks, result)
+                end
+            end
+
+            def self.root_in_query?(result_set, task, graph)
+                graph.depth_first_visit(task) do |v|
+                    return false if v != task && result_set.include?(v)
+                end
+                true
+            end
+
+            def self.roots_of(from, in_relation)
+                plan = from.plan
+                result_set = from.result_set
+
+                graph = plan.task_relation_graph_for(in_relation).reverse
+                new_results = result_set.find_all do |task|
+                    root_in_query?(result_set, task, graph)
+                end
+                new(plan, from.initial_set, new_results)
+            end
+        end
+    end
+end

--- a/lib/roby/queries/query.rb
+++ b/lib/roby/queries/query.rb
@@ -2,94 +2,32 @@
 
 module Roby
     module Queries
-        # A query is a TaskMatcher that applies on a plan. It should, in general, be
-        # preferred to TaskMatcher as it uses task indexes to be more efficient.
+        # Binding of a {TaskMatcher} with a particular plan
         #
-        # Queries cache their result. I.e. once #each has been called to get the
-        # query results, the query will always return the same results until #reset
-        # has been called.
+        # This is used as return value for {plan.find_tasks}. The `.each_in_plan`
+        # interface should be preferred instead:
+        #
+        # @example
+        #   SomeTaskModel.match.with_arguments(some: arg).executable.mission
+        #                .each_in_plan(plan)
         class Query < TaskMatcher
             # The plan this query acts on
             attr_reader :plan
 
             # Create a query object on the given plan
             def initialize(plan = nil)
-                @scope = :global
                 @plan = plan
                 super()
-                @plan_predicates = Set.new
-                @neg_plan_predicates = Set.new
             end
 
             def query
                 self
             end
 
-            # Search scope for queries on transactions. If equal to :local, the
-            # query will apply only on the scope of the searched transaction,
-            # otherwise it applies on a virtual plan that is the result of the
-            # transaction stack being applied.
-            #
-            # The default is :global.
-            #
-            # @see #local_scope #local_scope? #global_scope #global_scope?
-            attr_reader :scope
-
-            # Changes the scope of this query
-            #
-            # @see #scope.
-            def local_scope
-                @scope = :local
-                self
-            end
-
-            # Whether this query is limited to its plan
-            #
-            # @see #scope
-            def local_scope?
-                @scope == :local
-            end
-
-            # Changes the scope of this query
-            #
-            # @see #scope
-            def global_scope
-                @scope = :global
-                self
-            end
-
-            # Whether this query is using the global scope
-            def global_scope?
-                @scope == :global
-            end
-
             # Changes the plan this query works on. This calls #reset (obviously)
             def plan=(new_plan)
                 reset
                 @plan = new_plan
-            end
-
-            # The set of tasks which match in plan. This is a cached value, so use
-            # #reset to actually recompute this set.
-            def result_set
-                @result_set ||= plan.query_result_set(self)
-            end
-
-            def indexed_sets(index)
-                positive_sets, negative_sets = super
-
-                if plan_predicates.include?(:mission_task?)
-                    positive_sets << plan.mission_tasks
-                elsif neg_plan_predicates.include?(:mission_task?)
-                    negative_sets << plan.mission_tasks
-                end
-
-                if plan_predicates.include?(:permanent_task?)
-                    positive_sets << plan.permanent_tasks
-                elsif neg_plan_predicates.include?(:permanent_task?)
-                    negative_sets << plan.permanent_tasks
-                end
-                [positive_sets, negative_sets]
             end
 
             # Reinitializes the cached query result.
@@ -102,94 +40,13 @@ module Roby
                 self
             end
 
-            # The set of predicates of Plan which must return true for #=== to
-            # return true
-            attr_reader :plan_predicates
-            # The set of predicates of Plan which must return false for #=== to
-            # return true.
-            attr_reader :neg_plan_predicates
-
-            class << self
-                # For each name in +names+, define the #name and #not_name methods
-                # on Query objects. When one of these methods is called on a Query
-                # object, plan.name?(task) must return true (resp. false) for the
-                # task to match.
-                def match_plan_predicates(names)
-                    names.each do |name, predicate_name|
-                        predicate_name ||= name
-                        class_eval <<~PREDICATE_CODE, __FILE__, __LINE__ + 1
-                            def #{name}
-                                if neg_plan_predicates.include?(:#{predicate_name})
-                                    raise ArgumentError,
-                                        "trying to match (#{name} & !#{name})"
-                                end
-                                plan_predicates << :#{predicate_name}
-                                self
-                            end
-                            def not_#{name}
-                                if plan_predicates.include?(:#{predicate_name})
-                                    raise ArgumentError,
-                                        "trying to match (#{name} & !#{name})"
-                                end
-                                neg_plan_predicates << :#{predicate_name}
-                                self
-                            end
-                        PREDICATE_CODE
-                    end
-                end
+            def result_set(plan)
+                @result_set ||= evaluate(plan)
             end
 
-            ##
-            # :method: mission
-            #
-            # Filters missions
-            #
-            # Matches tasks in plan that are missions
-
-            ##
-            # :method: not_mission
-            #
-            # Filters out missions
-            #
-            # Matches tasks in plan that are not missions
-
-            ##
-            # :method: permanent
-            #
-            # Filters permanent tasks
-            #
-            # Matches tasks in plan that are declared as permanent tasks.
-
-            ##
-            # :method: not_permanent
-            #
-            # Filters out permanent tasks
-            #
-            # Matches tasks in plan that are not declared as permanent tasks
-
-            match_plan_predicates mission: :mission_task?
-            match_plan_predicates permanent: :permanent_task?
-
-            # Filters tasks which have no parents in the query itself.
-            #
-            # Will filter out tasks which have parents in +relation+ that are
-            # included in the query result.
-            def roots(relation)
-                @result_set = plan.query_roots(result_set, relation)
+            def roots(in_relation)
+                @result_set = result_set(plan).roots(in_relation)
                 self
-            end
-
-            # True if +task+ matches the query. Call #result_set to have the set of
-            # tasks which match in the given plan.
-            def ===(task)
-                return unless plan_predicates.all? { |pred| plan.send(pred, task) }
-                if neg_plan_predicates.any? { |neg_pred| plan.send(neg_pred, task) }
-                    return
-                end
-
-                return unless super
-
-                true
             end
 
             # Iterates on all the tasks in the given plan which match the query
@@ -197,11 +54,9 @@ module Roby
             # This set is cached, i.e. #each will yield the same task set until
             # #reset is called.
             def each(&block)
-                return enum_for(__method__) unless block_given?
-
-                plan.query_each(result_set, &block)
+                result_set(plan).each_in_plan(plan, &block)
             end
-            include Enumerable
+            include ::Enumerable
         end
     end
 end

--- a/lib/roby/queries/task_event_generator_matcher.rb
+++ b/lib/roby/queries/task_event_generator_matcher.rb
@@ -46,17 +46,11 @@ module Roby
                 self
             end
 
-            # @raise [NotImplementedError] Cannot yet do plan queries on task
-            #   event generators
-            def filter(_initial_set, _index)
-                raise NotImplementedError
-            end
-
-            alias plan_object_match :===
-
             def to_s
                 "#{task_matcher}.#{symbol}"
             end
+
+            alias plan_object_match ===
 
             # Tests whether the given task event generator matches self
             #
@@ -80,7 +74,23 @@ module Roby
 
             def match_not_generalized(object)
                 (symbol === object.symbol.to_s) &&
-                    plan_object_match(object) && (task_matcher === object.task)
+                    plan_object_match(object) &&
+                    (task_matcher === object.task)
+            end
+
+            # Enumerate the objects matching self in the plan
+            def each_in_plan(plan)
+                if generalized?
+                    raise ArgumentError,
+                          'cannot resolve a generalized matcher in the plan'
+                end
+
+                return enum_for(__method__, plan) unless block_given?
+
+                @task_matcher.each_in_plan(plan) do |task|
+                    event = task.event(symbol)
+                    yield(event) if self === event
+                end
             end
         end
     end

--- a/lib/roby/queries/task_matcher.rb
+++ b/lib/roby/queries/task_matcher.rb
@@ -24,11 +24,28 @@ module Roby
             # @return [Hash]
             attr_reader :arguments
 
+            PLAN_PREDICATES = {
+                mission_task?: :mission_tasks,
+                permanent_task?: :permanent_tasks
+            }.freeze
+
+            # @api private
+            #
+            # Set of predicates specific to the plan (e.g. mission/permanent)
+            attr_reader :plan_predicates
+
+            # @api private
+            #
+            # Set of predicates specific to the plan (e.g. mission/permanent)
+            attr_reader :neg_plan_predicates
+
             # Initializes an empty TaskMatcher object
             def initialize
                 super
                 @arguments = {}
-                @interruptible = nil
+                @indexed_query = !@instance
+                @plan_predicates = Set.new
+                @neg_plan_predicates = Set.new
             end
 
             def to_s
@@ -117,6 +134,7 @@ module Roby
             #       with_arguments(a: 10, c: 30) === task # => false
             def with_arguments(arguments)
                 @arguments ||= {}
+                @indexed_query = false
                 self.arguments.merge!(arguments) do |k, old, new|
                     if old != new
                         raise ArgumentError,
@@ -125,6 +143,57 @@ module Roby
                     old
                 end
                 self
+            end
+
+            def add_predicate(name)
+                @indexed_query = false unless Index::PREDICATES.include?(name)
+
+                super
+            end
+
+            def add_neg_predicate(name)
+                @indexed_query = false unless Index::PREDICATES.include?(name)
+
+                super
+            end
+
+            class << self
+                # @api private
+                def match_indexed_predicate(
+                    name,
+                    index: name.to_s, neg_index: nil,
+                    not_index: nil, not_neg_index: name.to_s
+                )
+                    method_name = name.to_s.gsub(/\?$/, '')
+                    class_eval <<~PREDICATE_METHOD, __FILE__, __LINE__ + 1
+                        def #{method_name}
+                            add_predicate(:#{name})
+                            #{"indexed_predicates << :#{index}" if index}
+                            #{"indexed_neg_predicates << :#{neg_index}" if neg_index}
+                            self
+                        end
+                        def not_#{method_name}
+                            add_neg_predicate(:#{name})
+                            #{"indexed_predicates << :#{not_index}" if not_index}
+                            #{"indexed_neg_predicates << :#{not_neg_index}" if not_neg_index}
+                            self
+                        end
+                    PREDICATE_METHOD
+                    declare_class_methods(method_name, "not_#{method_name}")
+                end
+
+                def match_indexed_predicates(*names)
+                    names.each do |n|
+                        unless Index::PREDICATES.include?(n)
+                            raise ArgumentError,
+                                  "#{n} is not declared in Index::PREDICATES. Use "\
+                                  'match_indexed_predicate directly to override '\
+                                  'this check'
+                        end
+
+                        match_indexed_predicate(n)
+                    end
+                end
             end
 
             ##
@@ -140,13 +209,6 @@ module Roby
             # Matches if the task is partially instanciated
             #
             # See also #fully_instanciated, Task#partially_instanciated?
-
-            ##
-            # :method: not_abstract
-            #
-            # Matches if the task is not abstract
-            #
-            # See also #abstract, Task#abstract?
 
             ##
             # :method: abstract
@@ -262,15 +324,72 @@ module Roby
 
             match_predicates(
                 :abstract?, :partially_instanciated?, :fully_instanciated?,
-                :starting?, :pending?, :running?, :finished?, :success?, :failed?,
                 :interruptible?
             )
 
+            match_indexed_predicates(
+                :starting?, :pending?, :running?, :finished?, :success?, :failed?
+            )
+
             # Finishing tasks are also running task, use the index on 'running'
-            match_predicate :finishing?, [[:running?], []]
+            match_indexed_predicate :finishing?, index: :running?, neg_index: nil,
+                                                 not_index: nil, not_neg_index: nil
 
             # Reusable tasks must be neither finishing nor finished
-            match_predicate :reusable?, [[], [:finished?]]
+            match_indexed_predicate :reusable?, index: nil, neg_index: :finished?,
+                                                not_index: nil, not_neg_index: nil
+
+            # @api private
+            #
+            # Helper to add a plan predicate in the match set
+            def add_plan_predicate(predicate)
+                if !PLAN_PREDICATES.key?(predicate)
+                    raise ArgumentError, "unknown plan predicate #{predicate}"
+                elsif @neg_plan_predicates.include?(predicate)
+                    raise ArgumentError, "trying to match #{predicate} & not_#{predicate}"
+                end
+
+                @plan_predicates << predicate
+                self
+            end
+
+            # @api private
+            #
+            # Helper to add a plan predicate in the match set
+            def add_neg_plan_predicate(predicate)
+                if !PLAN_PREDICATES.key?(predicate)
+                    raise ArgumentError, "unknown plan predicate #{predicate}"
+                elsif @plan_predicates.include?(predicate)
+                    raise ArgumentError, "trying to match #{predicate} & not_#{predicate}"
+                end
+
+                @neg_plan_predicates << predicate
+                self
+            end
+
+            # Matches if the task is a mission
+            def mission
+                add_plan_predicate :mission_task?
+            end
+
+            # Matches if the task is not a mission
+            def not_mission
+                add_neg_plan_predicate :mission_task?
+            end
+
+            declare_class_methods 'mission', 'not_mission'
+
+            # Matches if the task is permanent
+            def permanent
+                add_plan_predicate :permanent_task?
+            end
+
+            # Matches if the task is not permanent
+            def not_permanent
+                add_neg_plan_predicate :permanent_task?
+            end
+
+            declare_class_methods 'permanent', 'not_permanent'
 
             # Helper method for #with_child and #with_parent
             def handle_parent_child_arguments(other_query, relation, relation_options)
@@ -292,18 +411,96 @@ module Roby
             end
 
             # True if +task+ matches all the criteria defined on this object.
-            def ===(task)
+            def ===(task) # rubocop:disable Metrics/CyclomaticComplexity
                 return unless task.kind_of?(Roby::Task)
                 return unless task.arguments.slice(*arguments.keys) == arguments
+                return unless super
+                return unless (plan = task.plan)
+                return unless @plan_predicates.all? { |pred| plan.send(pred, task) }
+                return if @neg_plan_predicates.any? { |pred| plan.send(pred, task) }
 
-                super
+                true
             end
 
             # Returns true if filtering with this TaskMatcher using #=== is
             # equivalent to calling #filter() using a Index. This is used to
             # avoid an explicit O(N) filtering step after filter() has been called
             def indexed_query?
-                arguments.empty? && super
+                @indexed_query
+            end
+
+            # @api private
+            #
+            # Resolve the indexed sets needed to filter an initial set in {#filter}
+            #
+            # @return [(Set,Set)] the positive (intersection) and
+            #   negative (difference) sets. The result will be computed as
+            #    positive.inject(&:&) - negative.inject(&:|)
+            def indexed_sets(index)
+                positive_sets = []
+                @model.each do |m|
+                    positive_sets << index.by_model[m]
+                end
+
+                @owners.each do |o|
+                    candidates = index.by_owner[o]
+                    return [Set.new, Set.new] unless candidates
+
+                    positive_sets << candidates
+                end
+
+                @indexed_predicates.each do |pred|
+                    positive_sets << index.by_predicate[pred]
+                end
+
+                negative_sets =
+                    @indexed_neg_predicates
+                    .map { |pred| index.by_predicate[pred] }
+
+                @plan_predicates.each do |name|
+                    positive_sets << index.send(PLAN_PREDICATES.fetch(name))
+                end
+
+                @neg_plan_predicates.each do |name|
+                    negative_sets << index.send(PLAN_PREDICATES.fetch(name))
+                end
+
+                [positive_sets, negative_sets]
+            end
+
+            # Filters tasks from an initial set to remove as many not-matching
+            # tasks as possible
+            #
+            # If {#indexed_query?} is true, the result is required to be exact
+            # (i.e. return exactly all tasks in initial_set that match the query)
+            #
+            # @param [Set] initial_set
+            # @param [Index] index
+            # @return [([Set],[Set])] a list of 'positive' sets and a list of 'negative'
+            #    sets. The result is computed as
+            #    positive.inject(&:&) - negative.inject(&:|)
+            def filter(initial_set, index, initial_is_complete: false)
+                positive_sets, negative_sets = indexed_sets(index)
+                if !initial_is_complete || positive_sets.empty?
+                    positive_sets << initial_set
+                end
+
+                negative = negative_sets.shift || Set.new
+                unless negative_sets.empty?
+                    negative = negative.dup
+                    negative_sets.each { |set| negative.merge(set) }
+                end
+
+                positive_sets = positive_sets.sort_by(&:size)
+
+                result = Set.new
+                result.compare_by_identity
+                positive_sets.shift.each do |obj|
+                    next if negative.include?(obj)
+
+                    result.add(obj) if positive_sets.all? { |set| set.include?(obj) }
+                end
+                result
             end
 
             def find_event(event_name)
@@ -349,6 +546,90 @@ module Roby
             # TaskMatcher.which_fullfills is equivalent to
             # TaskMatcher.new.which_fullfills
             declare_class_methods :which_fullfills, :with_arguments
+
+            # @api private
+            #
+            # Resolves or returns the cached set of matching tasks in the plan
+            #
+            # This is a cached value, so use {#reset} to actually recompute
+            # this set.
+            #
+            # This should not be called directly. Use {#each_in_plan}
+            def evaluate(plan)
+                plan.query_result_set(self)
+            end
+
+            # Enumerate the objects matching self in the plan
+            #
+            # This resolves the query only the first time. After the first call,
+            # the same set of tasks will be returned. Use {#reset} to clear the
+            # cached results.
+            def each_in_plan(plan, &block)
+                return enum_for(__method__, plan) unless block_given?
+
+                evaluate(plan).each_in_plan(plan, &block)
+            end
+
+            # Filters tasks which have no parents in the query itself.
+            #
+            # Will filter out tasks which have parents in +relation+ that are
+            # included in the query result.
+            #
+            # @return [#each_in_plan]
+            def roots(plan, in_relation)
+                evaluate(plan).roots(in_relation)
+                self
+            end
+
+            # Computes the union of two predicates
+            #
+            # The returned task matcher will yield tasks that are matched by any
+            # of its the elements.
+            #
+            # Roby does only supports computing the OR of task matchers (cannot
+            # combine different operators)
+            def |(other)
+                result = OrMatcher::Tasks.new
+                result << self
+                case other
+                when OrMatcher::Tasks
+                    result.merge(other)
+                when TaskMatcher
+                    result << other
+                else
+                    raise ArgumentError,
+                          "cannot compute the union of a TaskMatcher with #{other}"
+                end
+            end
+
+            # Computes the intersection of two predicates
+            #
+            # The returned task matcher will yield tasks that are matched by all
+            # the elements.
+            #
+            # Roby does only supports computing the AND of task matchers (cannot
+            # combine different operators)
+            def &(other)
+                result = AndMatcher::Tasks.new
+                result << self
+                case other
+                when AndMatcher::Tasks
+                    result.merge(other)
+                when TaskMatcher
+                    result << other
+                else
+                    raise ArgumentError,
+                          "cannot compute the intersection of a TaskMatcher with #{other}"
+                end
+            end
+
+            # Negates this predicate
+            #
+            # The returned task matcher will yield tasks that are *not* matched by
+            # +self+
+            def negate
+                NotMatcher::Tasks.new(self)
+            end
         end
     end
 end

--- a/lib/roby/queries/transaction_query_result.rb
+++ b/lib/roby/queries/transaction_query_result.rb
@@ -1,0 +1,198 @@
+# frozen_string_literal: true
+
+module Roby
+    module Queries
+        class TransactionQueryResult
+            def initialize(stack = [])
+                @stack = stack
+            end
+
+            def local_query_results
+                @stack
+            end
+
+            def push(query_result)
+                @stack.push(query_result)
+            end
+
+            def each_in_plan(plan, &block)
+                if plan != @stack.last.plan
+                    raise ArgumentError,
+                          'attempting to enumerate results of a query ran '\
+                          "in #{@stack.first.plan} from #{plan}"
+                end
+
+                stack = @stack.dup
+                stack.pop.each(&block)
+                plan_stack = [plan]
+
+                until stack.empty?
+                    local_results = stack.pop
+                    local_results.each do |local_obj|
+                        wrapped_obj = plan_stack.inject(local_obj) do |obj, p|
+                            p.wrap(obj)
+                        end
+                        yield(wrapped_obj)
+                    end
+                end
+            end
+
+            def roots(in_relation)
+                self.class.roots_of(self, in_relation)
+            end
+
+            def self.from_transaction(transaction, matcher) # :nodoc:
+                if matcher.scope == :global
+                    up_results =
+                        transaction
+                        .plan.query_result_set(matcher)
+                        .local_query_results
+                    # remove tasks from the LAST plan that are proxied in self
+                    # This is done recursively (i.e. already done for all the
+                    # other levels)
+                    plan_results = up_results.pop
+
+                    final_result_set = Set.new
+                    final_result_set.compare_by_identity
+                    plan_results.each do |task|
+                        unless transaction.has_proxy_for_task?(task)
+                            final_result_set << task
+                        end
+                    end
+                    plan_results.result_set = final_result_set
+                    up_results.push plan_results
+                else
+                    up_results = []
+                end
+
+                new(up_results +
+                    PlanQueryResult.from_plan(transaction, matcher).local_query_results)
+            end
+
+            class ReachabilityVisitor < RGL::DFSVisitor
+                def initialize(graph, up_plan, up_seeds, this_set, down_plan, down_seeds)
+                    super(graph)
+                    @up_plan = up_plan
+                    @up_seeds = up_seeds
+                    @this_set = this_set
+                    @down_plan = down_plan
+                    @down_seeds = down_seeds
+                end
+
+                def handle_start_vertex(v)
+                    @start_vertex = v
+                end
+
+                def follow_edge?(u, v)
+                    !@down_plan || !(
+                        @down_plan.find_local_object_for_task(u) &&
+                        @down_plan.find_local_object_for_task(v)
+                    )
+                end
+
+                def handle_examine_vertex(v)
+                    if (@start_vertex != v) && @this_set.include?(v)
+                        throw :reachable, true
+                    elsif (proxy = @down_plan&.find_local_object_for_task(v))
+                        @down_seeds << proxy
+                    elsif v.transaction_proxy?
+                        @up_seeds << v.__getobj__
+                    end
+                end
+            end
+
+            # @api private
+            #
+            # Tests whether a set of tasks can be reached from a set of seeds 'as if'
+            # the transaction stack was applied
+            #
+            # Within 'stack', level N-1 is 'up', that is the plan of the
+            # transaction at level N, and level N+1 is 'down', that is a transaction
+            # built on top of level N.
+            #
+            # @param [Array<QueryRootsStackLevel>] stack
+            def self.reachable_on_applied_transactions?(stack)
+                visitors =
+                    [QueryRootsStackLevel.null, *stack, QueryRootsStackLevel.null]
+                    .each_cons(3).map do |up, this, down|
+                        visitor = ReachabilityVisitor.new(
+                            this.graph,
+                            up.plan, up.seeds,
+                            this.result_set,
+                            down.plan, down.seeds
+                        )
+                        if (start = this.seeds.first)
+                            visitor.handle_start_vertex(start)
+                        end
+                        [this, visitor]
+                    end
+
+                catch(:reachable) do
+                    loop do
+                        all_empty = true
+                        visitors.each do |stack_level, visitor|
+                            seeds = stack_level.seeds
+                            until seeds.empty?
+                                all_empty = false
+                                seed = seeds.shift
+                                unless visitor.finished_vertex?(seed)
+                                    stack_level.graph.depth_first_visit(
+                                        seed, visitor
+                                    ) {}
+                                end
+                            end
+                        end
+                        break if all_empty
+                    end
+                    return false
+                end
+                true
+            end
+
+            QueryRootsStackLevel = Struct.new :local_results, :graph, :seeds do
+                def plan
+                    local_results.plan
+                end
+
+                def result_set
+                    local_results.result_set
+                end
+
+                def self.null
+                    QueryRootsStackLevel.new(
+                        PlanQueryResult.new(nil, [], []), nil, []
+                    )
+                end
+            end
+
+            # @api private
+            #
+            # Given the result set of +query+, returns the subset of tasks which
+            # have no parent in +query+
+            #
+            # This is never called directly, but is used by the Query API
+            def self.roots_of(from, in_relation) # :nodoc:
+                stack = from.local_query_results.map do |local_results|
+                    local_plan = local_results.plan
+                    local_graph = local_plan.task_relation_graph_for(in_relation)
+                                            .reverse
+                    QueryRootsStackLevel.new(local_results, local_graph, [])
+                end
+
+                roots_results = stack.map do |stack_level|
+                    set = stack_level.local_results.result_set
+                    roots = set.find_all do |task|
+                        stack_level.seeds[0] = task
+                        !reachable_on_applied_transactions?(stack)
+                    end
+
+                    new_results = stack_level.local_results.dup
+                    new_results.result_set = roots
+                    new_results
+                end
+
+                new(roots_results)
+            end
+        end
+    end
+end

--- a/test/queries/test_and_matcher.rb
+++ b/test/queries/test_and_matcher.rb
@@ -1,21 +1,39 @@
+# frozen_string_literal: true
+
 require 'roby/test/self'
 require 'roby/tasks/simple'
 
-class TC_Queries_AndMatcher < Minitest::Test
-    TaskMatcher = Queries::TaskMatcher
+module Roby
+    module Queries
+        describe AndMatcher do
+            it 'combines task matchers' do
+                t1 = Tasks::Simple.new_submodel { argument :id }.new(id: 1)
+                t2 = Tasks::Simple.new_submodel { argument :id }.new(id: 2)
+                t3 = Roby::Task.new
+                plan.add [t1, t2, t3]
 
-    def test_it_should_allow_to_combine_matchers
-        t1 = Tasks::Simple.new_submodel { argument :id }.new(id: 1)
-        t2 = Tasks::Simple.new_submodel { argument :id }.new(id: 2)
-        t3 = Roby::Task.new
-        plan.add [t1, t2, t3]
+                query = (TaskMatcher.fully_instanciated & TaskMatcher.executable)
+                assert_equal [t1, t2].to_set, query.each_in_plan(plan).to_set
 
-        query = (TaskMatcher.fully_instanciated & TaskMatcher.executable)
-        assert_equal [t1, t2].to_set, query.each(plan).to_set
-        query = (TaskMatcher.fully_instanciated & TaskMatcher.executable.with_arguments(id: 1))
-        assert_equal [t1].to_set, query.each(plan).to_set
-        query = (TaskMatcher.fully_instanciated & TaskMatcher.abstract)
-        assert_equal [t3].to_set, query.each(plan).to_set
+                query = (TaskMatcher.fully_instanciated &
+                        TaskMatcher.executable.with_arguments(id: 1))
+                assert_equal [t1].to_set, query.each_in_plan(plan).to_set
+
+                query = (TaskMatcher.fully_instanciated & TaskMatcher.abstract)
+                assert_equal [t3].to_set, query.each_in_plan(plan).to_set
+            end
+
+            it 'combines an AND of task matchers with a task matcher' do
+                t1 = Tasks::Simple.new_submodel { argument :id }.new(id: 1)
+                t2 = Tasks::Simple.new_submodel { argument :id }.new(id: 2)
+                t3 = Roby::Task.new
+                plan.add [t1, t2, t3]
+
+                query = (TaskMatcher.fully_instanciated &
+                         TaskMatcher.executable &
+                         TaskMatcher.with_arguments(id: 1))
+                assert_equal [t1], query.each_in_plan(plan).to_a
+            end
+        end
     end
 end
-

--- a/test/queries/test_not_matcher.rb
+++ b/test/queries/test_not_matcher.rb
@@ -1,17 +1,21 @@
+# frozen_string_literal: true
+
 require 'roby/test/self'
 require 'roby/tasks/simple'
 
-class TC_Queries_NotMatcher < Minitest::Test
-    TaskMatcher = Queries::TaskMatcher
+module Roby
+    module Queries
+        describe NotMatcher do
+            it 'negates a task matcher' do
+                t1 = Tasks::Simple.new_submodel { argument :id }.new(id: 1)
+                t2 = Tasks::Simple.new_submodel { argument :id }.new(id: 2)
+                t3 = Roby::Task.new
+                plan.add [t1, t2, t3]
 
-    def test_it_should_allow_to_combine_matchers
-        t1 = Tasks::Simple.new_submodel { argument :id }.new(id: 1)
-        t2 = Tasks::Simple.new_submodel { argument :id }.new(id: 2)
-        t3 = Roby::Task.new
-        plan.add [t1, t2, t3]
-
-        query = (TaskMatcher.with_arguments(id: 1) | TaskMatcher.with_arguments(id: 2)).negate
-        assert_equal [t3].to_set, query.each(plan).to_set
+                query = TaskMatcher.with_arguments(id: 1).negate
+                assert_kind_of NotMatcher::Tasks, query
+                assert_equal [t2, t3].to_set, query.each_in_plan(plan).to_set
+            end
+        end
     end
 end
-

--- a/test/queries/test_or_matcher.rb
+++ b/test/queries/test_or_matcher.rb
@@ -1,18 +1,34 @@
+# frozen_string_literal: true
+
 require 'roby/test/self'
 require 'roby/tasks/simple'
 
-class TC_Queries_OrMatcher < Minitest::Test
-    TaskMatcher = Queries::TaskMatcher
+module Roby
+    module Queries
+        describe OrMatcher do
+            it 'combines task matchers' do
+                t1 = Tasks::Simple.new_submodel { argument :id }.new(id: 1)
+                t2 = Tasks::Simple.new_submodel { argument :id }.new(id: 2)
+                t3 = Roby::Task.new
+                plan.add [t1, t2, t3]
 
-    def test_it_should_allow_to_combine_matchers
-        t1 = Tasks::Simple.new_submodel { argument :id }.new(id: 1)
-        t2 = Tasks::Simple.new_submodel { argument :id }.new(id: 2)
-        t3 = Roby::Task.new
-        plan.add [t1, t2, t3]
+                query = (TaskMatcher.with_arguments(id: 1) |
+                         TaskMatcher.with_arguments(id: 2))
+                assert_equal [t1, t2].to_set, query.each_in_plan(plan).to_set
+            end
 
-        query = (TaskMatcher.with_arguments(id: 1) | TaskMatcher.with_arguments(id: 2))
-        assert_equal [t1, t2].to_set, query.each(plan).to_set
+            it 'combines an OR with a task matcher' do
+                t1 = Tasks::Simple.new_submodel { argument :id }.new(id: 1)
+                t2 = Tasks::Simple.new_submodel { argument :id }.new(id: 2)
+                t2.executable = false
+                t3 = Roby::Task.new
+                plan.add [t1, t2, t3]
+
+                query = (TaskMatcher.with_arguments(id: 1) |
+                         TaskMatcher.with_arguments(id: 2) |
+                         Roby::Task.match)
+                assert_equal [t1, t2, t3].to_set, query.each_in_plan(plan).to_set
+            end
+        end
     end
 end
-
-

--- a/test/queries/test_task_event_generator_matcher.rb
+++ b/test/queries/test_task_event_generator_matcher.rb
@@ -24,6 +24,17 @@ module Roby
                         Roby::Queries::TaskEventGeneratorMatcher.new(task_matcher, *args)
                     end
 
+                    it 'filters the task event generator using the plan object match' do
+                        matcher = Roby::Tasks::Simple.match.start_event.executable
+                        plan.add(t = Roby::Tasks::Simple.new)
+                        flexmock(t.start_event).should_receive(executable?: true)
+                        assert matcher === t.start_event
+
+                        plan.add(a = Roby::Tasks::Simple.new)
+                        flexmock(a.start_event).should_receive(executable?: false)
+                        refute matcher === a.start_event
+                    end
+
                     it 'returns false for a plain event generator' do
                         plan.add(generator = Roby::EventGenerator.new)
                         refute create_matcher === generator
@@ -66,7 +77,7 @@ module Roby
                         refute create_matcher('bla') === source_generator
                     end
                     it 'returns false if it is forwarded to another task for which '\
-                       'the task matcher returns true and the symbol matches' do
+                       'the task matcher returns true even if the symbol matches' do
                         task_matcher.should_receive(:===).with(task).and_return(true)
                         @symbol_match = flexmock
                         symbol_match.should_receive(:===).with('failed').and_return(false)
@@ -139,6 +150,42 @@ module Roby
                         symbol_match.should_receive(:===).with('stop').and_return(true)
                         assert create_matcher(symbol_match) === source_generator
                     end
+                end
+            end
+
+            describe 'plan enumeration' do
+                it 'raises if trying to enumerate the plan using a generalized matcher' do
+                    matcher = Roby::Tasks::Simple.match.stop_event.generalized
+                    assert_raises(ArgumentError) do
+                        matcher.each_in_plan(plan)
+                    end
+                end
+
+                it 'enumerates the event from the matching tasks' do
+                    plan.add(t1 = Roby::Tasks::Simple.new(id: 20))
+                    plan.add(t2 = Roby::Tasks::Simple.new(id: 21))
+
+                    results = Roby::Tasks::Simple
+                              .match.stop_event.each_in_plan(plan).to_set
+                    assert_equal [t1.stop_event, t2.stop_event].to_set,
+                                 results.to_set
+
+                    results = Roby::Tasks::Simple
+                              .match.with_arguments(id: 20).stop_event
+                              .each_in_plan(plan).to_a
+                    assert_equal [t1.stop_event], results
+                end
+
+                it 'post-filters the events using #===' do
+                    plan.add(t1 = Roby::Tasks::Simple.new(id: 20))
+                    plan.add(t2 = Roby::Tasks::Simple.new(id: 21))
+
+                    matcher = Roby::Tasks::Simple.match.stop_event
+                    flexmock(matcher)
+                    matcher.should_receive(:===).with(t1.stop_event).and_return(true)
+                    matcher.should_receive(:===).with(t2.stop_event).and_return(false)
+                    results = matcher.each_in_plan(plan).to_a
+                    assert_equal [t1.stop_event], results
                 end
             end
         end

--- a/test/queries/test_task_matcher.rb
+++ b/test/queries/test_task_matcher.rb
@@ -6,6 +6,197 @@ require 'roby/tasks/simple'
 module Roby
     module Queries
         describe TaskMatcher do
+            describe 'plan enumeration of basic predicates' do
+                after do
+                    plan.each_task do |t|
+                        execute { t.start_event.emit } if t.starting?
+                        execute { t.stop_event.emit } if t.finishing?
+                    end
+                end
+
+                it 'matches on #executable?' do
+                    plan.add(yes = Tasks::Simple.new)
+                    plan.add(no = Tasks::Simple.new)
+                    no.executable = false
+
+                    assert_finds_tasks [yes], TaskMatcher.executable
+                    assert_finds_tasks [no], TaskMatcher.not_executable
+                end
+
+                it 'matches on #abstract?' do
+                    plan.add(yes = Tasks::Simple.new)
+                    plan.add(no = Tasks::Simple.new)
+                    yes.abstract = true
+
+                    assert_finds_tasks [yes], TaskMatcher.abstract
+                    assert_finds_tasks [no], TaskMatcher.not_abstract
+                end
+
+                it 'matches on #fully_instanciated?' do
+                    task_m = Roby::Task.new_submodel { argument :arg }
+                    plan.add(yes = task_m.new(arg: 10))
+                    plan.add(no = task_m.new)
+                    assert_finds_tasks [yes], TaskMatcher.fully_instanciated
+                    assert_finds_tasks [no], TaskMatcher.not_fully_instanciated
+                end
+
+                it 'matches on #partially_instanciated?' do
+                    task_m = Roby::Task.new_submodel { argument :arg }
+                    plan.add(no = task_m.new(arg: 10))
+                    plan.add(yes = task_m.new)
+                    assert_finds_tasks [yes], TaskMatcher.partially_instanciated
+                    assert_finds_tasks [no], TaskMatcher.not_partially_instanciated
+                end
+
+                it 'deals with dynamic argument assignation' do
+                    task_m = Roby::Task.new_submodel { argument :arg }
+                    plan.add(t1 = task_m.new)
+                    plan.add(t2 = task_m.new(arg: 10))
+                    assert_finds_tasks [t1], TaskMatcher.partially_instanciated
+                    assert_finds_tasks [t1], TaskMatcher.not_fully_instanciated
+                    assert_finds_tasks [t2], TaskMatcher.fully_instanciated
+                    assert_finds_tasks [t2], TaskMatcher.not_partially_instanciated
+                    t1.arg = 10
+                    assert_finds_tasks [], TaskMatcher.partially_instanciated
+                    assert_finds_tasks [], TaskMatcher.not_fully_instanciated
+                    assert_finds_tasks [t1, t2], TaskMatcher.fully_instanciated
+                    assert_finds_tasks [t1, t2], TaskMatcher.not_partially_instanciated
+                end
+
+                it 'matches pending tasks' do
+                    plan.add(t = Roby::Tasks::Simple.new)
+                    assert_finds_tasks [t], TaskMatcher.pending
+                    assert_finds_tasks [], TaskMatcher.not_pending
+                    execute { t.start! }
+                    assert_finds_tasks [], TaskMatcher.pending
+                    assert_finds_tasks [t], TaskMatcher.not_pending
+                end
+
+                it 'matches starting tasks' do
+                    task_m = Roby::Tasks::Simple.new_submodel do
+                        event(:start) { |_| }
+                    end
+                    plan.add(t = task_m.new)
+                    assert_finds_tasks [t], TaskMatcher.not_starting
+                    assert_finds_tasks [], TaskMatcher.starting
+                    execute { t.start! }
+                    assert_finds_tasks [], TaskMatcher.not_starting
+                    assert_finds_tasks [t], TaskMatcher.starting
+                    execute { t.start_event.emit }
+                    assert_finds_tasks [t], TaskMatcher.not_starting
+                    assert_finds_tasks [], TaskMatcher.starting
+                end
+
+                it 'matches running tasks' do
+                    plan.add(t = Roby::Tasks::Simple.new)
+                    assert_finds_tasks [], TaskMatcher.running
+                    assert_finds_tasks [t], TaskMatcher.not_running
+                    execute { t.start! }
+                    assert_finds_tasks [t], TaskMatcher.running
+                    assert_finds_tasks [], TaskMatcher.not_running
+                    execute { t.stop_event.emit }
+                    assert_finds_tasks [], TaskMatcher.running
+                    assert_finds_tasks [t], TaskMatcher.not_running
+                end
+
+                it 'matches finishing tasks' do
+                    task_m = Roby::Tasks::Simple.new_submodel do
+                        event(:stop) { |_| }
+                    end
+                    plan.add(t = task_m.new)
+                    execute { t.start! }
+                    assert_finds_tasks [t], TaskMatcher.not_finishing
+                    assert_finds_tasks [], TaskMatcher.finishing
+                    execute { t.stop! }
+                    assert_finds_tasks [], TaskMatcher.not_finishing
+                    assert_finds_tasks [t], TaskMatcher.finishing
+                    execute { t.stop_event.emit }
+                    assert_finds_tasks [t], TaskMatcher.not_finishing
+                    assert_finds_tasks [], TaskMatcher.finishing
+                end
+
+                it 'matches successful tasks' do
+                    plan.add(t = Roby::Tasks::Simple.new)
+                    assert_finds_tasks [t], TaskMatcher.not_success
+                    assert_finds_tasks [], TaskMatcher.success
+                    execute { t.start! }
+                    assert_finds_tasks [t], TaskMatcher.not_success
+                    assert_finds_tasks [], TaskMatcher.success
+                    execute { t.success_event.emit }
+                    assert_finds_tasks [], TaskMatcher.not_success
+                    assert_finds_tasks [t], TaskMatcher.success
+                    assert_finds_tasks [t], TaskMatcher.finished
+                    assert_finds_tasks [t], TaskMatcher.not_failed
+                end
+
+                it 'matches failed tasks' do
+                    plan.add(t = Roby::Tasks::Simple.new)
+                    assert_finds_tasks [t], TaskMatcher.not_failed
+                    assert_finds_tasks [], TaskMatcher.failed
+                    execute { t.start! }
+                    assert_finds_tasks [t], TaskMatcher.not_failed
+                    assert_finds_tasks [], TaskMatcher.failed
+                    execute { t.failed_event.emit }
+                    assert_finds_tasks [], TaskMatcher.not_failed
+                    assert_finds_tasks [t], TaskMatcher.failed
+                    assert_finds_tasks [t], TaskMatcher.finished
+                    assert_finds_tasks [t], TaskMatcher.not_success
+                end
+
+                it 'matches finished tasks' do
+                    plan.add(t = Roby::Tasks::Simple.new)
+                    assert_finds_tasks [t], TaskMatcher.not_finished
+                    assert_finds_tasks [], TaskMatcher.finished
+                    execute { t.start! }
+                    assert_finds_tasks [t], TaskMatcher.not_finished
+                    assert_finds_tasks [], TaskMatcher.finished
+                    execute { t.stop_event.emit }
+                    assert_finds_tasks [], TaskMatcher.not_finished
+                    assert_finds_tasks [t], TaskMatcher.finished
+                    assert_finds_tasks [t], TaskMatcher.not_failed
+                    assert_finds_tasks [t], TaskMatcher.not_success
+                end
+
+                it 'matches reusable tasks set explicitly' do
+                    plan.add(t = Roby::Tasks::Simple.new)
+                    assert_finds_tasks [t], TaskMatcher.reusable
+                    assert_finds_tasks [], TaskMatcher.not_reusable
+                    t.do_not_reuse
+                    assert_finds_tasks [], TaskMatcher.reusable
+                    assert_finds_tasks [t], TaskMatcher.not_reusable
+                end
+
+                it 'matches tasks that are not reusable because they are finished' do
+                    plan.add(t = Roby::Tasks::Simple.new)
+                    assert_finds_tasks [t], TaskMatcher.reusable
+                    assert_finds_tasks [], TaskMatcher.not_reusable
+                    execute do
+                        t.start!
+                        t.stop!
+                    end
+                    assert_finds_tasks [], TaskMatcher.reusable
+                    assert_finds_tasks [t], TaskMatcher.not_reusable
+                end
+
+                it 'matches missions' do
+                    plan.add(t = Roby::Tasks::Simple.new)
+                    assert_finds_tasks [], TaskMatcher.mission
+                    plan.add_mission_task(t)
+                    assert_finds_tasks [t], TaskMatcher.mission
+                    plan.unmark_mission_task(t)
+                    assert_finds_tasks [], TaskMatcher.mission
+                end
+
+                it 'matches permanent tasks' do
+                    plan.add(t = Roby::Tasks::Simple.new)
+                    assert_finds_tasks [], TaskMatcher.permanent
+                    plan.add_permanent_task(t)
+                    assert_finds_tasks [t], TaskMatcher.permanent
+                    plan.unmark_permanent_task(t)
+                    assert_finds_tasks [], TaskMatcher.permanent
+                end
+            end
+
             describe 'the _event accessor' do
                 attr_reader :task_m
                 before do
@@ -15,13 +206,13 @@ module Roby
                 end
 
                 it 'returns the task event generator matcher for the given event' do
-                    matcher = plan.find_tasks(task_m).extra_event
+                    matcher = task_m.match.extra_event
                     assert_equal [task_m], matcher.task_matcher.model
                     assert_equal 'extra', matcher.symbol
                 end
                 it 'raises ArgumentError if arguments have been given' do
                     e = assert_raises(ArgumentError) do
-                        plan.find_tasks(task_m).extra_event(10)
+                        task_m.match.extra_event(10)
                     end
                     assert_equal 'extra_event expected zero arguments, got 1',
                                  e.message
@@ -29,17 +220,30 @@ module Roby
                 it 'raises NoMethodError if the event does not exist '\
                    'in the selected models' do
                     e = assert_raises(NoMethodError) do
-                        plan.find_tasks(task_m).does_not_exist_event
+                        task_m.match.does_not_exist_event
                     end
                     assert_equal "no event 'does_not_exist' in match model #{task_m}, "\
                                  'use #which_fullfills to narrow the task model',
                                  e.message
                 end
                 it 'matches against Roby::Task if no models have been selected at all' do
-                    matcher = plan.find_tasks.start_event
+                    matcher = TaskMatcher.new.start_event
                     assert_equal [], matcher.task_matcher.model
                     assert_equal 'start', matcher.symbol
                 end
+            end
+
+            def assert_match(m, obj)
+                assert m === obj
+            end
+
+            def refute_match(m, obj)
+                refute m === obj
+            end
+
+            def assert_finds_tasks(task_set, matcher)
+                found_tasks = matcher.each_in_plan(plan).to_set
+                assert_equal task_set.to_set, found_tasks
             end
         end
     end
@@ -48,21 +252,27 @@ end
 class TestQueriesTaskMatcher < Minitest::Test
     TaskMatcher = Queries::TaskMatcher
 
+    def setup
+        super
+        @plan_stack = [plan]
+    end
+
     def check_matches_fullfill(task_model, plan, t0, t1, t2)
-        result = TaskMatcher.new.each(plan).to_set
+        result = TaskMatcher.new.each_in_plan(plan).to_set
         assert_equal([t1, t2, t0].to_set, result)
-        result = TaskMatcher.new.with_model(Roby::Task).each(plan).to_set
+        result = TaskMatcher.new.with_model(Roby::Task).each_in_plan(plan).to_set
         assert_equal([t1, t2, t0].to_set, result, plan.task_index.by_model)
 
-        result = TaskMatcher.which_fullfills(task_model).each(plan).to_set
+        result = TaskMatcher.which_fullfills(task_model).each_in_plan(plan).to_set
         assert_equal([t1, t2].to_set, result)
 
-        result = TaskMatcher.with_model(task_model).each(plan).to_set
+        result = TaskMatcher.with_model(task_model).each_in_plan(plan).to_set
         assert_equal([t1, t2].to_set, result)
-        result = TaskMatcher.with_arguments(value: 1).each(plan).to_set
+        result = TaskMatcher.with_arguments(value: 1).each_in_plan(plan).to_set
         assert_equal([t0, t1].to_set, result)
 
-        result = TaskMatcher.which_fullfills(task_model, value: 1).each(plan).to_set
+        result = TaskMatcher.which_fullfills(task_model, value: 1)
+                            .each_in_plan(plan).to_set
         assert_equal([t1].to_set, result)
     end
 
@@ -112,55 +322,162 @@ class TestQueriesTaskMatcher < Minitest::Test
         plan.add_mission_task(t1)
         plan.add_mission_task(t2)
 
-        plan.in_transaction do |trsc|
+        in_transaction do |trsc|
             check_matches_fullfill(task_model, trsc, trsc[t0], trsc[t1], trsc[t2])
         end
-    end
-
-    def test_query_predicates
-        t1 = Tasks::Simple.new_submodel { argument :fake }.new
-        t2 = Roby::Task.new
-        plan.add [t1, t2]
-
-        assert_finds_tasks [], TaskMatcher.executable
-        assert_finds_tasks [t1, t2], TaskMatcher.not_executable
-        assert_finds_tasks [t2], TaskMatcher.abstract
-        assert_finds_tasks [t1], TaskMatcher.partially_instanciated
-        assert_finds_tasks [t2], TaskMatcher.fully_instanciated
-        t1.arguments[:fake] = 2
-        assert_finds_tasks [t1, t2], TaskMatcher.fully_instanciated
-        assert_finds_tasks [t2], TaskMatcher.fully_instanciated.abstract
-
-        assert_finds_tasks [t1, t2], TaskMatcher.pending
-        execute { t1.start! }
-        assert_finds_tasks [t2], TaskMatcher.pending
-        assert_finds_tasks [t1, t2], TaskMatcher.not_failed
-        assert_finds_tasks [t1, t2], TaskMatcher.not_success
-        assert_finds_tasks [t1, t2], TaskMatcher.not_finished
-
-        assert_finds_tasks [t1], TaskMatcher.running
-        execute { t1.success! }
-        assert_finds_tasks [t1], TaskMatcher.success
-        assert_finds_tasks [t1], TaskMatcher.finished
-        assert_finds_tasks [t1, t2], TaskMatcher.not_failed
-        assert_finds_tasks [t2], TaskMatcher.not_finished
-
-        execute { plan.remove_task(t1) }
-
-        t1 = Tasks::Simple.new
-        plan.add(t1)
-        execute do
-            t1.start!
-            t1.failed!
-        end
-        assert_finds_tasks [t1], TaskMatcher.failed
-        assert_finds_tasks [t1], TaskMatcher.finished
-        assert_finds_tasks [t1], TaskMatcher.finished.not_success
     end
 
     def test_it_does_not_allow_specifying_different_constraints_on_the_same_argument
         matcher = Tasks::Simple.match.with_arguments(id: 1)
         assert_raises(ArgumentError) { matcher.with_arguments(id: 2) }
+    end
+
+    def test_child_match
+        plan.add(t1 = Tasks::Simple.new(id: 1))
+        t2 = Tasks::Simple.new_submodel.new(id: '2')
+        tag = TaskService.new_submodel do
+            argument :tag_id
+        end
+        t3_model = Tasks::Simple.new_submodel
+        t3_model.include tag
+        t3 = t3_model.new(id: 3, tag_id: 3)
+        t1.depends_on t2
+        t2.depends_on t3
+        t1.depends_on t3
+
+        # t1    Tasks::Simple                   id: 1
+        # t2    t2_model < Tasks::Simple        id: '2'
+        # t3    t3_model < tag < Tasks::Simple  id: 3
+        # t1 -> t2 -> t3
+        # t1 -> t3
+
+        assert_equal 3, t1.model.match.each_in_plan(plan).to_a.size
+
+        child_match = TaskMatcher.which_fullfills(Tasks::Simple, id: 1)
+        assert_finds_nothing t1.model.match.with_child(child_match)
+
+        assert_finds_tasks [t1, t2], Tasks::Simple.match.with_child(Tasks::Simple)
+        assert_finds_tasks [t1], Tasks::Simple.match.with_child(Tasks::Simple, id: '2')
+        assert_finds_tasks [t1], Tasks::Simple.match.with_child(t2.model)
+                                              .with_child(t3.model)
+        assert_finds_tasks [t1, t2], Tasks::Simple.match.with_child(t3.model)
+        assert_finds_tasks [t1, t2], Tasks::Simple.match.with_child(tag, id: 3)
+        # :id is not an argument of +tag+, so the following should match, but
+        # the next one not.
+        assert_finds_tasks [t1, t2],
+                           Tasks::Simple.match.with_child(tag, id: 2)
+        assert_finds_nothing Tasks::Simple.match.with_child(tag, tag_id: 2)
+        assert_finds_nothing t1.model.match
+                               .with_child(Tasks::Simple, TaskStructure::PlannedBy)
+
+        t1.planned_by t2
+        assert_finds_tasks [t1], t1.model.match
+                                   .with_child(Tasks::Simple, TaskStructure::PlannedBy)
+        assert_finds_tasks [t1], t1.model.match
+                                   .with_child(Tasks::Simple,
+                                               relation: TaskStructure::PlannedBy)
+        assert_finds_nothing t1.model.match
+                               .with_child(Tasks::Simple,
+                                           id: 42, relation: TaskStructure::PlannedBy)
+        assert_finds_nothing t1.model.match
+                               .with_child(Tasks::Simple, TaskStructure::PlannedBy,
+                                           an_argument: :which_is_set)
+        t1.remove_child_object(t2, TaskStructure::PlannedBy)
+
+        child_match = TaskMatcher.which_fullfills(Tasks::Simple, id: t2.arguments[:id])
+        assert_finds_tasks [t1], t1.model.match.with_child(child_match)
+        assert_finds_nothing t1.model.match
+                               .with_child(Tasks::Simple, TaskStructure::PlannedBy)
+    end
+
+    def test_child_in_transactions
+        (t1, t2), t3 = prepare_plan add: 2, tasks: 1, model: Tasks::Simple
+        t1.depends_on t2
+        in_transaction do |trsc|
+            trsc[t2].depends_on t3
+
+            assert_equal 3, t1.model.match.to_a(trsc).size
+            child_match = TaskMatcher.which_fullfills(Tasks::Simple, id: 1)
+            assert_finds_nothing t1.model.match.with_child(child_match)
+
+            child_match = TaskMatcher.which_fullfills(Tasks::Simple)
+            assert_finds_tasks [trsc[t1], trsc[t2]],
+                               t1.model.match.with_child(child_match)
+
+            child_match = TaskMatcher.which_fullfills(
+                Tasks::Simple, id: t2.arguments[:id]
+            )
+            assert_finds_tasks [trsc[t1]], t1.model.match.with_child(child_match)
+        end
+    end
+
+    def test_parent_match
+        plan.add(t1 = Tasks::Simple.new(id: 1))
+        t2 = Tasks::Simple.new_submodel.new(id: 2)
+        t3 = Tasks::Simple.new_submodel.new(id: 3)
+        t3.depends_on t2
+        t3.depends_on t1
+        t2.depends_on t1
+
+        assert_equal 3, Tasks::Simple.match.to_a(plan).size
+
+        parent_match = TaskMatcher.which_fullfills(Tasks::Simple, id: 1)
+        assert_finds_nothing Tasks::Simple.match.with_parent(parent_match)
+
+        assert_finds_tasks [t1, t2], Tasks::Simple.match.with_parent(Tasks::Simple)
+        assert_finds_tasks [t1], Tasks::Simple.match
+                                              .with_parent(t3.model)
+                                              .with_parent(t2.model)
+        assert_finds_nothing Tasks::Simple.match.with_parent(Tasks::Simple,
+                                                             TaskStructure::PlannedBy)
+
+        t2.planned_by t1
+        assert_finds_tasks [t1], t1.model.match.with_parent(Tasks::Simple,
+                                                            TaskStructure::PlannedBy)
+        assert_finds_tasks [t1], t1.model.match
+                                   .with_parent(Tasks::Simple,
+                                                relation: TaskStructure::PlannedBy)
+        assert_finds_nothing(
+            t1.model.match
+              .with_parent(Tasks::Simple, id: 42, relation: TaskStructure::PlannedBy)
+        )
+
+        assert_finds_nothing(
+            t1.model.match.with_parent(Tasks::Simple, TaskStructure::PlannedBy,
+                                       an_argument: :which_is_set)
+        )
+
+        t2.remove_child_object(t1, TaskStructure::PlannedBy)
+
+        assert_finds_tasks [t1], Tasks::Simple.match.with_parent(Tasks::Simple,
+                                                                 id: t2.arguments[:id])
+        assert_finds_nothing(
+            Tasks::Simple.match.with_parent(Tasks::Simple,
+                                            id: t2.arguments[:id],
+                                            relation: TaskStructure::PlannedBy)
+        )
+    end
+
+    def test_parent_in_transaction
+        (t1, t2), t3 = prepare_plan add: 2, tasks: 1, model: Tasks::Simple
+        t1.depends_on t2
+        in_transaction do |trsc|
+            trsc[t2].depends_on t3
+
+            assert_equal 3, Tasks::Simple.match.to_a(trsc).size
+
+            parent_match = TaskMatcher.which_fullfills(Tasks::Simple, id: 1)
+            assert_finds_nothing Tasks::Simple.match.with_parent(parent_match)
+
+            parent_match = TaskMatcher.which_fullfills(Tasks::Simple)
+            assert_finds_tasks [trsc[t2], t3], Tasks::Simple.match
+                                                            .with_parent(parent_match)
+
+            parent_match = TaskMatcher.which_fullfills(
+                Tasks::Simple, id: t2.arguments[:id]
+            )
+            assert_finds_tasks [t3], Tasks::Simple.match.with_parent(parent_match)
+        end
     end
 
     def assert_match(m, obj)
@@ -171,8 +488,222 @@ class TestQueriesTaskMatcher < Minitest::Test
         refute m === obj
     end
 
+    def in_transaction
+        downmost_plan.in_transaction do |trsc|
+            begin
+                @plan_stack.push(trsc)
+                yield(trsc)
+            ensure
+                @plan_stack.pop
+            end
+        end
+    end
+
+    def downmost_plan
+        @plan_stack.last
+    end
+
     def assert_finds_tasks(task_set, matcher)
-        found_tasks = matcher.each(plan).to_set
+        found_tasks = matcher.each_in_plan(downmost_plan).to_set
         assert_equal task_set.to_set, found_tasks
+    end
+
+    def assert_finds_nothing(matcher)
+        assert_finds_tasks([], matcher)
+    end
+end
+
+module Roby
+    module Queries
+        describe Query do
+            describe '#===' do
+                before do
+                    @query = plan.find_tasks
+                    flexmock(plan)
+                    plan.add(@task = Tasks::Simple.new)
+                end
+
+                it 'does not match if one of the positive predicates returns false' do
+                    @query.add_plan_predicate :mission_task?
+                    plan.should_receive(:mission_task?).explicitly.and_return(false).once
+                    refute @query === @task
+                end
+
+                it 'matches if all the positive predicates returns true' do
+                    @query.add_plan_predicate :mission_task?
+                    plan.should_receive(:mission_task?).explicitly.and_return(true).once
+                    assert @query === @task
+                end
+
+                it 'matches if one of the negative predicates returns false' do
+                    @query.add_neg_plan_predicate :mission_task?
+                    plan.should_receive(:mission_task?).explicitly.and_return(false).once
+                    assert @query === @task
+                end
+
+                it 'does not match if one of the negative predicates returns true' do
+                    @query.add_neg_plan_predicate :mission_task?
+                    plan.should_receive(:mission_task?).explicitly.and_return(true).once
+                    refute @query === @task
+                end
+            end
+
+            describe 'in transactions with global scope' do
+                before do
+                    @task_m = Roby::Task.new_submodel do
+                        argument :id
+                    end
+                    @t1, @t2, @t3 = (1..3).map { |i| @task_m.new(id: i) }
+                    @t1.depends_on @t2
+                    plan.add(@t1)
+
+                    @trsc = Transaction.new(plan)
+                end
+
+                after do
+                    @trsc.discard_transaction unless @trsc.frozen?
+                end
+
+                it 'finds tasks in the transaction' do
+                    @trsc.add(@t3)
+                    result = @trsc.find_tasks.which_fullfills(@task_m, id: 3).to_a
+                    assert_equal [@t3], result
+                end
+
+                it 'finds proxies in the transaction' do
+                    p1 = @trsc.wrap(@t1)
+                    result = @trsc.find_tasks.which_fullfills(@task_m, id: 1).to_a
+                    assert_equal [p1], result
+                end
+
+                it 'finds tasks from the plan that are not yet in the transaction' do
+                    result = @trsc.find_tasks.which_fullfills(@task_m, id: 1).to_a
+                    assert_equal [@trsc[@t1]], result
+                end
+
+                it 'does not proxy plan tasks not matched by the query' do
+                    @trsc.find_tasks.which_fullfills(@task_m, id: 1).to_a
+                    refute @trsc.has_task?(@t2)
+                    refute @trsc.has_task?(@t3)
+                end
+
+                it 'finds tasks after they are added by a transaction' do
+                    @trsc.add(@t3)
+                    @trsc.commit_transaction
+                    result = plan.find_tasks.which_fullfills(@task_m, id: 3).to_a
+                    assert_equal([@t3], result)
+                end
+            end
+
+            describe '#roots' do
+                # !!! IMPORTANT
+                # In all tests we MUST resolve the query before we check the
+                # result since we want to test whether the query creates the
+                # proxies
+
+                before do
+                    @trsc = Transaction.new(plan)
+                end
+
+                it 'returns all single tasks of a plan' do
+                    t1, t2, t3 = prepare_plan add: 3
+                    assert_equal [t1, t2, t3].to_set,
+                                 plan.find_tasks.roots(TaskStructure::Dependency).to_set
+                end
+
+                it 'rejects tasks from a single plan that have parents' do
+                    t1, t2, t3 = prepare_plan add: 3
+                    t1.depends_on t2
+                    assert_equal [t1, t3].to_set,
+                                 plan.find_tasks.roots(TaskStructure::Dependency).to_set
+                end
+
+                it 'handles having a child in the transaction and the parent '\
+                   'in the plan for a relation in the plan' do
+                    plan.add(parent = Tasks::Simple.new)
+                    plan.add(child = Tasks::Simple.new)
+                    parent.depends_on child
+                    @trsc[child]
+
+                    query_results =
+                        @trsc.find_tasks.roots(TaskStructure::Dependency).to_a
+                    assert_equal [@trsc[parent]], query_results
+                end
+
+                it 'handles having a parent in the transaction and the child '\
+                   'in the plan' do
+                    plan.add(parent = Tasks::Simple.new)
+                    plan.add(child = Tasks::Simple.new)
+                    parent.depends_on child
+                    @trsc[parent]
+
+                    query_results =
+                        @trsc.find_tasks.roots(TaskStructure::Dependency).to_a
+                    assert_equal [@trsc[parent]], query_results
+                end
+
+                it 'handles having a plan task with a new parent in the transaction' do
+                    @trsc.add(parent = Tasks::Simple.new)
+                    plan.add(child = Tasks::Simple.new)
+                    parent.depends_on @trsc[child]
+
+                    query_results =
+                        @trsc.find_tasks.roots(TaskStructure::Dependency).to_a
+                    assert_equal [parent], query_results
+                end
+
+                it 'handles having a plan task with a new child in the transaction' do
+                    plan.add(parent = Tasks::Simple.new)
+                    @trsc.add(child = Tasks::Simple.new)
+                    @trsc[parent].depends_on child
+
+                    query_results =
+                        @trsc.find_tasks.roots(TaskStructure::Dependency).to_a
+                    assert_equal [@trsc[parent]], query_results
+                end
+
+                it 'handles having a plan relation removed by the transaction' do
+                    plan.add(parent = Tasks::Simple.new)
+                    plan.add(child = Tasks::Simple.new)
+                    parent.depends_on child
+                    @trsc[parent].remove_child @trsc[child]
+
+                    query_results =
+                        @trsc.find_tasks.roots(TaskStructure::Dependency).to_set
+                    assert_equal [@trsc[parent], @trsc[child]].to_set, query_results
+                end
+
+                it 'considers objects in all levels of the plan' do
+                    t1, t2, t3 = prepare_plan add: 3
+                    tr1, tr2, tr3 = prepare_plan tasks: 3
+                    [tr1, tr2, tr3].each { |t| @trsc.add(t) }
+
+                    t1.depends_on t2
+                    tr1.depends_on tr2
+                    @trsc[t3].depends_on tr3
+                    refute @trsc.find_local_object_for_task(t2)
+
+                    query_results =
+                        @trsc.find_tasks.roots(TaskStructure::Dependency).to_set
+                    assert_equal [@trsc[t1], @trsc[t3], tr1].to_set, query_results
+                end
+
+                it 'considers the merged graph' do
+                    t1, t2 = prepare_plan add: 2
+                    @trsc.add(tr = Roby::Tasks::Simple.new)
+
+                    t1.depends_on t2
+                    @trsc[t2].depends_on tr
+
+                    # !!! IMPORTANT
+                    # We MUST resolve the query before we check the result
+                    # since we want to test whether the query creates the
+                    # proxies
+                    query_results =
+                        @trsc.find_tasks.roots(TaskStructure::Dependency).to_set
+                    assert_equal [@trsc[t1]].to_set, query_results
+                end
+            end
+        end
     end
 end

--- a/test/test_transactions.rb
+++ b/test/test_transactions.rb
@@ -137,7 +137,7 @@ module TC_TransactionBehaviour
         end
         assert(plan.has_task?(t1))
         assert_equal([t2], t1.children.to_a)
- 
+
         t3 = Tasks::Simple.new
         transaction_commit(plan, t1, t2) do |trsc, p1, p2|
             p1.depends_on t3
@@ -487,7 +487,7 @@ module TC_TransactionBehaviour
             assert trsc.has_free_event?(p_ev)
         end
     end
-    
+
     # Tests insertion and removal of free events
     def test_commit_plan_events
         e1, e2 = (1..2).map { Roby::EventGenerator.new }
@@ -737,7 +737,7 @@ module TC_TransactionBehaviour
     def forwarding_graph; plan.event_relation_graph_for(Forwarding) end
     def dependency_graph; plan.task_relation_graph_for(Dependency) end
     def planned_by_graph; plan.task_relation_graph_for(PlannedBy) end
-    
+
     def test_commit_replace_updates_relations
         root, task, child, replacement = prepare_plan tasks: 4, model: Tasks::Simple
         root.depends_on task, model: Tasks::Simple
@@ -958,47 +958,6 @@ module TC_TransactionBehaviour
             assert(parent.depends_on?(child, recursive: false))
         end
         assert(!parent.depends_on?(child, recursive: false))
-    end
-
-    def test_query_roots_finds_a_path_in_plan
-        parent, child = prepare_plan add: 2
-        parent.depends_on child
-        transaction_commit(plan) do |trsc|
-            assert_equal [[parent].to_set, Set.new],
-                trsc.query_roots([[parent, child].to_set, Set.new], Dependency)
-        end
-    end
-
-    def test_query_roots_finds_a_path_in_transaction
-        transaction_commit(plan) do |trsc|
-            trsc.add(parent = Roby::Task.new)
-            parent.depends_on(child = Roby::Task.new)
-            assert_equal [[].to_set, [parent].to_set],
-                trsc.query_roots([[].to_set, [parent, child].to_set], Dependency)
-        end
-    end
-
-    def test_query_roots_finds_a_mixed_path_in_plan_and_transaction
-        root, parent, child, grand_child = prepare_plan add: 4
-        root.depends_on(parent)
-        child.depends_on grand_child
-        transaction_commit(plan, parent, child) do |trsc, p_parent, p_child|
-            p_parent.depends_on p_child
-            assert_equal [[root].to_set, [].to_set],
-                trsc.query_roots([[root, grand_child].to_set, [p_parent, p_child].to_set], Dependency)
-        end
-    end
-
-    def test_query_roots_does_ignore_relations_that_have_been_removed_in_transaction
-        root, parent, child, grand_child = prepare_plan add: 4
-        root.depends_on(parent)
-        parent.depends_on child
-        child.depends_on grand_child
-        transaction_commit(plan, parent, child) do |trsc, p_parent, p_child|
-            p_parent.remove_child p_child
-            assert_equal [[root].to_set, [p_child].to_set],
-                trsc.query_roots([[root, grand_child].to_set, [p_parent, p_child].to_set], Dependency)
-        end
     end
 
     def test_single_child_accessors_automatically_proxy_the_related_task
@@ -1459,7 +1418,7 @@ class TC_RecursiveTransaction < Minitest::Test
         end
     end
 end
- 
+
 module Roby
     describe Transaction do
         before do


### PR DESCRIPTION
So far, the Query class was the only one that could be used to
find tasks matching a TaskMatcher inside a plan. With the
recent addition of all types of matchers (events, task events,
and/or/not) and the need to add a port matcher in Syskit, this
commit refactors the code to allow any type of matcher to iterate
over a plan.

The main change in the commit is to replace the `query_set_result`/
`query_each` delegation from Query to plans by specific classes
with a defined interface (#each_in_plan). The old method was
expecting the result of query_set_result to be an opaque type
that could only be iterated upon by calling #query_each
on the plan that generated it.

This allowed me to relatively easily rewrite the #roots operator on
transactions to deal with any depth of stacked transactions (still very
expensive operation, use with care)