### PR TITLE
core: freeze dependency information

### DIFF
--- a/lib/roby/task_structure/dependency.rb
+++ b/lib/roby/task_structure/dependency.rb
@@ -161,9 +161,11 @@ module Roby
                     end
                     old_value
                 end
+                result[:model].freeze
 
                 # Finally, merge the roles (the easy part ;-))
                 result[:roles] = opt1[:roles] | opt2[:roles]
+                result.freeze
 
                 result
             end
@@ -597,6 +599,8 @@ module Roby
 
                     # Check if there is already a dependency link. If it is the case,
                     # merge the options. Otherwise, just add.
+                    options.freeze
+                    options.each_value(&:freeze)
                     add_child(task, options)
                     task
                 end

--- a/test/droby/v5/test_droby_dump.rb
+++ b/test/droby/v5/test_droby_dump.rb
@@ -355,8 +355,7 @@ module Roby
                         info   = task0[task1, TaskStructure::Dependency]
                         r_info = r_task0[r_task1, TaskStructure::Dependency]
                         assert_equal [[r_task1.model], Hash.new], r_info.delete(:model)
-                        info.delete(:model)
-                        assert_equal r_info, info
+                        assert_equal r_info, info.slice(*(info.keys - [:model]))
                     end
 
                     it "marshals relations between events" do

--- a/test/task_structure/test_dependency.rb
+++ b/test/task_structure/test_dependency.rb
@@ -162,21 +162,6 @@ class TC_Dependency < Minitest::Test
         assert_equal [task_m, Roby::Task], task.singleton_class.fullfilled_model
     end
 
-    def test_fullfilled_model_validation
-        tag = TaskService.new_submodel
-        klass = Roby::Task.new_submodel
-
-        p1, p2, child = prepare_plan add: 3, model: Tasks::Simple
-        p1.depends_on child, model: [Tasks::Simple, { id: "discover-3" }]
-        p2.depends_on child, model: [Tasks::Simple, { id: 'discover-3' }]
-
-        # Mess with the relation definition
-        p1[child, Dependency][:model].last[:id] = 'discover-10'
-        assert_raises(ModelViolation) { child.fullfilled_model }
-        p1[child, Dependency][:model] = [klass, {}]
-        assert_raises(ModelViolation) { child.fullfilled_model }
-    end
-
     def test_fullfilled_model_determination_from_dependency_relation
         tag = TaskService.new_submodel
         klass = Tasks::Simple.new_submodel do


### PR DESCRIPTION
I've been wondering one time too many about whether the info had
been modified in-place. Just freeze the bloody thing.

(For the record, always wondered, has not happened in a very long time)