### PR TITLE
Improve test and linting support in apps

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -67,8 +67,10 @@ if USE_RUBOCOP
     begin
         require "rubocop/rake_task"
         RuboCop::RakeTask.new do |t|
-            t.formatters << "junit"
-            t.options << "-o" << "#{REPORT_DIR}/rubocop.junit.xml"
+            if USE_JUNIT
+                t.formatters << "junit"
+                t.options << "-o" << "#{REPORT_DIR}/rubocop.junit.xml"
+            end
         end
         task "test" => "rubocop"
     rescue LoadError

--- a/lib/roby/app.rb
+++ b/lib/roby/app.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "find"
 require "facets/string/camelcase"
 require "roby/support"
 require "roby/robot"

--- a/lib/roby/app/rake.rb
+++ b/lib/roby/app/rake.rb
@@ -7,7 +7,68 @@ require "shellwords"
 
 module Roby
     module App
-        # Rake task definitions for the Roby apps
+        # Utility for Rakefile's in the generated apps
+        #
+        # = Tests
+        #
+        # {Rake::TestTask} generates a set of Rake tasks which run the tests.
+        # One task is created per robot configuration in `config/robots/`, and
+        # one "test" task is created that runs all the others. For instance,
+        # adding
+        #
+        #   Roby::App::Rake::TestTask.new
+        #
+        # in an app that has `config/robots/default.rb` and
+        # `config/robots/live.rb` will generate the `test:default`, `test:live`
+        # and `test` tasks.
+        #
+        # See {Rake::TestTask} documentation for possible configuration.
+        # Attributes can be modified in a block passed to `new`, e.g.:
+        #
+        #   Roby::App::Rake::TestTask.new do |t|
+        #       t.robot_names.delete(%w[default default])
+        #   end
+        #
+        # The tests will by default run the default minitest reporter. However,
+        # if the JUNIT environment variable is set to 1, they will instead be
+        # configured to generate a junit-compatible report. The report is named
+        # after the robot configuration (e.g. `default:default.junit.xml`) and
+        # placed in the report dir.
+        #
+        # The report dir is by default a `.test-results` folder at the root of
+        # the app. It can be changed by setting the `REPORT_DIR` environment
+        # variable.
+        #
+        # = Rubocop
+        #
+        # {Rake.define_rubocop} will configure a "rubocop" task. Its sibling,
+        # {Rake.define_rubocop_if_enabled} will do so, but controlled by a
+        # `RUBOCOP` environment variable:
+        #
+        #   - `RUBOCOP=1` will require that rubocop is present and define the
+        #     task
+        #   - `RUBOCOP=0` will never define the task
+        #   - any other value (including not having the variable defined) will
+        #     define the task only if rubocop is available.
+        #
+        # Note that the method only defines the task. If you mean to have it run
+        # along with the tests, you must add it explicitely as a dependency
+        #
+        #   task "test" => "rubocop"
+        #
+        # When using {Rake.define_rubocop_if_enabled}, use the method's return
+        # value to guard against the cases where the task is not defined, e.g.
+        #
+        #   task "test" => "rubocop" if Roby::App::Rake.define_rubocop_if_enabled
+        #
+        # The task uses rubocop's standard output formatter by default.
+        # However, if the JUNIT environment variable is set to 1, it will
+        # instead be configured to generate a junit-compatible report named
+        # `rubocop.junit.xml` in the same report dir than the tests.
+        #
+        # The report dir is by default a `.test-results` folder at the root of
+        # the app. It can be changed by setting the `REPORT_DIR` environment
+        # variable.
         module Rake
             # Whether the {.define_rubocop_if_enabled} should fail if rubocop is
             # not available

--- a/lib/roby/app/rake.rb
+++ b/lib/roby/app/rake.rb
@@ -288,11 +288,9 @@ module Roby
                 begin
                     require "rubocop/rake_task"
                 rescue LoadError
-                    if Rake.require_rubocop?
-                        raise
-                    else
-                        return
-                    end
+                    raise if required
+
+                    return
                 end
 
                 define_rubocop(junit: junit, report_dir: report_dir)

--- a/lib/roby/cli/gen/actions/test.rb.erb
+++ b/lib/roby/cli/gen/actions/test.rb.erb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
-require '<%= require_path %>'
+require "<%= require_path %>"
+
 <% indent, open, close = ::Roby::CLI::Gen.in_module(*class_name[0..-2]) %>
 <%= open %>
 <%= indent %>describe <%= class_name.last %> do

--- a/lib/roby/cli/gen/app/.rubocop.yml
+++ b/lib/roby/cli/gen/app/.rubocop.yml
@@ -1,0 +1,3 @@
+inherit_gem:
+  rubocop-rock: defaults.yml
+

--- a/lib/roby/cli/gen/app/Rakefile
+++ b/lib/roby/cli/gen/app/Rakefile
@@ -9,6 +9,8 @@ task :default
 Roby.app.load_base_config
 Roby::App::Rake::TestTask.new
 
+task "test" => "rubocop" if Roby::App::Rake.define_rubocop_if_enabled
+
 YARD::Rake::YardocTask.new do |yard|
     yard.files = ["models/**/*.rb", "lib/**/*.rb"]
 end

--- a/lib/roby/cli/gen/class/test.rb.erb
+++ b/lib/roby/cli/gen/class/test.rb.erb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-require '<%= require_path %>'
+require "<%= require_path %>"
+
 <% indent, open, close = ::Roby::CLI::Gen.in_module(*class_name[0..-2]) %>
 <%= open %>
 <%= indent %>describe <%= class_name.last %> do
 <%= indent %>end
 <%= close %>
-

--- a/lib/roby/cli/gen/module/test.rb.erb
+++ b/lib/roby/cli/gen/module/test.rb.erb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
-require '<%= require_path %>'
+require "<%= require_path %>"
+
 <% indent, open, close = ::Roby::CLI::Gen.in_module(*module_name[0..-2]) %>
 <%= open %>
 <%= indent %>describe <%= module_name.last %> do

--- a/lib/roby/cli/gen/roby_app/config/robots/robot.rb.erb
+++ b/lib/roby/cli/gen/roby_app/config/robots/robot.rb.erb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 <% if robot_name != 'default' %>## A common pattern is to load the 'default' robot configuration
-require_relative './default'<% end %>
+require_relative "./default"
 
-## One can require the configuration from another robot, for instance if one has
+<% end %>## One can require the configuration from another robot, for instance if one has
 ## a common robot class with minor modifications
 #
 # require 'config/robots/robot_class'

--- a/lib/roby/cli/gen/task/test.rb.erb
+++ b/lib/roby/cli/gen/task/test.rb.erb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
-require '<%= require_path %>'
+require "<%= require_path %>"
+
 <% indent, open, close = ::Roby::CLI::Gen.in_module(*class_name[0..-2]) %>
 <%= open %>
 <%= indent %>describe <%= class_name.last %> do

--- a/lib/roby/test/aruba_minitest.rb
+++ b/lib/roby/test/aruba_minitest.rb
@@ -44,12 +44,14 @@ module Roby
                 @aruba_api.run_command(*args)
             end
 
-            def run_roby_and_stop(cmd, *args, fail_on_error: true)
-                run_command_and_stop("#{Gem.ruby} #{roby_bin} #{cmd}", *args, fail_on_error: fail_on_error)
+            def run_roby_and_stop(cmd, *args, fail_on_error: true, **opts)
+                run_command_and_stop("#{Gem.ruby} #{roby_bin} #{cmd}", *args,
+                                     fail_on_error: fail_on_error, **opts)
             end
 
-            def run_roby(cmd, *args, fail_on_error: true)
-                run_command("#{Gem.ruby} #{roby_bin} #{cmd}", *args, fail_on_error: fail_on_error)
+            def run_roby(cmd, *args, fail_on_error: true, **opts)
+                run_command("#{Gem.ruby} #{roby_bin} #{cmd}", *args,
+                            fail_on_error: fail_on_error, **opts)
             end
 
             def method_missing(m, *args, &block)

--- a/manifest.xml
+++ b/manifest.xml
@@ -44,5 +44,6 @@
   <test_depend package="aruba" />
   <test_depend package="rack-test" />
   <test_depend package="rubocop" />
+  <test_depend package="rubocop-rock" />
 </package>
 

--- a/test/cli/test_gen_main.rb
+++ b/test/cli/test_gen_main.rb
@@ -8,9 +8,15 @@ module Roby
         describe "roby gen" do
             include Test::ArubaMinitest
 
-            def validate_app_valid(*args)
+            def validate_app_runs(*args)
                 roby_run = run_roby ["run", *args].join(" ")
                 run_roby_and_stop "quit --retry"
+                roby_run.stop
+                assert_command_finished_successfully roby_run
+            end
+
+            def validate_app_tests
+                roby_run = run_command "rake test", environment: { RUBOCOP: 1 }
                 roby_run.stop
                 assert_command_finished_successfully roby_run
             end
@@ -18,7 +24,8 @@ module Roby
             describe "creation of a new app in the current directory" do
                 it "generates a new valid app" do
                     run_roby_and_stop "gen app"
-                    validate_app_valid
+                    validate_app_runs
+                    validate_app_tests
                 end
 
                 it "generates a default robot configuration" do
@@ -28,7 +35,7 @@ module Roby
 
                 it "is accessible through the deprecated 'init' subcommand" do
                     run_roby_and_stop "init"
-                    validate_app_valid
+                    validate_app_runs
                 end
             end
 
@@ -40,7 +47,8 @@ module Roby
                 describe "gen robot" do
                     it "generates a new valid robot configuration" do
                         run_roby_and_stop "gen robot test"
-                        validate_app_valid "-rtest"
+                        validate_app_runs "-rtest"
+                        validate_app_tests
                     end
                 end
             end


### PR DESCRIPTION
Test and linting can now be controlled by the JUNIT, RUBOCOP and
REPORT_DIR environment variables. Their output is placed in
REPORT_DIR if set, `$srcdir/.test-results` if not

Apps that mean to use Rubocop are expected to call {Roby::App::Rake.
Rubocop is enabled automatically if available when RUBOCOP is set to
anything but 0 or 1. It is disabled if set to 0. It is enabled, and will fail if
not present, when set to 1. Rubocop generates a junit report if JUNIT
is set to 1, the output dir being controlled by REPORT_DIR

Each robot test now gets its own test output, while they previously were happily
overwriting each other.