### PR TITLE
fix running tests within the buildbot CI

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -95,14 +95,18 @@ task :uic do
     rbuic = "rbuic4"
     rbuic = "/usr/lib/kde4/bin/rbuic4" if File.exist?("/usr/lib/kde4/bin/rbuic4")
 
+    failed = false
     UIFILES.each do |file|
         file = "lib/roby/" + file
         unless system(rbuic, "-o", file.gsub(/\.ui$/, "_ui.rb"), file)
             STDERR.puts "Failed to generate #{file}"
+            failed = true
         end
     end
+    raise "uic generation failed" if failed
 end
 task "compile" => "uic"
+task "test" => "uic" if has_gui
 
 YARD::Rake::YardocTask.new
 task "doc" => "yard"

--- a/lib/roby/droby/logfile/client.rb
+++ b/lib/roby/droby/logfile/client.rb
@@ -57,7 +57,7 @@ module Roby
                     @rx = 0
                     @socket =
                         begin TCPSocket.new(host, port)
-                        rescue Errno::ECONNREFUSED => e
+                        rescue Errno::ECONNREFUSED, Errno::EADDRNOTAVAIL => e
                             raise Interface::ConnectionError, "cannot contact Roby log server at '#{host}:#{port}': #{e.message}"
                         end
                     socket.fcntl(Fcntl::FD_CLOEXEC, 1)

--- a/lib/roby/interface/rest/server.rb
+++ b/lib/roby/interface/rest/server.rb
@@ -210,7 +210,7 @@ module Roby
                                              "#{returned_value}"
                     end
                     true
-                rescue Errno::ECONNREFUSED
+                rescue Errno::ECONNREFUSED, Errno::EADDRNOTAVAIL
                     false
                 rescue RestClient::Exception => e
                     raise InvalidServer, "unexpected server answer to 'ping': #{e}"

--- a/lib/roby/interface/tcp.rb
+++ b/lib/roby/interface/tcp.rb
@@ -163,7 +163,7 @@ module Roby
             addr = socket.addr(true)
             channel = DRobyChannel.new(socket, true, marshaller: marshaller)
             Client.new(channel, "#{addr[2]}:#{addr[1]}", handshake: handshake)
-        rescue Errno::ECONNREFUSED => e
+        rescue Errno::ECONNREFUSED, Errno::EADDRNOTAVAIL => e
             raise ConnectionError, "failed to connect to #{host}:#{port}: #{e.message}",
                   e.backtrace
         rescue SocketError => e


### PR DESCRIPTION
Our internal CI based on [Buildbot and Kubernetes workers](https://github.com/tidewise/buildbot-ci/) has different quirks than Travis.

- One thing is that the UI is available (it's not in Travis) and the UIC must be run before the tests.
- Another is an issue with how Kubernetes defines 'localhost', which caused problems in connection checks (see 8e54ad9)

With this PR, both Roby and Syskit tests pass.