### PR TITLE
gen: add # :nodoc: to the innermost generated module

### DIFF
--- a/lib/roby/cli/gen/helpers.rb
+++ b/lib/roby/cli/gen/helpers.rb
@@ -196,8 +196,10 @@ module Roby
                     indent = ""
                     open_code = []
                     close_code = []
-                    module_path.each do |m|
-                        open_code.push "#{indent}module #{m}"
+                    last_module_i = module_path.size - 1
+                    module_path.each_with_index do |m, i|
+                        nodoc = " #:nodoc:" if i == last_module_i
+                        open_code.push "#{indent}module #{m}#{nodoc}"
                         close_code.unshift "#{indent}end"
                         indent += "    "
                     end


### PR DESCRIPTION
The Style/Documentation cop ignores what looks like namespaces, but
Roby's usage of DSL-like methods breaks that detection. So, some
generated files trigger Style/Documentation.

Add `# :nodoc:` to silence the cop for what we know are namespaces.
Note that this never includes the class that is being generated, which
*will* have to be documented.