### PR TITLE
test: improve the ability to reuse expectations 

### DIFF
--- a/lib/roby/test/execution_expectations.rb
+++ b/lib/roby/test/execution_expectations.rb
@@ -1148,7 +1148,7 @@ module Roby
                 def initialize(at_least_during, block, description, backtrace)
                     super(backtrace)
                     @at_least_during = at_least_during
-                    @description = description
+                    @description = description || @backtrace[0].to_s
                     @block = block
                     @deadline = Time.now + at_least_during
                     @failed = false
@@ -1172,14 +1172,18 @@ module Roby
                 end
 
                 def to_s
-                    @description || @backtrace[0].to_s
+                    if @description.respond_to?(:call)
+                        @description.call
+                    else
+                        @description
+                    end
                 end
             end
 
             class Achieve < Expectation
                 def initialize(block, description, backtrace)
                     super(backtrace)
-                    @description = description
+                    @description = description || @backtrace[0].to_s
                     @block = block
                 end
 
@@ -1192,7 +1196,11 @@ module Roby
                 end
 
                 def to_s
-                    @description || @backtrace[0].to_s
+                    if @description.respond_to?(:call)
+                        @description.call
+                    else
+                        @description
+                    end
                 end
             end
 

--- a/test/test/test_execution_expectations.rb
+++ b/test/test/test_execution_expectations.rb
@@ -646,18 +646,32 @@ module Roby
                         end
                         assert (Time.now - base_time) >= 1
                     end
+                    it "uses the given description for to_s" do
+                        expectation = nil
+                        expect_execution.timeout(0).to do
+                            expectation = maintain(description: "some text") { true }
+                        end
+                        assert_equal "some text", expectation.to_s
+                    end
+                    it "accepts a proc as description, to be resolved when needed" do
+                        expectation = nil
+                        value = 0
+                        expect_execution.timeout(0).to do
+                            expectation =
+                                maintain(description: -> { value.to_s }) { value = 10 }
+                        end
+
+                        assert_equal "10", expectation.to_s
+                    end
                 end
 
                 describe "#achieve" do
                     it "succeeds if the block returns true" do
-                        expect_execution
-                            .to { achieve { true } }
+                        expect_execution.to { achieve { true } }
                     end
                     it "fails if the block never returns true" do
                         assert_raises(ExecutionExpectations::Unmet) do
-                            expect_execution
-                                .timeout(0)
-                                .to { achieve {} }
+                            expect_execution.timeout(0).to { achieve {} }
                         end
                     end
                     it "remains achieved once it did" do
@@ -665,20 +679,33 @@ module Roby
                         # ExecutionExpectations evaluates #update_match multiple
                         # times.
                         flipflop = false
-                        expect_execution
-                            .timeout(0)
-                            .to do
-                                achieve { flipflop = !flipflop }
-                            end
+                        expect_execution.timeout(0).to do
+                            achieve { flipflop = !flipflop }
+                        end
                     end
                     it "returns the block's value" do
                         obj = flexmock
-                        ret = expect_execution
-                            .timeout(0)
-                            .to do
-                                achieve { obj }
-                            end
+                        ret = expect_execution.timeout(0).to do
+                            achieve { obj }
+                        end
                         assert_same obj, ret
+                    end
+                    it "uses the given description for to_s" do
+                        expectation = nil
+                        expect_execution.timeout(0).to do
+                            expectation = achieve(description: "some text") { true }
+                        end
+                        assert_equal "some text", expectation.to_s
+                    end
+                    it "accepts a proc as description, to be resolved when needed" do
+                        expectation = nil
+                        value = 0
+                        expect_execution.timeout(0).to do
+                            expectation =
+                                achieve(description: -> { value.to_s }) { value = 10 }
+                        end
+
+                        assert_equal "10", expectation.to_s
                     end
                 end
 


### PR DESCRIPTION
This adds two small functionalities to the existing expectations, with the aim to be able
to do small changes to existing expectations without having to create a whole new one
each time:

- `filter_result_with` allows to change the result returned by an expectation
- `achieve` and `maintain` now accept a block as description, to allow for a
   more dynamic description (as e.g. `expected 10 samples, received 5`)