### PR TITLE
test: give access to Roby storage in REST::Test

### DIFF
--- a/lib/roby/interface/rest/test.rb
+++ b/lib/roby/interface/rest/test.rb
@@ -30,15 +30,22 @@ module Roby
                                                "to return the REST API"
                 end
 
+                # The {Helpers#roby_storage} object that is being accessed by the API
+                def roby_storage
+                    @roby_storage ||= {}
+                end
+
                 # @api private
                 #
                 # Overloaded from Rack::Test to inject the app and plan
                 # and make them available to the API
                 def build_rack_mock_session
                     interface = Roby::Interface::Interface.new(app)
-                    actual_api = Roby::Interface::REST::Server.attach_api_to_interface(
-                        rest_api, interface
-                    )
+                    actual_api =
+                        Roby::Interface::REST::Server
+                        .attach_api_to_interface(
+                            rest_api, interface, roby_storage
+                        )
                     Rack::MockSession.new(actual_api)
                 end
             end

--- a/test/interface/rest/test_test.rb
+++ b/test/interface/rest/test_test.rb
@@ -21,11 +21,23 @@ module Roby
                         get "/test" do
                             roby_execute { roby_plan.num_tasks }
                         end
+
+                        get "/storage_value" do
+                            roby_storage["write"] = 21
+                            roby_storage["read"]
+                        end
                     end
                 end
 
                 it "allows to execute a test that synchronizes with the engine" do
                     assert_equal 0, JSON.parse(get("/test").body)
+                end
+
+                it "gives access to the same roby_storage object that is used "\
+                   "by the API itself" do
+                    roby_storage["read"] = 42
+                    assert_equal 42, JSON.parse(get("/storage_value").body)
+                    assert_equal 21, roby_storage["write"]
                 end
             end
         end


### PR DESCRIPTION
This allows for API tests to manipulate the internal storage's
contents (for unit-testing) instead of being restricted to blackbox
tests.