### PR TITLE
app: apply the configuration from --set arguments after reload

### DIFF
--- a/lib/roby/app.rb
+++ b/lib/roby/app.rb
@@ -884,6 +884,8 @@ module Roby
             call_plugins(:setup, self)
             # And run the setup handlers
             setup_handlers.each(&:call)
+            # Re-apply configuration parameters from the command line
+            apply_argv_set
 
             require_models
 


### PR DESCRIPTION
This is useful in the IDE, to be able to reload the models while
some --set options were given.