### PR TITLE
normalize some calls that use keyword arguments to use the ** splat

### DIFF
--- a/lib/roby/actions/action.rb
+++ b/lib/roby/actions/action.rb
@@ -63,7 +63,7 @@ module Roby
 
             # Deploys this action on the given plan
             def instanciate(plan, **arguments)
-                model.instanciate(plan, self.arguments.merge(arguments))
+                model.instanciate(plan, **self.arguments.merge(arguments))
             end
 
             def to_s

--- a/lib/roby/actions/models/action.rb
+++ b/lib/roby/actions/models/action.rb
@@ -41,7 +41,7 @@ module Roby
                 # @return [Action] an action using this action model and the given
                 #   arguments
                 def new(**arguments)
-                    Actions::Action.new(self, normalize_arguments(arguments))
+                    Actions::Action.new(self, **normalize_arguments(arguments))
                 end
 
                 def ==(other)

--- a/lib/roby/actions/models/method_action.rb
+++ b/lib/roby/actions/models/method_action.rb
@@ -139,12 +139,18 @@ module Roby
                 end
 
                 # Returns the plan pattern that will deploy this action on the plan
-                def plan_pattern(arguments = {})
-                    job_id, arguments = Kernel.filter_options arguments, :job_id
+                def plan_pattern(job_id: nil, **arguments)
+                    job_argument =
+                        if job_id
+                            { job_id: job_id }
+                        else
+                            {}
+                        end
 
                     planner = Roby::Actions::Task.new(
-                        Hash[action_model: self,
-                             action_arguments: arguments].merge(job_id)
+                        action_model: self,
+                        action_arguments: arguments,
+                        **job_argument
                     )
                     planner.planning_result_task
                 end

--- a/lib/roby/app.rb
+++ b/lib/roby/app.rb
@@ -2818,9 +2818,9 @@ module Roby
             end
 
             if mission
-                plan.add_mission_task(task = m.plan_pattern(arguments))
+                plan.add_mission_task(task = m.plan_pattern(**arguments))
             else
-                plan.add(task = m.plan_pattern(arguments))
+                plan.add(task = m.plan_pattern(**arguments))
             end
             [task, task.planning_task]
         end

--- a/lib/roby/cli/main.rb
+++ b/lib/roby/cli/main.rb
@@ -138,7 +138,7 @@ module Roby
                 " Use this to validate the current configuration"
             option :robot, aliases: "r", desc: "the robot name", default: "default"
             option :set, desc: "set configuration variable(s)",
-                         type: :array
+                         type: :array, default: []
             def check(app_dir = nil, *extra_files)
                 app = Roby.app
                 app.app_dir = app_dir if app_dir

--- a/lib/roby/coordination/models/actions.rb
+++ b/lib/roby/coordination/models/actions.rb
@@ -185,11 +185,11 @@ module Roby
                     action_interface&.find_action_by_name(m.to_s) || super
                 end
 
-                def method_missing(m, *args)
-                    if action = action_interface.find_action_by_name(m.to_s)
-                        action.new(*args)
-                    else super
-                    end
+                def method_missing(m, *args, **kw)
+                    action = action_interface.find_action_by_name(m.to_s)
+                    return super unless action
+
+                    action.new(*args, **kw)
                 end
             end
         end

--- a/lib/roby/coordination/models/base.rb
+++ b/lib/roby/coordination/models/base.rb
@@ -70,9 +70,8 @@ module Roby
                 #   task model that is going to be used as a toplevel task for the
                 #   state machine
                 # @return [Model<StateMachine>] a subclass of StateMachine
-                def setup_submodel(subclass, options = {})
-                    options = Kernel.validate_options options, root: Roby::Task
-                    subclass.root(options[:root])
+                def setup_submodel(subclass, root: Roby::Task, **options)
+                    subclass.root(root)
                     super
                 end
 
@@ -133,10 +132,13 @@ module Roby
                         super
                 end
 
-                def method_missing(m, *args, &block)
+                def method_missing(m, *args, **kw, &block)
                     if has_argument?(m)
-                        unless args.empty?
-                            raise ArgumentError, "expected zero arguments to #{m}, got #{args.size}: #{args}"
+                        unless args.empty? && kw.empty?
+                            raise ArgumentError,
+                                  "expected zero arguments to #{m}, "\
+                                  "got #{args.size} positional arguments (#{args}) and "\
+                                  "#{kw.size} keyword arguments (#{kw})"
                         end
 
                         Variable.new(m)

--- a/lib/roby/coordination/models/script.rb
+++ b/lib/roby/coordination/models/script.rb
@@ -243,9 +243,9 @@ module Roby
                 #   calling {Base#task} on the relevant object
                 # @param [Hash] options the dependency relation options. See
                 #   {Roby::TaskStructure::Dependency::Extension#depends_on}
-                def execute(task, options = {})
+                def execute(task, **options)
                     task = validate_or_create_task task
-                    start(task, options)
+                    start(task, **options)
                     wait(task.success_event)
                 end
 

--- a/lib/roby/coordination/models/task_from_action.rb
+++ b/lib/roby/coordination/models/task_from_action.rb
@@ -31,7 +31,7 @@ module Roby
                         else value
                         end
                     end
-                    action.as_plan(arguments)
+                    action.as_plan(**arguments)
                 end
 
                 # Returns the action's underlying coordination model if there is one

--- a/lib/roby/droby/logfile/writer.rb
+++ b/lib/roby/droby/logfile/writer.rb
@@ -18,7 +18,7 @@ module Roby
                     @event_io = event_io
                     @buffer_io = StringIO.new("".dup, "w")
 
-                    Logfile.write_header(event_io, options)
+                    Logfile.write_header(event_io, **options)
                 end
 
                 def self.open(path, **options)

--- a/lib/roby/event_generator.rb
+++ b/lib/roby/event_generator.rb
@@ -360,7 +360,7 @@ module Roby
             for h in handlers
                 if h.copy_on_replace?
                     event ||= yield
-                    event.on(h.as_options, &h.block)
+                    event.on(**h.as_options, &h.block)
                 end
             end
 
@@ -368,7 +368,9 @@ module Roby
                 cancel, h = h
                 if h.copy_on_replace?
                     event ||= yield
-                    event.if_unreachable(cancel_at_emission: cancel, on_replace: :copy, &h.block)
+                    event.if_unreachable(
+                        cancel_at_emission: cancel, on_replace: :copy, &h.block
+                    )
                 end
             end
 
@@ -521,8 +523,8 @@ module Roby
         #   once { |context| ... }
         #
         # Calls the provided event handler only once
-        def once(options = {}, &block)
-            on(options.merge(once: true), &block)
+        def once(**options, &block)
+            on(**options.merge(once: true), &block)
             self
         end
 

--- a/lib/roby/interface/client.rb
+++ b/lib/roby/interface/client.rb
@@ -344,7 +344,14 @@ module Roby
             #   action -- the job ID for the newly created action
             def call(path, m, *args)
                 if (action_match = /(.*)!$/.match(m.to_s))
-                    start_job(action_match[1], *args)
+                    if args.empty?
+                        args = [{}]
+                    elsif args.size > 1 || !args.last.kind_of?(Hash)
+                        raise ArgumentError,
+                              "expected a single Hash argument, but got #{args}"
+                    end
+
+                    start_job(action_match[1], **args.first)
                 else
                     io.write_packet([path, m, *args])
                     result, = poll(1, timeout: @call_timeout)

--- a/lib/roby/interface/job.rb
+++ b/lib/roby/interface/job.rb
@@ -37,7 +37,7 @@ module Roby
                 to_s
             end
 
-            def initialize(arguments = {})
+            def initialize(**)
                 super
                 if Conf.app.auto_allocate_job_ids? && !job_id
                     allocate_job_id

--- a/lib/roby/models/task.rb
+++ b/lib/roby/models/task.rb
@@ -232,7 +232,7 @@ module Roby
                           "that returns it"
                 end
 
-                new(arguments)
+                new(**arguments)
             end
 
             # @deprecated

--- a/lib/roby/models/task_event.rb
+++ b/lib/roby/models/task_event.rb
@@ -27,7 +27,7 @@ module Roby
                 submodel, task_model: nil, symbol: nil, command: false,
                 terminal: false, **options, &block
             )
-                super(submodel, options, &block)
+                super(submodel, **options, &block)
                 submodel.task_model = task_model
                 submodel.symbol     = symbol
                 submodel.terminal   = terminal

--- a/lib/roby/task.rb
+++ b/lib/roby/task.rb
@@ -385,7 +385,7 @@ module Roby
         end
 
         def create_fresh_copy
-            model.new(arguments.dup)
+            model.new(**arguments.dup)
         end
 
         def initialize_copy(old) # :nodoc:

--- a/roby.gemspec
+++ b/roby.gemspec
@@ -55,7 +55,7 @@ Gem::Specification.new do |s|
     s.add_development_dependency "aruba"
     s.add_development_dependency "cucumber"
     s.add_development_dependency "rack-test"
-    s.add_development_dependency "rubocop"
+    s.add_development_dependency "rubocop", "= 0.85.1"
     s.add_development_dependency "rubocop-rock"
 
     # NOTE: stackprof and rbtrace are linux- and MRI-specific

--- a/test/test_task.rb
+++ b/test/test_task.rb
@@ -784,13 +784,13 @@ module Roby
 
             def self.it_matches_common_replace_transaction_behaviour
                 it_matches_common_replace_transaction_behaviour_for_handler(:finalization_handlers) do |event, args|
-                    event.when_finalized(args) {}
+                    event.when_finalized(**args) {}
                 end
                 it_matches_common_replace_transaction_behaviour_for_handler(:handlers) do |event, args|
-                    event.on(args) {}
+                    event.on(**args) {}
                 end
                 it_matches_common_replace_transaction_behaviour_for_handler(:unreachable_handlers) do |event, args|
-                    event.if_unreachable(args) {}
+                    event.if_unreachable(**args) {}
                 end
             end
 
@@ -2902,7 +2902,7 @@ class TC_Task < Minitest::Test
         task, planner_task = task_t.new, task_t.new
         task.planned_by planner_task
         flexmock(Roby.app).should_receive(:prepare_action)
-                          .with(task_t, {}).and_return([task, planner_task])
+                          .with(task_t, any).and_return([task, planner_task])
 
         plan.add(as_plan = task_t.as_plan)
         assert_same task, as_plan


### PR DESCRIPTION
One important tidbit introduced in this PR are the `sanitize_keywords_to_array` and `sanitize_keywords_to_hash` helpers. They handle inconsistencies in Ruby 2.7 (compared to previous Rubies) for calls that mix strings and symbols in the last hash, such as

~~~
provides MODEL, "some" => "mapping", some: keywords
~~~