### PR TITLE
define an empty poll handler so that the class-level poll blocks can call super()

### DIFF
--- a/lib/roby/task.rb
+++ b/lib/roby/task.rb
@@ -1112,6 +1112,12 @@ module Roby
 
         # @api private
         #
+        # Method under which `Models::Task#poll` registers its given block.
+        # Defined empty at this level to allow calling super() unconditionally
+        def poll_handler; end
+
+        # @api private
+        #
         # Internal method used to register the poll blocks in the engine
         # execution cycle
         def do_poll(plan) # :nodoc:
@@ -1126,9 +1132,7 @@ module Roby
                     execute_block.block.call(self)
                 end
 
-                if respond_to?(:poll_handler)
-                    poll_handler
-                end
+                poll_handler
 
                 if machine = state_machine
                     machine.do_poll(self)

--- a/test/test_task.rb
+++ b/test/test_task.rb
@@ -896,6 +896,14 @@ module Roby
                 assert_equal [expected, expected], poll_cycles
             end
 
+            it "has an empty default implementation that can be called with super()" do
+                called = false
+                task_m.poll { super(); called = true }
+                plan.add(task = task_m.new)
+                execute { task.start! }
+                assert called
+            end
+
             it "returns a disposable that un-subscribes it" do
                 poll_count = 0
                 plan.add_permanent_task(task = task_m.new)


### PR DESCRIPTION
Otherwise, defining a `poll` block at the class level would require
knowing whether the superclass has a poll block or not. With this,
one has to unconditionally call `super()`.

Note that existing compositions/tasks won't be affected (since they
already do not have a superclass poll block)

Ideally, these blocks would not interact with each other. But in the
spirit of "document, don't change", only make this bit a little bit
nicer.