### PR TITLE
test: validate that the argument is a task in run_planners

### DIFF
--- a/lib/roby/test/run_planners.rb
+++ b/lib/roby/test/run_planners.rb
@@ -52,6 +52,11 @@ module Roby
             #   planning tasks generate subplans containing planning tasks
             #   themselves)
             def run_planners(root_task, recursive: true)
+                unless root_task.respond_to?(:as_plan)
+                    raise ArgumentError,
+                          "#{root_task} is not a Roby task and cannot be converted to one"
+                end
+
                 unless execution_engine.in_propagation_context?
                     service = nil
                     expect_execution do

--- a/test/test/test_run_planners.rb
+++ b/test/test/test_run_planners.rb
@@ -31,6 +31,16 @@ module Roby
                 RunPlanners.deregister_planning_handler(@handler_class) if @handler_class
             end
 
+            it "raises right away if the argument is not a task and cannot be converted "\
+               "to one" do
+                obj = flexmock
+                e = assert_raises(ArgumentError) do
+                    run_planners(obj)
+                end
+                assert_equal "#{obj} is not a Roby task and cannot be converted to one",
+                             e.message
+            end
+
             it "calls the handler's start and finished? methods under propagation" do
                 @handler_class = Class.new(RunPlanners::PlanningHandler) do
                     def start(tasks)


### PR DESCRIPTION
Otherwise, the user will get a cryptic error message. This is in
addition a rather common occurence when doing the common

`run_planner(find_tasks(M).first)`