### PR TITLE
workaround performance issue on first connection in Ruby 2.7

### DIFF
--- a/lib/roby/interface/droby_channel.rb
+++ b/lib/roby/interface/droby_channel.rb
@@ -17,6 +17,16 @@ module Roby
             # until it bails out
             attr_reader :max_write_buffer_size
 
+            # This is a workaround for a very bad performance behavior on first
+            # load. These classes are auto-loaded and it takes forever to load
+            # them in multithreaded contexts.
+            WEBSOCKET_CLASSES = [
+                WebSocket::Frame::Outgoing::Client,
+                WebSocket::Frame::Outgoing::Server,
+                WebSocket::Frame::Incoming::Client,
+                WebSocket::Frame::Incoming::Server
+            ].freeze
+
             def initialize(
                 io, client,
                 marshaller: DRoby::Marshal.new(auto_create_plans: true),


### PR DESCRIPTION
It seems that Ruby 2.7 has seen some effort w.r.t. fixing race
conditions related to autoloading. Unfortunately, it also seems
that it in our case we hit some lock contention or something.

Pre-load the Websocket classes. This fixes a Syskit interface
connection taking minutes on "real" links (i.e. non-loopback)
instead of seconds.