### PR TITLE
app: fix loading robot types from app.yml

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -139,7 +139,6 @@ Layout/LineLength:
     - 'lib/roby/task_structure/planned_by.rb'
     - 'lib/roby/tasks/external_process.rb'
     - 'lib/roby/tasks/virtual.rb'
-    - 'lib/roby/test/aruba_minitest.rb'
     - 'lib/roby/test/assertions.rb'
     - 'lib/roby/test/common.rb'
     - 'lib/roby/test/dsl.rb'
@@ -1412,7 +1411,6 @@ Naming/MethodParameterName:
     - 'lib/roby/task_structure/dependency.rb'
     - 'lib/roby/task_structure/executed_by.rb'
     - 'lib/roby/tasks/virtual.rb'
-    - 'lib/roby/test/aruba_minitest.rb'
     - 'lib/roby/test/assertions.rb'
     - 'lib/roby/test/event_reporter.rb'
     - 'lib/roby/test/execution_expectations.rb'
@@ -1700,7 +1698,6 @@ Style/Documentation:
     - 'lib/roby/tasks/group.rb'
     - 'lib/roby/tasks/parallel.rb'
     - 'lib/roby/tasks/timeout.rb'
-    - 'lib/roby/test/aruba_minitest.rb'
     - 'lib/roby/test/assertion.rb'
     - 'lib/roby/test/assertions.rb'
     - 'lib/roby/test/dsl.rb'
@@ -1864,7 +1861,6 @@ Style/GuardClause:
     - 'lib/roby/task_structure/planned_by.rb'
     - 'lib/roby/tasks/external_process.rb'
     - 'lib/roby/tasks/thread.rb'
-    - 'lib/roby/test/aruba_minitest.rb'
     - 'lib/roby/test/assertions.rb'
     - 'lib/roby/test/common.rb'
     - 'lib/roby/test/minitest_helpers.rb'
@@ -1982,7 +1978,6 @@ Style/IfUnlessModifier:
     - 'lib/roby/tasks/group.rb'
     - 'lib/roby/tasks/thread.rb'
     - 'lib/roby/tasks/virtual.rb'
-    - 'lib/roby/test/aruba_minitest.rb'
     - 'lib/roby/test/common.rb'
     - 'lib/roby/test/expect_execution.rb'
     - 'lib/roby/test/minitest_helpers.rb'
@@ -2027,7 +2022,6 @@ Style/MissingRespondToMissing:
     - 'lib/roby/state/open_struct.rb'
     - 'lib/roby/state/state_model.rb'
     - 'lib/roby/task_arguments.rb'
-    - 'lib/roby/test/aruba_minitest.rb'
 
 # Offense count: 53
 Style/MultilineBlockChain:

--- a/lib/roby/app.rb
+++ b/lib/roby/app.rb
@@ -766,6 +766,8 @@ module Roby
             @cleanup_handlers      = []
             @controllers           = []
             @action_handlers       = []
+
+            @robots = App::RobotNames.new
         end
 
         # Loads the base configuration
@@ -996,14 +998,7 @@ module Roby
         # The robot names configuration
         #
         # @return [App::RobotNames]
-        def robots
-            unless @robots
-                robots = App::RobotNames.new(options["robots"] || {})
-                robots.strict = !!options["robots"]
-                @robots = robots
-            end
-            @robots
-        end
+        attr_reader :robots
 
         # Declares a block that should be executed when the Roby app gets
         # initialized (i.e. just after init.rb gets loaded)
@@ -1825,6 +1820,8 @@ module Roby
 
             Application.info "loading config file #{file}"
             options = YAML.safe_load(File.read(file)) || {}
+
+            @robots.load_config_yaml(options["robots"] || {})
 
             if robot_name && (robot_config = options.delete("robots"))
                 options = options.recursive_merge(robot_config[robot_name] || {})


### PR DESCRIPTION
This was simply broken. The @robots instance variable was magically
created the first time it was accessed, which of course ended up
being at the wrong time.

Create it in #initialize and update it on app.yml loading using
a separate load_config_yml method. And add tests.

