### PR TITLE
core: remove GC short path for plans that have only pending or finished tasks

### DIFF
--- a/lib/roby/execution_engine.rb
+++ b/lib/roby/execution_engine.rb
@@ -1980,16 +1980,6 @@ module Roby
                     break
                 end
 
-                if local_tasks.all? { |t| t.pending? || t.finished? }
-                    local_tasks.each do |t|
-                        debug { "GC: #{t} is not running, removed" }
-                        if plan.garbage_task(t)
-                            did_something = true
-                        end
-                    end
-                    break
-                end
-
                 # Mark all root local_tasks as garbage.
                 roots = local_tasks.dup
                 plan.each_task_relation_graph do |g|


### PR DESCRIPTION
Depends on:
- [ ] https://github.com/rock-core/tools-syskit/pull/271

This alternate codepath was introduced a long time ago, in a attempt
to speed up garbage collection in some cases. The problem at the time
was that garbage collection passes would only remove the toplevel tasks.
This is not an issue anymore, as we do as many passes as possible,
internally to the method as well as during the execution cycle.

This piece of code was actually the source of a longstanding but never
fixed grave bug that manifested itself in Syskit, with running tasks
ending having nil execution agent. I finally managed to have a way
to reproduce (even if it is random and would take anywhere from 1
min to 1 hour). This reproducing case will be added to Syskit as
a stress test.

Syskit uses the `#can_finalize?` predicate to ensure that tasks
that are being configured are not garbage collected. The main
code path would properly deal with it, but this code path would
not, actually removing the agent. I believe that the (very minor)
optimization is not worth having to make sure the two code paths
do follow the same behavior.