### PR TITLE
fix rubocop version to 0.83.0

### DIFF
--- a/roby.gemspec
+++ b/roby.gemspec
@@ -55,7 +55,7 @@ Gem::Specification.new do |s|
     s.add_development_dependency "aruba"
     s.add_development_dependency "cucumber"
     s.add_development_dependency "rack-test"
-    s.add_development_dependency "rubocop", "= 0.85.1"
+    s.add_development_dependency "rubocop", "= 0.83.0"
     s.add_development_dependency "rubocop-rock"
 
     # NOTE: stackprof and rbtrace are linux- and MRI-specific


### PR DESCRIPTION
Versions between 0.83 and 0.89.0 have a bug that triggers on Roby.
Versions after 0.89.0 have a breaking change in the way
CyclomaticComplexity counts the complexity, which also breaks
on roby.

Stick to the last working version for now