### PR TITLE
allow to enable or disable timepoint logging

### DIFF
--- a/lib/roby/app.rb
+++ b/lib/roby/app.rb
@@ -130,6 +130,22 @@ module Roby
         # @see #register_exception #clear_exceptions
         attr_reader :registered_exceptions
 
+        # Whether internal timepoints should be logged
+        #
+        # This generates a magnitude higher amount of data than "normal"
+        # logging. Enable this during development if you have issues with
+        # Roby being unresponsive
+        def log_timepoints?
+            if @log_timepoints.nil?
+                log["timepoints"]
+            else
+                @log_timepoints
+            end
+        end
+
+        # Override {#log_timepoints?} as configured in app.yml
+        attr_writer :log_timepoints
+
         # @!method development_mode?
         #
         # Whether the app should run in development mode
@@ -946,7 +962,7 @@ module Roby
             logfile_path = File.join(log_dir, "#{robot_name}-events.log")
             event_io = File.open(logfile_path, "w")
             logfile = DRoby::Logfile::Writer.new(event_io, plugins: plugins.map { |n, _| n })
-            plan.event_logger = DRoby::EventLogger.new(logfile)
+            plan.event_logger = DRoby::EventLogger.new(logfile, log_timepoints: log_timepoints?)
             plan.execution_engine.event_logger = plan.event_logger
 
             Robot.info "logs are in #{log_dir}"

--- a/lib/roby/app/scripts/run.rb
+++ b/lib/roby/app/scripts/run.rb
@@ -43,6 +43,9 @@ options = OptionParser.new do |opt|
     opt.on "--no-logs", "treat the log directory as ephemeral" do
         app.public_logs = false
     end
+    opt.on "--log-timepoints", "log internal Roby timings" do
+        app.log_timepoints = true
+    end
     opt.on "--wait-shell-connection", "wait for a shell connection before running" do
         wait_shell_connection = true
     end

--- a/lib/roby/cli/gen/app/config/app.yml
+++ b/lib/roby/cli/gen/app/config/app.yml
@@ -25,6 +25,15 @@ log:
   #
   events: true
 
+  # Whether Roby's internal timepoints should be logged as well
+  #
+  # These timepoints allow to trace timing during Roby's internal processing.
+  # They do generate an order of magnitude more data than the system's events.
+  # One would enable this only to debug unexpected timing issues
+  #
+  # This value can be overriden on the "run" command line with --log-timepoints
+  timepoints: false
+
   # Logging levels.
   #
   # Logging in Roby is controlled per-module in a hierarchical way. It means that to get

--- a/lib/roby/droby/event_logging.rb
+++ b/lib/roby/droby/event_logging.rb
@@ -14,6 +14,8 @@ module Roby
 
             # Log a timepoint on the underlying logger
             def log_timepoint(name)
+                return unless event_logger.log_timepoints?
+
                 current_thread = Thread.current
                 event_logger.dump_timepoint(
                     :timepoint, Time.now,
@@ -23,6 +25,8 @@ module Roby
 
             # Run a block within a timepoint group
             def log_timepoint_group(name)
+                return yield unless event_logger.log_timepoints?
+
                 log_timepoint_group_start(name)
                 yield
             ensure
@@ -34,6 +38,8 @@ module Roby
             # The logger will NOT do any validation of the group start/end
             # pairing at logging time. This is done at replay time
             def log_timepoint_group_start(name)
+                return unless event_logger.log_timepoints?
+
                 current_thread = Thread.current
                 event_logger.dump_timepoint(
                     :timepoint_group_start, Time.now,
@@ -46,6 +52,8 @@ module Roby
             # The logger will NOT do any validation of the group start/end
             # pairing at logging time. This is done at replay time
             def log_timepoint_group_end(name)
+                return unless event_logger.log_timepoints?
+
                 current_thread = Thread.current
                 event_logger.dump_timepoint(
                     :timepoint_group_end, Time.now,

--- a/lib/roby/droby/null_event_logger.rb
+++ b/lib/roby/droby/null_event_logger.rb
@@ -3,6 +3,8 @@
 module Roby
     module DRoby
         class NullEventLogger
+            def log_timepoints?; end
+
             def dump(m, time, *args); end
 
             def dump_timepoint(m, time, *args); end


### PR DESCRIPTION
I started wondering why connecting to a running system was
simply **so slow**. It was always painfully slow, but I felt
it became a lot worse.

Turns out that timepoint logging, a feature that has been added
a few years back, is actually very verbose (timepoints have long
names, which are repeated sometimes multiple times per cycle). On
our systems, timepoints were by far the biggest part of an event log,
causing logs that should be in the hundred of MB to be multiple GBs.

This commit disables them by default - even I use them only in very
specific cases - and allow to re-enable them both through app.yml
and via the command line.