### PR TITLE
test: add missing definition for log_timepoints? in the test event reporter

### DIFF
--- a/lib/roby/test/event_reporter.rb
+++ b/lib/roby/test/event_reporter.rb
@@ -9,12 +9,17 @@ module Roby
 
             attr_reader :received_events
 
-            def initialize(io, enabled: false)
+            def initialize(io, enabled: false, log_timepoints: false)
                 @io = io
                 @enabled = enabled
                 @filters = []
                 @filters_out = []
                 @received_events = []
+                @log_timepoints = log_timepoints
+            end
+
+            def log_timepoints?
+                @log_timepoints
             end
 
             def dump_time


### PR DESCRIPTION
Turns out I didn't check the state of CI before merging #187. Sorry.