### PR TITLE
improve "configurability" of Interface::REST server and task

### DIFF
--- a/lib/roby/interface/rest/server.rb
+++ b/lib/roby/interface/rest/server.rb
@@ -41,6 +41,7 @@ module Roby
                                port: Roby::Interface::DEFAULT_REST_PORT,
                                api: REST::API,
                                main_route: "/api",
+                               middlewares: [Rack::CommonLogger, Rack::ShowExceptions],
                                **thin_options)
 
                     @app = app
@@ -54,8 +55,7 @@ module Roby
                         yield(self) if block_given?
 
                         map main_route do
-                            use Rack::CommonLogger
-                            use Rack::ShowExceptions
+                            middlewares.each { |m| use m }
                             run api
                         end
                     end

--- a/lib/roby/interface/rest/server.rb
+++ b/lib/roby/interface/rest/server.rb
@@ -41,6 +41,7 @@ module Roby
                                port: Roby::Interface::DEFAULT_REST_PORT,
                                api: REST::API,
                                main_route: "/api",
+                               storage: {},
                                middlewares: [Rack::CommonLogger, Rack::ShowExceptions],
                                **thin_options)
 
@@ -50,7 +51,9 @@ module Roby
                     @interface = Interface.new(app)
                     @wait_start = Concurrent::IVar.new
 
-                    api = self.class.attach_api_to_interface(api, @interface)
+                    api = self.class.attach_api_to_interface(
+                        api, @interface, storage
+                    )
                     rack_app = Rack::Builder.new do
                         yield(self) if block_given?
 

--- a/lib/roby/interface/rest/task.rb
+++ b/lib/roby/interface/rest/task.rb
@@ -24,14 +24,21 @@ module Roby
                 # Default is '/api'
                 argument :main_route, default: "/api"
 
+                # Whether all requests are to be displayed
+                argument :verbose, default: false
+
                 event :start do |_event|
-                    @rest_server = Server.new(
-                        roby_app, host: host, port: port,
-                                  main_route: main_route, api: rest_api
-                    )
+                    @rest_server = Server.new(roby_app, **rest_server_args)
                     start_event.achieve_asynchronously do
                         @rest_server.start
                     end
+                end
+
+                def rest_server_args
+                    base_args = { host: host, port: port,
+                                  main_route: main_route, api: rest_api }
+                    base_args[:middlewares] = [] unless verbose
+                    base_args
                 end
 
                 # The Roby app that is being exposed

--- a/test/interface/rest/test_server.rb
+++ b/test/interface/rest/test_server.rb
@@ -56,6 +56,24 @@ module Roby
                     end
                 end
 
+                it "makes available the storage argument as roby_storage in the API" do
+                    api = Class.new(Grape::API) do
+                        mount API
+                        helpers Helpers
+
+                        get "/storage_value" do
+                            roby_storage[:test_storage_value]
+                        end
+                    end
+                    storage = { test_storage_value: 10 }
+                    @server = REST::Server.new(@app, port: 0, api: api, storage: storage)
+                    @server.start
+
+                    assert_equal "10", RestClient.get(
+                        "http://127.0.0.1:#{@server.port}/api/storage_value"
+                    )
+                end
+
                 describe "over TCP" do
                     describe "a given port of zero" do
                         before do


### PR DESCRIPTION
- this commit disables the logging and error reporting middlewares by default. They are
  very VERY noisy - to the point of unusability - in polling situations
- it allows the caller to inject a storage object (to handle roby_storage), which allows to
  initialize the API locally with some values coming from e.g. arguments instead of having
  to get everything from globals