### PR TITLE
core: remove duplicate tags when merging fullfilled models

### DIFF
--- a/lib/roby/task_structure/dependency.rb
+++ b/lib/roby/task_structure/dependency.rb
@@ -70,6 +70,7 @@ module Roby
                         raise Roby::ModelViolation, "inconsistency in fullfilled models: #{model} and #{m} are incompatible"
                     end
                 end
+                tags.uniq!
 
                 arguments = arguments.merge(required_arguments) do |name, old, new|
                     if old != new

--- a/test/task_structure/test_dependency.rb
+++ b/test/task_structure/test_dependency.rb
@@ -602,6 +602,11 @@ module Roby
                     merged = Dependency.merge_fullfilled_model(target, [source_tag_m], Hash[arg1: 20])
                     assert_equal [target_tag_m, source_tag_m], merged[1]
                 end
+                it "removes duplicate tags" do
+                    target = [task_m, [target_tag_m], Hash[arg0: 10]]
+                    merged = Dependency.merge_fullfilled_model(target, [target_tag_m], Hash[arg1: 20])
+                    assert_equal [target_tag_m], merged[1]
+                end
                 it "merges the arguments" do
                     target = [task_m, [target_tag_m], Hash[arg0: 10]]
                     merged = Dependency.merge_fullfilled_model(target, [source_tag_m], Hash[arg1: 20])


### PR DESCRIPTION
I hit a bug where two Syskit components would get merged in a way that
the same fullfilled model, which had tags, was merged over and
over again. Exponentials ... Who does not like those ?

Anyways, the tag list is supposed to be small, so I preferred
keeping the array and calling uniq! afterwards on it