### PR TITLE
droby: separate log reading/writing code into reusable bits

### DIFF
--- a/lib/roby/droby/logfile.rb
+++ b/lib/roby/droby/logfile.rb
@@ -138,6 +138,27 @@ module Roby
 
                 buffer
             end
+
+            # Decode a chunk loaded with {.read_one_chunk}
+            def self.decode_one_chunk(chunk)
+                begin ::Marshal.load_with_missing_constants(chunk)
+                rescue ArgumentError => e
+                    if e.message == "marshal data too short"
+                        raise TruncatedFileError, "marshal data invalid"
+                    end
+
+                    raise
+                end
+            rescue Exception => e # rubocop:disable Lint/RescueException
+                raise e, "#{e.message}, running roby-log repair "\
+                         "might repair the file", e.backtrace
+            end
+
+            # Write a single entry in the log file
+            def self.write_entry(io, chunk)
+                io.write([chunk.size].pack("L<"))
+                io.write chunk
+            end
         end
     end
 end

--- a/lib/roby/droby/logfile/reader.rb
+++ b/lib/roby/droby/logfile/reader.rb
@@ -57,19 +57,18 @@ module Roby
                     event_io.seek(pos)
                 end
 
+                def read_one_chunk
+                    Logfile.read_one_chunk(event_io)
+                end
+
+                def decode_one_chunk(chunk)
+                    Logfile.decode_one_chunk(chunk)
+                end
+
                 def load_one_cycle
-                    return unless (chunk = Logfile.read_one_chunk(event_io))
+                    return unless (chunk = read_one_chunk)
 
-                    begin ::Marshal.load_with_missing_constants(chunk)
-                    rescue ArgumentError => e
-                        if e.message == "marshal data too short"
-                            raise TruncatedFileError, "marshal data invalid"
-                        end
-
-                        raise
-                    end
-                rescue Exception => e
-                    raise e, "#{e.message}, running roby-log repair might repair the file", e.backtrace
+                    decode_one_chunk(chunk)
                 end
 
                 def self.process_options_hash(options_hash)


### PR DESCRIPTION
This is to be used for log management/processing (e.g. repairing
truncated logs)