### PR TITLE
cli: fix 'shell' when under the irb gem

### DIFF
--- a/lib/roby/app/scripts/shell.rb
+++ b/lib/roby/app/scripts/shell.rb
@@ -3,6 +3,7 @@
 require "roby"
 require "optparse"
 require "rb-readline"
+require "readline"
 
 app = Roby.app
 app.guess_app_dir

--- a/lib/roby/app/scripts/shell.rb
+++ b/lib/roby/app/scripts/shell.rb
@@ -104,9 +104,7 @@ Readline.completion_proc = lambda do |string|
     return []
 end
 
-class ShellEvalContext < BasicObject
-    include ::Kernel
-
+class ShellEvalContext
     WHITELISTED_METHODS = %i[actions wtf? cancel safe unsafe safe? help]
         .freeze
 
@@ -158,7 +156,7 @@ end
 begin
     # Make main_remote_interface__ the top-level object
     shell_context__ = ShellEvalContext.new(main_remote_interface__)
-    ws = IRB::WorkSpace.new(shell_context__.instance_eval { binding })
+    ws = IRB::WorkSpace.new(shell_context__)
     irb = IRB::Irb.new(ws)
 
     output_sync = Mutex.new

--- a/lib/roby/test/aruba_minitest.rb
+++ b/lib/roby/test/aruba_minitest.rb
@@ -76,7 +76,9 @@ module Roby
             end
 
             def assert_command_finished_successfully(cmd)
-                refute cmd.timed_out?, "#{cmd} timed out on stop"
+                refute cmd.timed_out?,
+                       "#{cmd} timed out on stop\n-- STDOUT\n#{cmd.stdout}\n"\
+                       "STDERR\n#{cmd.stderr}"
                 assert_equal 0, cmd.exit_status,
                              "#{cmd} finished with a non-zero exit status "\
                              "(#{cmd.exit_status})\n-- STDOUT\n#{cmd.stdout}\n"\

--- a/test/cli/test_main.rb
+++ b/test/cli/test_main.rb
@@ -122,9 +122,9 @@ module Roby
                     run_cmd = run_roby "run --port 9999"
                     shell_cmd = run_roby "shell --host localhost:9999"
                     shell_cmd.write "quit\n"
-                    assert_command_stops run_cmd
                     shell_cmd.write "exit\n"
                     assert_command_stops shell_cmd
+                    assert_command_stops run_cmd
                 end
             end
         end


### PR DESCRIPTION
Shell-related test started failing in CI because Readline was not defined. It turned out that the shell was not compatible with the gemified irb, which was pulled in some workspaces by iruby.

This pull request fixes the problems related to this interdependency.
