### PR TITLE
test: define UnexpectedErrors#each_execution_exception

### DIFF
--- a/lib/roby/test/execution_expectations.rb
+++ b/lib/roby/test/execution_expectations.rb
@@ -374,6 +374,14 @@ module Roby
                     @errors = errors
                 end
 
+                def each_execution_exception
+                    return enum_for(__method__) unless block_given?
+
+                    @errors.each do |e|
+                        yield(e) if e.kind_of?(ExecutionException)
+                    end
+                end
+
                 def each_original_exception
                     return enum_for(__method__) unless block_given?
 


### PR DESCRIPTION
While #each_original_exception allowed to find the Exception subclasses,
we had no way to check the ExecutionException objects (to e.g. look
at the trace or origin of an error).