### PR TITLE
rework how quarantined tasks are handled

### DIFF
--- a/lib/roby/event_generator.rb
+++ b/lib/roby/event_generator.rb
@@ -500,6 +500,12 @@ module Roby
             self
         end
 
+        # Tests whether self is forwarded to the given generator
+        def forwarded_to?(generator)
+            plan.event_relation_graph_for(EventStructure::Forwarding)
+                .has_edge?(self, generator)
+        end
+
         # Returns an event which is emitted +seconds+ seconds after this one
         def delay(seconds)
             if seconds == 0 then self

--- a/lib/roby/executable_plan.rb
+++ b/lib/roby/executable_plan.rb
@@ -48,6 +48,7 @@ module Roby
             super(graph_observer: self, event_logger: event_logger)
 
             @execution_engine = ExecutionEngine.new(self)
+            @quarantined_tasks = Set.new
             @force_gc = Set.new
             @exception_handlers = []
             on_exception LocalizedError do |plan, error|
@@ -55,27 +56,22 @@ module Roby
             end
         end
 
-        # @api private
+        # Set of running tasks that are in quarantine
         #
-        # Put the given task in quarantine. In practice, it means that all the
-        # event relations of that task's events are removed, as well as its
-        # children. Then, the task is marked as quarantined with
-        # {Task#quarantined?} and the engine will not attempt to garbage-collect
-        # it anymore
-        #
-        # This is used as a last resort, when the task cannot be stopped/GCed by
-        # normal means.
-        def quarantine_task(task)
-            task.quarantined!
+        # @return [Set<Task>]
+        attr_reader :quarantined_tasks
+
+        # (see Task#quarantined!)
+        def quarantine_task(task, reason: nil)
+            task.quarantined!(reason: reason)
         end
 
         # @api private
         #
-        # Actually put the task in quarantine. This is used for symmetry between
-        # {Task#quarantine!} and {#quarantine_task}
-        def handle_quarantined_task(task)
+        # Helper to {#quaratine_task}
+        def register_quarantined_task(task)
             log(:quarantined_task, droby_id, task)
-            task.clear_relations(remove_internal: false, remove_strong: false)
+            @quarantined_tasks << task
         end
 
         # Check that this is an executable plan
@@ -143,6 +139,40 @@ module Roby
                     end
                 end
             end
+        end
+
+        def check_structure
+            super.merge(check_quarantined_tasks_in_use)
+        end
+
+        # @api private
+        #
+        # Look for quarantined tasks that are still in use
+        def check_quarantined_tasks_in_use
+            @quarantined_tasks.each_with_object({}) do |task, result|
+                if quarantined_task_in_use?(task)
+                    error = QuarantinedTaskError.new(task)
+                    result[error.to_execution_exception] = nil
+                end
+            end
+        end
+
+        # Check whether the given quarantined task is in use
+        #
+        # It is used to determine whether a {QuarantinedTaskError} should be
+        # generated
+        #
+        # @param [Task] task a quarantined task
+        def quarantined_task_in_use?(task)
+            return true if mission_task?(task) || permanent_task?(task)
+
+            default_useful_task_graphs.each do |g|
+                g.each_in_neighbour(task) do |parent_t|
+                    return true unless parent_t.finished? || parent_t.quarantined?
+                end
+            end
+
+            false
         end
 
         # Calls the given block in the execution thread of this plan's engine.
@@ -531,13 +561,16 @@ module Roby
             end
 
             super
+
             @force_gc.delete(object)
+            @quarantined_tasks.delete(object)
         end
 
         # Clear the plan
         def clear
             super
             @force_gc.clear
+            @quarantined_tasks.clear
         end
 
         # Replace +task+ with a fresh copy of itself and start it.

--- a/lib/roby/executable_plan.rb
+++ b/lib/roby/executable_plan.rb
@@ -66,11 +66,16 @@ module Roby
         # This is used as a last resort, when the task cannot be stopped/GCed by
         # normal means.
         def quarantine_task(task)
-            log(:quarantined_task, droby_id, task)
-
             task.quarantined!
+        end
+
+        # @api private
+        #
+        # Actually put the task in quarantine. This is used for symmetry between
+        # {Task#quarantine!} and {#quarantine_task}
+        def handle_quarantined_task(task)
+            log(:quarantined_task, droby_id, task)
             task.clear_relations(remove_internal: false, remove_strong: false)
-            self
         end
 
         # Check that this is an executable plan

--- a/lib/roby/execution_engine.rb
+++ b/lib/roby/execution_engine.rb
@@ -2293,80 +2293,44 @@ module Roby
         # loop can forcefully quit
         INTERRUPT_FORCE_EXIT_DEAD_ZONE = 10
 
+        EventLoopExitState = Struct.new(
+            :last_stop_count, :last_quit_warning, :force_exit_deadline
+        )
+
         # The main event loop. It returns when the execution engine is asked to
         # quit. In general, this does not need to be called direclty: use #run
         # to start the event loop in a separate thread.
         def event_loop
-            last_stop_count = 0
-            last_quit_warning = Time.now
             @cycle_start = Time.now
             @cycle_index = 0
 
-            force_exit_deadline = nil
-
+            exit_state = EventLoopExitState.new(0, Time.now, nil)
             loop do
-                begin
-                    if profile_gc?
-                        GC::Profiler.enable
-                    end
+                GC::Profiler.enable if profile_gc?
 
-                    if quitting?
-                        if forced_exit?
-                            return
-                        end
+                if quitting?
+                    return if forced_exit?
+                    return if event_loop_teardown(exit_state)
+                end
 
-                        begin
-                            remaining = clear
-                            return unless remaining
+                log_timepoint_group "cycle" do
+                    execute_one_cycle
+                end
 
-                            if (last_stop_count != remaining.size) || (Time.now - last_quit_warning) > 10
-                                if last_stop_count == 0
-                                    info "Roby quitting ..."
-                                end
+                GC::Profiler.disable if profile_gc?
+            rescue Interrupt
+                event_loop_handle_interrupt(exit_state)
+            rescue Exception => e
+                if quitting?
+                    fatal "Execution thread FORCEFULLY quitting "\
+                          "because of unhandled exception"
+                    Roby.log_exception_with_backtrace(e, self, :fatal)
+                    raise
+                else
+                    quit
 
-                                issue_quit_progression_warning(remaining)
-                                last_quit_warning = Time.now
-                                last_stop_count = remaining.size
-                            end
-                        rescue Exception => e
-                            warn "Execution thread failed to clean up"
-                            Roby.log_exception_with_backtrace(e, self, :warn, filter: false)
-                            return
-                        end
-                    end
-
-                    log_timepoint_group "cycle" do
-                        execute_one_cycle
-                    end
-
-                    if profile_gc?
-                        GC::Profiler.disable
-                    end
-                rescue Exception => e
-                    if e.kind_of?(Interrupt)
-                        if quitting?
-                            if force_exit_deadline && (force_exit_deadline - Time.now) < 0
-                                fatal "Quitting without cleaning up"
-                                force_quit
-                            else
-                                fatal "Still #{Integer(force_exit_deadline - Time.now)}s before interruption will quit without cleaning up"
-                            end
-                        else
-                            fatal "Received interruption request"
-                            fatal "Interrupt again in #{INTERRUPT_FORCE_EXIT_DEAD_ZONE}s to quit without cleaning up"
-                            quit
-                            force_exit_deadline = Time.now + INTERRUPT_FORCE_EXIT_DEAD_ZONE
-                        end
-                    elsif !quitting?
-                        quit
-
-                        fatal "Execution thread quitting because of unhandled exception"
-                        Roby.log_exception_with_backtrace(e, self, :fatal)
-                    else
-                        fatal "Execution thread FORCEFULLY quitting because of unhandled exception"
-                        Roby.log_exception_with_backtrace(e, self, :fatal)
-                        raise
-                    end
+                    fatal "Execution thread quitting because of unhandled exception"
+                    Roby.log_exception_with_backtrace(e, self, :fatal)
                 end
             end
         ensure
@@ -2375,6 +2339,57 @@ module Roby
                 plan.tasks.each do |t|
                     warn "  #{t}"
                 end
+            end
+        end
+
+        # @api private
+        #
+        # Handle the teardown logic for {#event_loop}
+        #
+        # @return [Boolean] whether {#event_loop} can stop now (true), or not (false)
+        def event_loop_teardown(exit_state)
+            return true unless (remaining = clear)
+
+            display_warning = (exit_state.last_stop_count != remaining.size) ||
+                              (Time.now - exit_state.last_quit_warning) > 10
+            return unless display_warning
+
+            if display_warning
+                info "Roby quitting ..." if exit_state.last_stop_count == 0
+
+                issue_quit_progression_warning(remaining)
+                exit_state.last_quit_warning = Time.now
+                exit_state.last_stop_count = remaining.size
+            end
+            false
+        rescue Exception => e
+            warn "Execution thread failed to clean up"
+            Roby.log_exception_with_backtrace(e, self, :warn, filter: false)
+            true
+        end
+
+        # @api private
+        #
+        # Handle a received Interrupt for {#event_loop}
+        def event_loop_handle_interrupt(exit_state)
+            if quitting?
+                exit_state.force_exit_deadline ||=
+                    Time.now + INTERRUPT_FORCE_EXIT_DEADLINE
+                time_until_deadline = exit_state.force_exit_deadline - Time.now
+                if time_until_deadline < 0
+                    fatal "Quitting without cleaning up"
+                    force_quit
+                else
+                    fatal "Still #{time_until_deadline.ceil}s before "\
+                          "interruption will quit without cleaning up"
+                end
+            else
+                fatal "Received interruption request"
+                fatal "Interrupt again in #{INTERRUPT_FORCE_EXIT_DEAD_ZONE}s "\
+                      "to quit without cleaning up"
+                quit
+                exit_state.force_exit_deadline =
+                    Time.now + INTERRUPT_FORCE_EXIT_DEAD_ZONE
             end
         end
 

--- a/lib/roby/plan.rb
+++ b/lib/roby/plan.rb
@@ -1285,18 +1285,6 @@ module Roby
             task_index.self_owned
         end
 
-        def quarantined_tasks
-            tasks.find_all(&:quarantined?)
-        end
-
-        # @api private
-        #
-        # Actually put the task in quarantine. This is used for symmetry between
-        # {Task#quarantine!} and {#quarantine_task}
-        def handle_quarantined_task(task)
-            task.quarantined!
-        end
-
         def remote_tasks
             if (local_tasks = task_index.self_owned)
                 tasks - local_tasks

--- a/lib/roby/plan.rb
+++ b/lib/roby/plan.rb
@@ -1289,6 +1289,14 @@ module Roby
             tasks.find_all(&:quarantined?)
         end
 
+        # @api private
+        #
+        # Actually put the task in quarantine. This is used for symmetry between
+        # {Task#quarantine!} and {#quarantine_task}
+        def handle_quarantined_task(task)
+            task.quarantined!
+        end
+
         def remote_tasks
             if (local_tasks = task_index.self_owned)
                 tasks - local_tasks

--- a/lib/roby/standard_errors.rb
+++ b/lib/roby/standard_errors.rb
@@ -241,6 +241,30 @@ module Roby
         end
     end
 
+    # Raised when an error occurs on a task while we were terminating it
+    class QuarantinedTaskError < LocalizedError
+        attr_reader :reason
+
+        def initialize(task)
+            super(task)
+
+            @reason = task.quarantine_reason
+            report_exceptions_from(reason)
+        end
+
+        def pretty_print(pp)
+            pp.text "The following task has been put in quarantine"
+            pp.breakable
+
+            super
+            pp.breakable
+
+            unless original_exceptions.include?(reason)
+                reason.pretty_print(pp)
+            end
+        end
+    end
+
     # Raised when an operation is attempted while the ownership does not allow
     # it.
     class OwnershipError < RuntimeError; end

--- a/lib/roby/task.rb
+++ b/lib/roby/task.rb
@@ -548,7 +548,10 @@ module Roby
         #
         # Once set it cannot be unset
         def quarantined!
+            return if quarantined?
+
             @quarantined = true
+            plan&.handle_quarantined_task(self)
         end
 
         def failed_to_start?

--- a/test/test_event_generator.rb
+++ b/test/test_event_generator.rb
@@ -1362,18 +1362,27 @@ module Roby
                 @context = flexmock
                 plan.add(source)
                 flexmock(execution_engine)
-                execution_engine.should_receive(:queue_forward).once
-                    .with([], source, [context], nil).pass_thru
             end
             it "queues the target emission when the source emits" do
                 target = EventGenerator.new
                 source.forward_to target
+                execution_engine.should_receive(:queue_forward).once
+                    .with([], source, [context], nil).pass_thru
                 execution_engine.should_receive(:queue_forward).once
                     .with(->(sources) { sources == [source.last] }, target, [context], nil)
                     .pass_thru
                 event = expect_execution { source.emit(context) }
                     .to { emit target }
                 assert_equal source.last.context, event.context
+            end
+            it "returns true in forwarded_to?" do
+                target = EventGenerator.new
+                source.forward_to target
+                assert source.forwarded_to?(target)
+            end
+            it "returns true in forwarded_to? for unrelated events" do
+                target = EventGenerator.new
+                refute source.forwarded_to?(target)
             end
         end
 

--- a/test/test_executable_plan.rb
+++ b/test/test_executable_plan.rb
@@ -247,15 +247,8 @@ module Roby
                 plan.quarantine_task(task)
                 assert task.quarantined?
             end
-            it "removes all non-strong task relations and all external event relations" do
-                task.should_receive(:clear_relations)
-                    .with(remove_internal: false, remove_strong: false).once
-                plan.quarantine_task(task)
-            end
             it "is symmetric with Task#quarantined!" do
                 assert_logs_event(:quarantined_task, plan.droby_id, task)
-                task.should_receive(:clear_relations)
-                    .with(remove_internal: false, remove_strong: false).once
                 task.quarantined!
                 assert_includes plan.quarantined_tasks, task
                 assert task.quarantined?
@@ -343,6 +336,28 @@ module Roby
                         end
                     end
                 end
+            end
+        end
+
+        describe "#remove_task" do
+            it "removes the task" do # just make sure we actually call super ...
+                plan.add(task = Roby::Task.new)
+                execute { plan.remove_task(task) }
+                refute plan.has_task?(task)
+            end
+
+            it "removes the task from the force_gc set" do
+                plan.add(task = Roby::Task.new)
+                execute { plan.execution_engine.garbage_collect([task]) }
+                refute plan.has_task?(task)
+                refute plan.force_gc.include?(task)
+            end
+
+            it "removes the task from the quarantined set" do
+                plan.add(task = Roby::Task.new)
+                task.quarantined!
+                execute { plan.remove_task(task) }
+                refute plan.quarantined_tasks.include?(task)
             end
         end
 

--- a/test/test_executable_plan.rb
+++ b/test/test_executable_plan.rb
@@ -239,13 +239,26 @@ module Roby
                 assert_logs_event(:quarantined_task, plan.droby_id, task)
                 plan.quarantine_task(task)
             end
+            it "adds the task to the quarantined task set" do
+                plan.quarantine_task(task)
+                assert_includes plan.quarantined_tasks, task
+            end
             it "marks the task as quarantined" do
                 plan.quarantine_task(task)
                 assert task.quarantined?
             end
             it "removes all non-strong task relations and all external event relations" do
-                task.should_receive(:clear_relations).with(remove_internal: false, remove_strong: false).once
+                task.should_receive(:clear_relations)
+                    .with(remove_internal: false, remove_strong: false).once
                 plan.quarantine_task(task)
+            end
+            it "is symmetric with Task#quarantined!" do
+                assert_logs_event(:quarantined_task, plan.droby_id, task)
+                task.should_receive(:clear_relations)
+                    .with(remove_internal: false, remove_strong: false).once
+                task.quarantined!
+                assert_includes plan.quarantined_tasks, task
+                assert task.quarantined?
             end
         end
 

--- a/test/test_task.rb
+++ b/test/test_task.rb
@@ -1205,6 +1205,16 @@ module Roby
                     assert strong_graph.has_edge?(task.start_event, ev)
                     assert strong_graph.has_edge?(ev, task.stop_event)
                 end
+                it "keeps event relations between the tasks that are strongly related" do
+                    agent_m = Roby::Task.new_submodel { event :ready }
+                    task.executed_by(agent = agent_m.new)
+                    task.start_event.forward_to agent.start_event
+                    agent.stop_event.forward_to task.stop_event
+                    refute task.clear_relations(remove_internal: false, remove_strong: false)
+
+                    assert task.start_event.forwarded_to?(agent.start_event)
+                    assert agent.stop_event.forwarded_to?(task.stop_event)
+                end
                 it "removes strong relations with remove_strong: true" do
                     strong_graph.add_edge(task.start_event, ev, nil)
                     strong_graph.add_edge(ev, task.stop_event, nil)
@@ -1213,6 +1223,7 @@ module Roby
                     refute strong_graph.has_edge?(ev, task.stop_event)
                 end
             end
+
             describe "remove_internal: true" do
                 it "clears both internal and external relations involving the task's events" do
                     plan.add(ev = Roby::EventGenerator.new)


### PR DESCRIPTION
The quarantine code was a very old concept, that never really got
overhauled. It's trying to handle one of the dark alleys of state
management: what to do when tasks don't want to get stopped (or,
even worse, fail to).

When mapping an external process to a Roby task, it was also meant
to map the "I don't know what's the state of the remote process
anymore" situation. I.e. what to do when things go _really_ wrong.

The (really old) reaction was to isolate the task and let it be.
Turns out that by removing its relationships, we also remove the
ability for   Roby to figure out that something is wrong (since
we removed the dependencies). This is fine as long as the quarantine
was the byproduct of the GC process (the I can't stop / I don't want
to stop) when figured out by the garbage collection.

But the "I got an exception but I failed to stop" or "I can't read
the state of this external process" situations need to also cleanup
whatever depend on the task at fault. Which is usually handled by
an error.

This commit changes the quarantine process to:
- generate an error (QuarantinedTaskError) to cleanup whatever
  is using it
- keep relations until they are cleaned up by the GC
- the GC still leaves quarantined tasks alone (does not try to
  automatically stop them)

Overall, this should play a lot better with recovery mechanisms, which
can figure out the best way to handle the rest (Syskit may for instance
try to restart the component's deployment)

