### PR TITLE
test: export 'cycle_index' in the stats of logs generated by the droby helpers

### DIFF
--- a/lib/roby/test/droby_log_helpers.rb
+++ b/lib/roby/test/droby_log_helpers.rb
@@ -36,6 +36,7 @@ module Roby
                 logfile = DRoby::Logfile::Writer.new(io)
                 @__event_logger = DRoby::EventLogger.new(logfile)
                 @__cycle_start = Time.now
+                @__cycle_index = 0
 
                 return @__event_logger unless block_given?
 
@@ -79,7 +80,8 @@ module Roby
                 @__event_logger.flush_cycle(
                     :cycle_end, t,
                     [{ start: [@__cycle_start.tv_sec, @__cycle_start.tv_usec],
-                       end: (t - @__cycle_start) }]
+                       end: (t - @__cycle_start),
+                       cycle_index: (@__cycle_index += 1) }]
                 )
 
                 @__cycle_start = t


### PR DESCRIPTION
Those are used to test some log processing scripts, and the scripts
now need the index.