### PR TITLE
feat(app): define the ignore_errors_from predicate

### DIFF
--- a/lib/roby/test/execution_expectations.rb
+++ b/lib/roby/test/execution_expectations.rb
@@ -1005,6 +1005,13 @@ module Roby
                     @task.quarantined?
                 end
 
+                def relates_to_error?(execution_exception)
+                    return unless execution_exception.originates_from?(@task)
+
+                    Roby.flatten_exception(execution_exception.exception)
+                        .any? { |e| e.kind_of?(QuarantinedTaskError) }
+                end
+
                 def to_s
                     "#{@task} should be quarantined"
                 end

--- a/test/test/test_execution_expectations.rb
+++ b/test/test/test_execution_expectations.rb
@@ -771,6 +771,25 @@ module Roby
                         end
                     end
                 end
+
+                describe "#quarantine" do
+                    it "matches if the task is quarantined" do
+                        plan.add(task = Roby::Task.new)
+                        expect_execution { task.quarantined! }.to { quarantine(task) }
+                    end
+
+                    it "fails if the task is not quarantined" do
+                        plan.add(task = Roby::Task.new)
+                        assert_raises(ExecutionExpectations::Unmet) do
+                            expect_execution.timeout(0.1).to { quarantine(task) }
+                        end
+                    end
+
+                    it "ignores the QuarantinedTaskError" do
+                        plan.add_mission_task(task = Roby::Task.new)
+                        expect_execution { task.quarantined! }.to { quarantine(task) }
+                    end
+                end
             end
 
             describe "#execute" do

--- a/test/test/test_execution_expectations.rb
+++ b/test/test/test_execution_expectations.rb
@@ -790,6 +790,26 @@ module Roby
                         expect_execution { task.quarantined! }.to { quarantine(task) }
                     end
                 end
+
+                describe "#ignore_errors_from" do
+                    it "passes if the predicate matches" do
+                        plan.add(task = Roby::Task.new)
+                        expect_execution { task.start! }
+                            .to { ignore_errors_from emit(task.start_event) }
+                    end
+
+                    it "does not require the predicate to match" do
+                        plan.add(task = Roby::Task.new)
+                        expect_execution.to { ignore_errors_from emit(task.start_event) }
+                    end
+
+                    it "ignores errors related to the predicate" do
+                        plan.add_mission_task(task = Roby::Task.new)
+                        expect_execution { task.quarantined! }.to do
+                            ignore_errors_from quarantine(task)
+                        end
+                    end
+                end
             end
 
             describe "#execute" do


### PR DESCRIPTION
Some tests may generate some side-effects that are not strictly part
of the test, but do trigger the unexpected error checks in the test
harness.

If these side-effects are permanent, one can add the matching predicate
to the expectations. However, it may also be the byproduct of a race,
in which case it may or may not happen.

The `ignore_errors_from` predicate makes sure that the expectations
do not generate these unexpected errors, while still not demanding
that the predicate matches.

For instance, some Syskit tests check the runtime behavior of killing
the deployment while a long remote call is in progress. This must always
produce the aborted_event emission (which we test for), but also -
depending on timing - may raise ComError at the point of call *before*
aborted is emitted, which leads to the task being put in quarantine.

The side effect (quarantine) creates an unexpected error
(QuarantinedTaskError). This can be ignored with

    ignore_errors_from quarantine(task)

