### PR TITLE
Prepare for rubocop 1.0

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -27,7 +27,7 @@ def minitest_set_options(test_task, name)
         if minitest_options.empty?
             ""
         else
-            "\"" + minitest_options.join("\" \"") + "\""
+            "\"#{minitest_options.join('" "')}\""
         end
     test_task.options = "#{TESTOPTS} #{minitest_args} -- --simplecov-name=#{name}"
 end
@@ -97,7 +97,7 @@ task :uic do
 
     failed = false
     UIFILES.each do |file|
-        file = "lib/roby/" + file
+        file = "lib/roby/#{file}"
         unless system(rbuic, "-o", file.gsub(/\.ui$/, "_ui.rb"), file)
             STDERR.puts "Failed to generate #{file}"
             failed = true

--- a/benchmark/relations/graph.rb
+++ b/benchmark/relations/graph.rb
@@ -12,6 +12,7 @@ class Vertex
     include Roby::Relations::DirectedRelationSupport
 
     attr_reader :relation_graphs
+
     def initialize(graph)
         @relation_graphs = Hash[graph => graph, graph.class => graph]
     end

--- a/benchmark/ruby/yield_vs_block.rb
+++ b/benchmark/ruby/yield_vs_block.rb
@@ -3,7 +3,7 @@
 require "benchmark"
 
 def call_yield(enum)
-    enum.each { |v| yield(v) }
+    enum.each { |v| yield(v) } # rubocop:disable Style/ExplicitBlockArgument
 end
 
 def call_block(enum, &block)

--- a/lib/roby/actions/models/action.rb
+++ b/lib/roby/actions/models/action.rb
@@ -28,6 +28,7 @@ module Roby
                 #
                 # @return [Array<Argument>]
                 attr_reader :arguments
+
                 # If true, the method is flagged as advanced. I.e., it won't be
                 # listed by default in the shell when the 'actions' command is
                 # called

--- a/lib/roby/actions/models/method_action.rb
+++ b/lib/roby/actions/models/method_action.rb
@@ -10,6 +10,8 @@ module Roby
                 class InvalidReturnedType < RuntimeError
                     def initialize(action_interface_model, method_name,
                         returned_task, expected_type)
+                        super()
+
                         @action_interface_model = action_interface_model
                         @method_name = method_name
                         @returned_task = returned_task

--- a/lib/roby/app/cucumber/helpers.rb
+++ b/lib/roby/app/cucumber/helpers.rb
@@ -184,7 +184,7 @@ module Roby
                     else
                         reference.each do |key|
                             is_numeric = Float(arg_value) rescue nil
-                            nest unless (expectation = expected[key])
+                            next unless (expectation = expected[key])
 
                             msg = if is_numeric
                                       "but it got no unit"
@@ -283,7 +283,7 @@ module Roby
             #
             # @return [(Numeric,String),nil]
             def self.try_numerical_value_with_unit(string)
-                m = /^(-?\.\d+|-?\d+(?:\.\d+)?)([^\d\.]\w*)$/.match(string)
+                m = /^(-?\.\d+|-?\d+(?:\.\d+)?)([^\d.]\w*)$/.match(string)
                 [Float(m[1]), m[2]] if m
             end
 
@@ -294,19 +294,20 @@ module Roby
             #
             # @raise InvalidUnit if the unit parameter is unknown
             def self.apply_unit(value, unit)
-                if unit == "deg"
+                case unit
+                when "deg"
                     value * Math::PI / 180
-                elsif unit == "m"
+                when "m"
                     value
-                elsif unit == "h"
+                when "h"
                     value * 3600
-                elsif unit == "min"
+                when "min"
                     value * 60
-                elsif unit == "s"
+                when "s"
                     value
                 else
                     raise InvalidUnit,
-                          'unknown unit #{unit}, known units are deg, m (meters), '\
+                          "unknown unit #{unit}, known units are deg, m (meters), "\
                           "h (hour), min (minute) and s (seconds)"
                 end
             end

--- a/lib/roby/app/cucumber/world.rb
+++ b/lib/roby/app/cucumber/world.rb
@@ -22,13 +22,11 @@ module Roby
 end
 
 After do |scenario|
-    if kind_of?(Roby::App::Cucumber::World)
-        if roby_controller.roby_running?
-            if !roby_controller.roby_connected? # failed to connect, kill forcefully
-                roby_controller.roby_kill
-            else
-                roby_controller.roby_stop
-            end
+    if kind_of?(Roby::App::Cucumber::World) && roby_controller.roby_running?
+        if roby_controller.roby_connected? # failed to connect, kill forcefully
+            roby_controller.roby_stop
+        else
+            roby_controller.roby_kill
         end
     end
 end

--- a/lib/roby/app/rake.rb
+++ b/lib/roby/app/rake.rb
@@ -193,6 +193,8 @@ module Roby
                 end
 
                 def initialize(task_name = "test", all_by_default: false)
+                    super()
+
                     @task_name = task_name
                     @app = Roby.app
                     @all_by_default = all_by_default

--- a/lib/roby/app/robot_names.rb
+++ b/lib/roby/app/robot_names.rb
@@ -12,6 +12,7 @@ module Roby
             # @return [Hash<String,String>] a set of aliases, i.e. short names
             #   for robots
             attr_reader :aliases
+
             # @return [Boolean] if true, Roby will generate an error if a
             #   non-declared robot is used. Otherwise, it will only issue a
             #   warning

--- a/lib/roby/app/scripts/run.rb
+++ b/lib/roby/app/scripts/run.rb
@@ -133,8 +133,9 @@ error = Roby.display_exception(STDERR) do
         end
 
         handler = Roby.plan.execution_engine.each_cycle(description: "roby run bootup") do
-            if wait_shell_connection
-                next if Roby.app.shell_interface.client_count(handshake: true) == 0
+            if wait_shell_connection &&
+               Roby.app.shell_interface.client_count(handshake: true) == 0
+                next
             end
 
             # Start the requested actions

--- a/lib/roby/app/test_reporter.rb
+++ b/lib/roby/app/test_reporter.rb
@@ -11,10 +11,7 @@ module Roby
         # accounts for load errors (exceptions that happen outside of minitest
         # itself) and is using DRoby's marshalling for exceptions
         class TestReporter
-            attr_reader :pid
-            attr_reader :slave_name
-            attr_reader :server
-            attr_reader :manager
+            attr_reader :pid, :slave_name, :server, :manager
 
             # Whether some failures were reported
             attr_predicate :has_failures?

--- a/lib/roby/cli/gen_main.rb
+++ b/lib/roby/cli/gen_main.rb
@@ -14,7 +14,7 @@ module Roby
 
             no_commands do
                 def template(template_path, *args, **kw)
-                    super(template_path + ".erb", *args, **kw)
+                    super("#{template_path}.erb", *args, **kw)
                 rescue Thor::Error
                     super(template_path, *args, **kw)
                 end
@@ -73,7 +73,7 @@ module Roby
                 )
 
                 template File.join("actions", "class.rb"),
-                         File.join("models", "actions", *file_name) + ".rb",
+                         "#{File.join('models', 'actions', *file_name)}.rb",
                          context: Gen.make_context("class_name" => class_name)
 
                 context = Gen.make_context(
@@ -97,7 +97,7 @@ module Roby
                 )
 
                 template File.join("class", "class.rb"),
-                         File.join("lib", Roby.app.app_name, *file_name) + ".rb",
+                         "#{File.join('lib', Roby.app.app_name, *file_name)}.rb",
                          context: Gen.make_context("class_name" => class_name)
 
                 context = Gen.make_context(
@@ -120,7 +120,7 @@ module Roby
                 )
 
                 template File.join("module", "module.rb"),
-                         File.join("lib", Roby.app.app_name, *file_name) + ".rb",
+                         "#{File.join('lib', Roby.app.app_name, *file_name)}.rb",
                          context: Gen.make_context("module_name" => class_name)
                 context = Gen.make_context(
                     "module_name" => class_name,
@@ -145,7 +145,7 @@ module Roby
                 )
 
                 template File.join("task", "class.rb"),
-                         File.join("models", "tasks", *file_name) + ".rb",
+                         "#{File.join('models', 'tasks', *file_name)}.rb",
                          context: Gen.make_context("class_name" => class_name)
                 template File.join("task", "test.rb"),
                          File.join("test", "tasks", *file_name[0..-2],
@@ -169,7 +169,7 @@ module Roby
                 )
 
                 template File.join("task_srv", "class.rb"),
-                         File.join("models", "services", *file_name) + ".rb",
+                         "#{File.join('models', 'services', *file_name)}.rb",
                          context: Gen.make_context("class_name" => class_name)
             end
         end

--- a/lib/roby/cli/log.rb
+++ b/lib/roby/cli/log.rb
@@ -73,14 +73,15 @@ module Roby
                             thread_id, thread_name, timepoint_name = *args
                             path = (current_context[thread_id] ||= [thread_name])
 
-                            if m == :timepoint
+                            case m
+                            when :timepoint
                                 puts "#{Roby.format_time(Time.at(sec, usec))} "\
                                      "#{path.join('/')}/#{timepoint_name}"
-                            elsif m == :timepoint_group_start
+                            when :timepoint_group_start
                                 puts "#{Roby.format_time(Time.at(sec, usec))} "\
                                      "#{path.join('/')}/#{timepoint_name} {"
                                 path.push timepoint_name
-                            elsif m == :timepoint_group_end
+                            when :timepoint_group_end
                                 path.pop
                                 puts "#{Roby.format_time(Time.at(sec, usec))} "\
                                      "#{path.join('/')}/#{timepoint_name} }"
@@ -98,11 +99,12 @@ module Roby
                 end
                 while data = stream.load_one_cycle
                     data.each_slice(4) do |m, sec, usec, args|
-                        if m == :timepoint
+                        case m
+                        when :timepoint
                             analyzer.add Time.at(sec, usec), *args
-                        elsif m == :timepoint_group_start
+                        when :timepoint_group_start
                             analyzer.group_start Time.at(sec, usec), *args
-                        elsif m == :timepoint_group_end
+                        when :timepoint_group_end
                             analyzer.group_end Time.at(sec, usec), *args
                         end
                     end

--- a/lib/roby/coordination/action_state_machine.rb
+++ b/lib/roby/coordination/action_state_machine.rb
@@ -123,9 +123,7 @@ module Roby
 
             def instanciate_state_transition(task, new_state)
                 remove_current_task
-                begin
-                    instanciate_state(new_state)
-                end
+                instanciate_state(new_state)
                 run_hook :on_transition, task, new_state
             end
         end

--- a/lib/roby/coordination/base.rb
+++ b/lib/roby/coordination/base.rb
@@ -134,12 +134,13 @@ module Roby
             # @param [Coordination::Models::Task] object the model-level coordination task
             # @return [Coordination::Task] object the instance-level coordination task
             def instance_for(object)
-                unless (ins = instances[object])
-                    if !parent || !(ins = parent.instances[object])
-                        ins = instances[object] = object.new(self)
-                    end
+                if (ins = instances[object])
+                    ins
+                elsif parent && (ins = parent.instances[object])
+                    ins
+                else
+                    instances[object] = object.new(self)
                 end
-                ins
             end
         end
     end

--- a/lib/roby/coordination/fault_handler.rb
+++ b/lib/roby/coordination/fault_handler.rb
@@ -7,16 +7,16 @@ module Roby
 
             def step
                 super
-                if finished?
-                    if model.carry_on?
-                        response_task = self.root_task
-                        plan = response_task.plan
-                        response_task.each_parent_object(Roby::TaskStructure::ErrorHandling) do |repaired_task|
-                            plan.replan(repaired_task)
-                        end
-                        response_task.success_event.emit
-                    end
+
+                return unless finished?
+                return unless model.carry_on?
+
+                response_task = self.root_task
+                plan = response_task.plan
+                response_task.each_parent_object(Roby::TaskStructure::ErrorHandling) do |repaired_task|
+                    plan.replan(repaired_task)
                 end
+                response_task.success_event.emit
             end
 
             def to_s

--- a/lib/roby/coordination/models/arguments.rb
+++ b/lib/roby/coordination/models/arguments.rb
@@ -34,19 +34,23 @@ module Roby
                 #   model, or if some required arguments are not set
                 def validate_arguments(arguments)
                     arguments = Kernel.normalize_options arguments
-                    arguments.keys.each do |arg_name|
+                    arguments.each_key do |arg_name|
                         unless find_argument(arg_name)
-                            raise ArgumentError, "#{arg_name} is not an argument on #{self}"
+                            raise ArgumentError,
+                                  "#{arg_name} is not an argument on #{self}"
                         end
                     end
-                    each_argument do |_, arg|
-                        unless arguments.has_key?(arg.name)
-                            if arg.required
-                                raise ArgumentError, "#{arg.name} is required by #{self}, but is not provided (given arguments: #{arguments})"
-                            end
 
-                            arguments[arg.name] = arg.default
+                    each_argument do |_, arg|
+                        next if arguments.has_key?(arg.name)
+
+                        if arg.required
+                            raise ArgumentError,
+                                  "#{arg.name} is required by #{self}, but is "\
+                                  "not provided (given arguments: #{arguments})"
                         end
+
+                        arguments[arg.name] = arg.default
                     end
                     arguments
                 end

--- a/lib/roby/coordination/models/capture.rb
+++ b/lib/roby/coordination/models/capture.rb
@@ -55,7 +55,10 @@ module Roby
                 # backing event has not yet happened
                 class Unbound < RuntimeError
                     attr_reader :capture
+
                     def initialize(capture)
+                        super()
+
                         @capture = capture
                     end
                 end

--- a/lib/roby/coordination/models/child.rb
+++ b/lib/roby/coordination/models/child.rb
@@ -9,11 +9,11 @@ module Roby
                 attr_reader :parent
                 # @return [String] the child's role, relative to its parent
                 attr_reader :role
-                # The child's model
-                attr_reader :model
 
                 def initialize(parent, role, model)
-                    @parent, @role, @model = parent, role, model
+                    super(model)
+
+                    @parent, @role = parent, role
                 end
 
                 def ==(other)

--- a/lib/roby/coordination/models/exceptions.rb
+++ b/lib/roby/coordination/models/exceptions.rb
@@ -17,6 +17,8 @@ module Roby
                 attr_reader :states
 
                 def initialize(states)
+                    super()
+
                     @states = states
                 end
 

--- a/lib/roby/coordination/models/fault_handler.rb
+++ b/lib/roby/coordination/models/fault_handler.rb
@@ -79,6 +79,8 @@ module Roby
                     attr_reader :replacement_task
 
                     def initialize(replacement_task)
+                        super()
+
                         @replacement_task = replacement_task
                     end
 
@@ -166,14 +168,13 @@ module Roby
                 end
 
                 def find_response_locations(origin)
-                    if response_location == :origin
-                        return [origin].to_set
-                    end
+                    return [origin].to_set if response_location == :origin
 
                     predicate =
-                        if response_location == :missions
+                        case response_location
+                        when :missions
                             proc { |t| t.mission? && t.running? }
-                        elsif response_location == :actions
+                        when :actions
                             proc { |t| t.running? && t.planning_task && t.planning_task.kind_of?(Roby::Actions::Task) }
                         end
 
@@ -213,10 +214,14 @@ module Roby
                         #
                         # In addition, if origin == task, we need to handle the
                         # error events as well
-                        task.add_error_handler response_task,
-                                               [task.stop_event.to_execution_exception_matcher, execution_exception_matcher].to_set
+                        task.add_error_handler(
+                            response_task,
+                            [task.stop_event.to_execution_exception_matcher,
+                             execution_exception_matcher].to_set
+                        )
                     end
-                    locations.each do |task|
+
+                    locations.each do |task| # rubocop:disable Style/CombinableLoops
                         # This should not be needed. However, the current GC
                         # implementation in ExecutionEngine does not stop at
                         # finished tasks, and therefore would not GC the

--- a/lib/roby/coordination/models/script.rb
+++ b/lib/roby/coordination/models/script.rb
@@ -12,12 +12,13 @@ module Roby
 
                 # Script element that implements {Script#start}
                 class Start < Coordination::ScriptInstruction
-                    attr_reader :task
-                    attr_reader :dependency_options
+                    attr_reader :task, :dependency_options
 
                     attr_predicate :explicit_start?, true
 
                     def initialize(task, explicit_start: false, **dependency_options)
+                        super()
+
                         @explicit_start = explicit_start
                         @task = task
                         @dependency_options = dependency_options
@@ -63,6 +64,8 @@ module Roby
                     # @option options [Time] :after (nil) value for
                     #   {#time_barrier}
                     def initialize(event, after: nil)
+                        super()
+
                         @event = event
                         @done = false
                         @time_barrier = after
@@ -156,6 +159,8 @@ module Roby
                     attr_reader :event
 
                     def initialize(event)
+                        super()
+
                         @event = event
                     end
 
@@ -174,8 +179,7 @@ module Roby
                 end
 
                 class TimeoutStart
-                    attr_reader :seconds
-                    attr_reader :event
+                    attr_reader :seconds, :event
 
                     def initialize(seconds, options = {})
                         @seconds = seconds

--- a/lib/roby/coordination/models/task.rb
+++ b/lib/roby/coordination/models/task.rb
@@ -68,10 +68,9 @@ module Roby
                 # @return [Boolean] true if the event is an event of self, and
                 #   false otherwise
                 def has_event?(event_name)
-                    if model&.respond_to?(:find_event)
-                        model.find_event(event_name.to_sym)
-                    else true
-                    end
+                    return true unless model.respond_to?(:find_event)
+
+                    model.find_event(event_name.to_sym)
                 end
 
                 # Returns an model-level coordination event that can be used to

--- a/lib/roby/coordination/models/task_from_variable.rb
+++ b/lib/roby/coordination/models/task_from_variable.rb
@@ -7,6 +7,7 @@ module Roby
             # variable
             class TaskFromVariable < TaskWithDependencies
                 attr_reader :variable_name
+
                 def initialize(variable_name, task_model)
                     @variable_name = variable_name
                     super(task_model)

--- a/lib/roby/coordination/script.rb
+++ b/lib/roby/coordination/script.rb
@@ -7,11 +7,11 @@ module Roby
             DeadInstruction = Models::Script::DeadInstruction
 
             class BlockExecute < ScriptInstruction
-                attr_reader :task
-
-                attr_reader :block
+                attr_reader :task, :block
 
                 def initialize(block)
+                    super()
+
                     @block = block
                 end
 
@@ -29,6 +29,7 @@ module Roby
             module Models
                 class PollUntil
                     attr_reader :event, :block
+
                     def initialize(event, block)
                         @event = event
                         @block = block
@@ -48,6 +49,8 @@ module Roby
                 attr_reader :root_task, :event, :block
 
                 def initialize(root_task, event, block)
+                    super()
+
                     @root_task = root_task
                     @event = event
                     @block = block
@@ -100,11 +103,12 @@ module Roby
             end
 
             class TimeoutStart < ScriptInstruction
-                attr_reader :model
-                attr_reader :event
+                attr_reader :model, :event
                 attr_accessor :timeout_stop
 
                 def initialize(model, event)
+                    super()
+
                     @model = model
                     @event = event
                 end
@@ -134,6 +138,8 @@ module Roby
                 attr_reader :timeout_start
 
                 def initialize(timeout_start)
+                    super()
+
                     @timeout_start = timeout_start
                     timeout_start.timeout_stop = self
                 end
@@ -144,9 +150,7 @@ module Roby
                 end
             end
 
-            attr_reader :current_instruction
-
-            attr_reader :instructions
+            attr_reader :current_instruction, :instructions
 
             def prepare
                 @instructions = []
@@ -178,9 +182,9 @@ module Roby
                 return if current_instruction && !current_instruction.disabled?
 
                 while (@current_instruction = instructions.shift)
-                    unless current_instruction.disabled?
-                        break unless current_instruction.execute(self)
-                    end
+                    next if current_instruction.disabled?
+
+                    break unless current_instruction.execute(self)
                 end
             rescue LocalizedError => e
                 raise e

--- a/lib/roby/coordination/task_state_machine.rb
+++ b/lib/roby/coordination/task_state_machine.rb
@@ -5,8 +5,7 @@ require "state_machine/machine"
 module Roby
     # Helper to get a more roby-like feeling to the state machine definitions
     class StateMachineDefinitionContext
-        attr_reader :task_model
-        attr_reader :state_machine
+        attr_reader :task_model, :state_machine
 
         def initialize(task_model, state_machine)
             @task_model = task_model

--- a/lib/roby/droby/event_logger.rb
+++ b/lib/roby/droby/event_logger.rb
@@ -113,7 +113,8 @@ module Roby
             end
 
             def append_message(m, time, args)
-                if m == :merged_plan
+                case m
+                when :merged_plan
                     plan_id, merged_plan = *args
 
                     merged_plan.tasks.each do |t|
@@ -126,11 +127,11 @@ module Roby
                         object_manager.register_object(e)
                     end
                     args = [plan_id, merged_plan.droby_dump(marshal)]
-                elsif m == :finalized_task
+                when :finalized_task
                     task = args[1]
                     args = marshal.dump(args)
                     object_manager.deregister_object(task)
-                elsif m == :finalized_event
+                when :finalized_event
                     event = args[1]
                     args = marshal.dump(args)
                     object_manager.deregister_object(event)

--- a/lib/roby/droby/logfile/writer.rb
+++ b/lib/roby/droby/logfile/writer.rb
@@ -11,8 +11,7 @@ module Roby
                 # The current log format version
                 FORMAT_VERSION = 5
 
-                attr_reader :event_io
-                attr_reader :buffer_io
+                attr_reader :event_io, :buffer_io
 
                 def initialize(event_io, **options)
                     @event_io = event_io

--- a/lib/roby/droby/object_manager.rb
+++ b/lib/roby/droby/object_manager.rb
@@ -50,11 +50,11 @@ module Roby
             # @param [PeerID] peer_id the ID of our peer
             # @return [DRobyID,nil]
             def registered_sibling_on(local_object, peer_id)
-                if local_object.respond_to?(:droby_id)
-                    if siblings = siblings_by_local_object_id.fetch(local_object.droby_id, nil)
-                        siblings[peer_id]
-                    end
-                end
+                return unless local_object.respond_to?(:droby_id)
+
+                siblings =
+                    siblings_by_local_object_id.fetch(local_object.droby_id, nil)
+                siblings[peer_id] if siblings
             end
 
             # The ID this object is known for on the given peer
@@ -152,9 +152,8 @@ module Roby
                 end
 
                 if local_object.respond_to?(:name)
-                    if local_object == models_by_name[n = local_object.name]
-                        models_by_name.delete(n)
-                    end
+                    n = local_object.name
+                    models_by_name.delete(n) if local_object == models_by_name[n]
                 end
             end
 

--- a/lib/roby/droby/plan_rebuilder.rb
+++ b/lib/roby/droby/plan_rebuilder.rb
@@ -230,12 +230,13 @@ module Roby
 
             def task_status_change(time, task, status)
                 task = local_object(task)
-                if status == :normal
+                case status
+                when :normal
                     plan.unmark_mission_task(task)
                     plan.unmark_permanent_task(task)
-                elsif status == :permanent
+                when :permanent
                     plan.add_permanent_task(task)
-                elsif status == :mission
+                when :mission
                     plan.add_mission_task(task)
                 end
                 task
@@ -243,9 +244,10 @@ module Roby
 
             def event_status_change(time, event, status)
                 event = local_object(event)
-                if status == :normal
+                case status
+                when :normal
                     plan.unmark_permanent_event(event)
-                elsif status == :permanent
+                when :permanent
                     plan.add_permanent_event(event)
                 end
                 event

--- a/lib/roby/droby/timepoints.rb
+++ b/lib/roby/droby/timepoints.rb
@@ -6,9 +6,7 @@ module Roby
     module DRoby
         module Timepoints
             class Analysis
-                attr_reader :roots
-                attr_reader :thread_names
-                attr_reader :current_groups
+                attr_reader :roots, :thread_names, :current_groups
 
                 def initialize
                     @thread_names = {}
@@ -59,10 +57,7 @@ module Roby
             end
 
             class Point
-                attr_reader :group
-                attr_reader :name
-                attr_reader :time
-                attr_reader :duration
+                attr_reader :group, :name, :time, :duration
 
                 def initialize(time, name, duration, group)
                     @time = time
@@ -89,8 +84,7 @@ module Roby
             end
 
             class Aggregate
-                attr_reader :current_time
-                attr_reader :timepoints
+                attr_reader :current_time, :timepoints
 
                 def initialize
                     @timepoints = []
@@ -162,8 +156,7 @@ module Roby
             end
 
             class Root < Aggregate
-                attr_reader :name
-                attr_reader :level
+                attr_reader :name, :level
 
                 def initialize(name = "root")
                     super()
@@ -174,11 +167,7 @@ module Roby
             end
 
             class Group < Aggregate
-                attr_reader :name
-                attr_reader :level
-                attr_reader :group
-
-                attr_reader :start_time
+                attr_reader :name, :level, :group, :start_time
 
                 def initialize(time, name, group)
                     super()

--- a/lib/roby/droby/timepoints_ctf.rb
+++ b/lib/roby/droby/timepoints_ctf.rb
@@ -6,15 +6,7 @@ module Roby
     module DRoby
         module Timepoints
             class CTF
-                attr_reader :uuid
-                attr_reader :clock_base
-                attr_reader :name_to_addr_mapping
-
-                attr_reader :packet_timestamp_begin
-                attr_reader :packet_timestamp_end
-                attr_reader :packet_contents
-
-                attr_reader :thread_ids
+                attr_reader :uuid, :clock_base, :name_to_addr_mapping, :packet_timestamp_begin, :packet_timestamp_end, :packet_contents, :thread_ids
 
                 def initialize(clock_base: 0)
                     @uuid = SecureRandom.random_bytes(16).unpack("C*")

--- a/lib/roby/droby/v5/builtin.rb
+++ b/lib/roby/droby/v5/builtin.rb
@@ -35,8 +35,7 @@ module Roby
                     end
 
                     class DRoby < Exception # rubocop:disable Lint/InheritException
-                        attr_reader :exception_class
-                        attr_reader :formatted_message
+                        attr_reader :exception_class, :formatted_message
 
                         def initialize(exception_class, formatted_message, message = nil)
                             @exception_class, @formatted_message =

--- a/lib/roby/droby/v5/droby_dump.rb
+++ b/lib/roby/droby/v5/droby_dump.rb
@@ -5,8 +5,7 @@ module Roby
         module V5
             module BidirectionalGraphDumper
                 class DRoby
-                    attr_reader :vertices
-                    attr_reader :edges
+                    attr_reader :vertices, :edges
 
                     def initialize(vertices, edges)
                         @vertices = vertices
@@ -82,8 +81,7 @@ module Roby
             # Exception class used on the unmarshalling of LocalizedError for exception
             # classes that do not have their own marshalling
             class UntypedLocalizedError < LocalizedError
-                attr_accessor :formatted_message
-                attr_accessor :exception_class
+                attr_accessor :formatted_message, :exception_class
 
                 def initialize(failure_point, fatal: nil)
                     super(failure_point)
@@ -123,6 +121,7 @@ module Roby
                 class DRoby
                     attr_reader :model, :failure_point, :fatal, :message, :backtrace,
                                 :original_exceptions, :formatted_message
+
                     def initialize(model, failure_point, fatal, message, backtrace,
                                    original_exceptions, formatted_message = [])
                         @model, @failure_point, @fatal, @message, @backtrace,
@@ -152,9 +151,8 @@ module Roby
                 end
 
                 class DRoby
-                    attr_reader :planned_task
-                    attr_reader :planning_task
-                    attr_reader :failure_reason
+                    attr_reader :planned_task, :planning_task, :failure_reason
+
                     def initialize(planned_task, planning_task, failure_reason)
                         @planned_task  = planned_task
                         @planning_task = planning_task
@@ -178,9 +176,7 @@ module Roby
                 end
 
                 class DRoby
-                    attr_reader :trace
-                    attr_reader :exception
-                    attr_reader :handled
+                    attr_reader :trace, :exception, :handled
 
                     def initialize(trace, exception, handled)
                         @trace, @exception, @handled = trace, exception, handled
@@ -222,8 +218,7 @@ module Roby
                     end
 
                     class DRoby < DRobyModel
-                        attr_reader :events
-                        attr_reader :arguments
+                        attr_reader :events, :arguments
 
                         def initialize(name, remote_siblings, arguments, supermodel, provided_models, events)
                             super(name, remote_siblings, supermodel, provided_models)
@@ -276,6 +271,7 @@ module Roby
                     attr_reader :remote_siblings
                     # The set of owners for that object.
                     attr_reader :owners
+
                     # Create a DistributedObject::DRoby object with the given information
                     def initialize(remote_siblings, owners)
                         @remote_siblings, @owners = remote_siblings, owners
@@ -374,10 +370,7 @@ module Roby
                 end
 
                 class DRoby
-                    attr_reader :propagation_id
-                    attr_reader :time
-                    attr_reader :generator
-                    attr_reader :context
+                    attr_reader :propagation_id, :time, :generator, :context
 
                     def initialize(propagation_id, time, generator, context)
                         @propagation_id, @time, @generator, @context = propagation_id, time, generator, context
@@ -479,6 +472,7 @@ module Roby
             module TaskArgumentsDumper
                 class DRoby
                     attr_reader :values
+
                     def initialize(values)
                         @values = values
                     end
@@ -598,17 +592,7 @@ module Roby
                 end
 
                 class DRoby
-                    attr_reader :plan_class
-                    attr_reader :droby_id
-                    attr_reader :groups
-                    attr_reader :tasks
-                    attr_reader :task_events
-                    attr_reader :free_events
-                    attr_reader :mission_tasks
-                    attr_reader :permanent_tasks
-                    attr_reader :permanent_events
-                    attr_reader :task_relation_graphs
-                    attr_reader :event_relation_graphs
+                    attr_reader :plan_class, :droby_id, :groups, :tasks, :task_events, :free_events, :mission_tasks, :permanent_tasks, :permanent_events, :task_relation_graphs, :event_relation_graphs
 
                     def initialize(plan_class, droby_id,
                                    tasks, task_events, free_events,
@@ -801,6 +785,7 @@ module Roby
                     # be sent to our peers.
                     class DRoby
                         attr_reader :ops
+
                         def initialize(ops)
                             @ops = ops
                         end
@@ -842,6 +827,7 @@ module Roby
                     # be sent to our peers.
                     class DRoby
                         attr_reader :ops
+
                         def initialize(ops)
                             @ops = ops
                         end
@@ -863,6 +849,7 @@ module Roby
                     # be sent to our peers.
                     class DRoby
                         attr_reader :exception_matcher, :involved_tasks_matchers
+
                         def initialize(exception_matchers, involved_tasks_matchers)
                             @exception_matcher = exception_matcher
                             @involved_tasks_matchers = involved_tasks_matchers
@@ -892,6 +879,7 @@ module Roby
                     # be sent to our peers.
                     class DRoby
                         attr_reader :model, :failure_point_matcher
+
                         def initialize(model, failure_point_matcher)
                             @model = model
                             @failure_point_matcher = failure_point_matcher
@@ -920,13 +908,7 @@ module Roby
                     class DRoby
                         # The exact match class that has been marshalled using this object
                         attr_reader :model
-                        attr_reader :predicates
-                        attr_reader :neg_predicates
-                        attr_reader :indexed_predicates
-                        attr_reader :indexed_neg_predicates
-                        attr_reader :parents
-                        attr_reader :children
-                        attr_reader :owners
+                        attr_reader :predicates, :neg_predicates, :indexed_predicates, :indexed_neg_predicates, :parents, :children, :owners
 
                         def initialize(model, predicates, neg_predicates, indexed_predicates, indexed_neg_predicates, owners, parents, children)
                             @model = model
@@ -1001,9 +983,9 @@ module Roby
                     # An intermediate representation of Query objects suitable to be sent
                     # to our peers.
                     class DRoby < TaskMatcherDumper::DRoby
-                        attr_accessor :plan_id
-                        attr_accessor :scope
+                        attr_accessor :plan_id, :scope
                         attr_reader :plan_predicates, :neg_plan_predicates
+
                         def initialize(*args)
                             super
                             @plan_predicates, @neg_plan_predicates = Set.new, Set.new

--- a/lib/roby/droby/v5/droby_model.rb
+++ b/lib/roby/droby/v5/droby_model.rb
@@ -4,10 +4,7 @@ module Roby
     module DRoby
         module V5
             class DRobyModel
-                attr_reader :name
-                attr_reader :remote_siblings
-                attr_reader :supermodel
-                attr_reader :provided_models
+                attr_reader :name, :remote_siblings, :supermodel, :provided_models
 
                 def initialize(name, remote_siblings, supermodel, provided_models)
                     @name, @remote_siblings, @supermodel, @provided_models =

--- a/lib/roby/event_constraints.rb
+++ b/lib/roby/event_constraints.rb
@@ -450,6 +450,7 @@ module Roby
         # See documentation from UnboundTaskPredicate
         class UnboundTaskPredicate::Negate < UnboundTaskPredicate
             attr_reader :predicate
+
             def initialize(pred)
                 @predicate = pred
                 super()
@@ -493,6 +494,7 @@ module Roby
         # See documentation from UnboundPredicateSupport
         class UnboundTaskPredicate::Never < UnboundTaskPredicate
             attr_reader :predicate
+
             def initialize(pred)
                 unless pred.kind_of?(UnboundTaskPredicate::SingleEvent)
                     raise ArgumentError,
@@ -557,6 +559,7 @@ module Roby
         # explanations.
         class UnboundTaskPredicate::BinaryCommutativePredicate < UnboundTaskPredicate
             attr_reader :predicates
+
             def initialize(left, right)
                 @predicates = [left, right]
                 super()

--- a/lib/roby/event_generator.rb
+++ b/lib/roby/event_generator.rb
@@ -19,8 +19,7 @@ module Roby
     #
     class EventGenerator < PlanObject
         class << self
-            attr_reader :relation_spaces
-            attr_reader :all_relation_spaces
+            attr_reader :relation_spaces, :all_relation_spaces
         end
         @relation_spaces = []
         @all_relation_spaces = []
@@ -827,9 +826,10 @@ module Roby
             end
             if on_failure != :nothing
                 promise.on_error(description: "#{self}#emit_failed") do |reason|
-                    if on_failure == :fail
+                    case on_failure
+                    when :fail
                         emit_failed(reason)
-                    elsif on_failure == :emit
+                    when :emit
                         emit(*context)
                     end
                 end
@@ -840,6 +840,7 @@ module Roby
 
         # A [time, event] array of past event emitted by this object
         attr_reader :history
+
         # True if this event has been emitted once.
         attr_predicate :emitted?
         # True if this event has been emitted once.
@@ -862,8 +863,8 @@ module Roby
         end
 
         # Yields all precondition handlers defined for this generator
-        def each_precondition
-            @preconditions.each { |o| yield(o) }
+        def each_precondition(&block)
+            @preconditions.each(&block)
         end
 
         # Call this method in the #calling hook to cancel calling the event

--- a/lib/roby/exceptions.rb
+++ b/lib/roby/exceptions.rb
@@ -66,6 +66,7 @@ module Roby
 
         # If this specific exception has been marked has handled
         attr_accessor :handled
+
         # If this exception has been marked as handled
         def handled?
             handled
@@ -192,9 +193,10 @@ module Roby
         # Returns true if the exception has been handled, false otherwise
         def handle_exception(exception_object)
             each_exception_handler do |matcher, handler|
-                if exception_object.exception.kind_of?(FailedExceptionHandler)
+                if exception_object.exception.kind_of?(FailedExceptionHandler) &&
+                   exception_object.exception.handler == handler
                     # Do not handle a failed exception handler by itself
-                    next if exception_object.exception.handler == handler
+                    next
                 end
 
                 if matcher === exception_object
@@ -434,6 +436,7 @@ module Roby
 
     class BacktraceFormatter
         attr_reader :backtrace
+
         def initialize(exception, backtrace = exception.backtrace)
             @exception = exception
             @backtrace = backtrace

--- a/lib/roby/executable_plan.rb
+++ b/lib/roby/executable_plan.rb
@@ -232,12 +232,11 @@ module Roby
                       "attempting to reuse #{child} which is marked as garbage"
             end
 
-            if last_dag = relations.find_all(&:dag?).last
-                if child.relation_graph_for(last_dag).reachable?(child, parent)
-                    raise Relations::CycleFoundError,
-                          "adding an edge from #{parent} to #{child} would create "\
-                          "a cycle in #{last_dag}"
-                end
+            last_dag = relations.find_all(&:dag?).last
+            if last_dag && child.relation_graph_for(last_dag).reachable?(child, parent)
+                raise Relations::CycleFoundError,
+                      "adding an edge from #{parent} to #{child} would create "\
+                      "a cycle in #{last_dag}"
             end
 
             relations.each do |rel|

--- a/lib/roby/execution_engine.rb
+++ b/lib/roby/execution_engine.rb
@@ -440,7 +440,10 @@ module Roby
             finished = []
             propagation_info = PropagationInfo.new
             loop do
-                framework_errors = gather_framework_errors("#join_all_waiting_work", raise_caught_exceptions: false) do
+                framework_errors = gather_framework_errors(
+                    "#join_all_waiting_work",
+                    raise_caught_exceptions: false
+                ) do
                     next_steps = nil
                     event_errors = gather_errors do
                         next_steps = gather_propagation do
@@ -453,7 +456,9 @@ module Roby
                         end
                     end
 
-                    this_propagation = propagate_events_and_errors(next_steps, event_errors, garbage_collect_pass: false)
+                    this_propagation = propagate_events_and_errors(
+                        next_steps, event_errors, garbage_collect_pass: false
+                    )
                     propagation_info.merge(this_propagation)
                 end
                 propagation_info.add_framework_errors(framework_errors)
@@ -670,9 +675,10 @@ module Roby
             end
         end
 
-        def process_pending_application_exceptions(application_errors = clear_application_exceptions,
-            raise_framework_errors: Roby.app.abort_on_application_exception?)
-
+        def process_pending_application_exceptions(
+            application_errors = clear_application_exceptions,
+            raise_framework_errors: Roby.app.abort_on_application_exception?
+        )
             # We don't aggregate exceptions, so report them all and raise one
             if display_exceptions?
                 application_errors.each do |error, source|

--- a/lib/roby/execution_engine.rb
+++ b/lib/roby/execution_engine.rb
@@ -19,6 +19,8 @@ module Roby
         end
 
         def initialize(errors)
+            super()
+
             @errors = errors
         end
 
@@ -212,9 +214,8 @@ module Roby
         class PollBlockDefinition
             ON_ERROR = %i[raise ignore disable].freeze
 
-            attr_reader :description
-            attr_reader :handler
-            attr_reader :on_error
+            attr_reader :description, :handler, :on_error
+
             attr_predicate :late?, true
             attr_predicate :once?, true
             attr_predicate :disabled?, true
@@ -251,14 +252,16 @@ module Roby
                 handler.call(*args)
                 true
             rescue Exception => e
-                if on_error == :raise
+                case on_error
+                when :raise
                     engine.add_framework_error(e, description)
                     false
-                elsif on_error == :disable
-                    engine.warn "propagation handler #{description} disabled because of the following error"
+                when :disable
+                    engine.warn "propagation handler #{description} disabled "\
+                                "because of the following error"
                     Roby.log_exception_with_backtrace(e, engine, :warn)
                     false
-                elsif on_error == :ignore
+                when :ignore
                     engine.warn "ignored error from propagation handler #{description}"
                     Roby.log_exception_with_backtrace(e, engine, :warn)
                     true
@@ -336,9 +339,10 @@ module Roby
             #   the handler
             def add_propagation_handler(type: :external_events, description: "propagation handler", **poll_options, &block)
                 type, handler = create_propagation_handler(type: type, description: description, **poll_options, &block)
-                if type == :propagation
+                case type
+                when :propagation
                     propagation_handlers << handler
-                elsif type == :external_events
+                when :external_events
                     external_events_handlers << handler
                 end
                 handler
@@ -405,7 +409,10 @@ module Roby
 
         class JoinAllWaitingWorkTimeout < RuntimeError
             attr_reader :waiting_work
+
             def initialize(waiting_work)
+                super()
+
                 @waiting_work = waiting_work.dup
             end
 
@@ -510,6 +517,7 @@ module Roby
         # The set of source events for the current propagation action. This is a
         # mix of EventGenerator and Event objects.
         attr_reader :propagation_sources
+
         # The set of events extracted from #sources
         def propagation_source_events
             result = Set.new
@@ -600,8 +608,10 @@ module Roby
         # The method returns the resulting hash. Use #in_propagation_context? to know if the
         # current engine is in a propagation context, and #add_event_propagation
         # to add a new entry to this set.
-        def gather_propagation(initial_set = {})
-            raise InternalError, "nested call to #gather_propagation" if in_propagation_context?
+        def gather_propagation(initial_set = {}, &block)
+            if in_propagation_context?
+                raise InternalError, "nested call to #gather_propagation"
+            end
 
             old_allow_propagation, @allow_propagation = @allow_propagation, true
 
@@ -613,9 +623,7 @@ module Roby
                 @propagation_sources = nil
                 @propagation_step_id = 0
 
-                propagation_context([]) do
-                    yield
-                end
+                propagation_context([], &block)
 
                 result, @propagation = @propagation, nil
                 result
@@ -1198,11 +1206,9 @@ module Roby
 
         # Graph visitor that propagates exceptions in the dependency graph
         class ExceptionPropagationVisitor < Relations::ForkMergeVisitor
-            attr_reader :exception_handler
-            attr_reader :handled_exceptions
-            attr_reader :unhandled_exceptions
+            attr_reader :exception_handler, :handled_exceptions, :unhandled_exceptions
 
-            def initialize(graph, object, origin, origin_neighbours = graph.out_neighbours(origin), &exception_handler)
+            def initialize(graph, object, origin, origin_neighbours, exception_handler)
                 super(graph, object, origin, origin_neighbours)
                 @exception_handler = exception_handler
                 @handled_exceptions = []
@@ -1250,7 +1256,7 @@ module Roby
         # @return [Array<(ExecutionException,Array<Task>)>] the set of unhandled
         #   exceptions, as a mapping from an exception description to the set of
         #   tasks that are affected by it
-        def propagate_exception_in_plan(exceptions)
+        def propagate_exception_in_plan(exceptions, &handler)
             propagation_graph = dependency_graph.reverse
 
             # Propagate the exceptions in the hierarchy
@@ -1291,9 +1297,9 @@ module Roby
                     break
                 end
 
-                visitor = ExceptionPropagationVisitor.new(propagation_graph, exception, origin, parents) do |e, task|
-                    yield(e, task)
-                end
+                visitor = ExceptionPropagationVisitor.new(
+                    propagation_graph, exception, origin, parents, handler
+                )
                 visitor.visit
 
                 unhandled = visitor.unhandled_exceptions.inject { |a, b| a.merge(b) }
@@ -1448,6 +1454,7 @@ module Roby
         # control. For now, those errors cause the whole controller to shut
         # down.
         attr_reader :application_exceptions
+
         def clear_application_exceptions
             unless @application_exceptions
                 raise RecursivePropagationContext, "unbalanced call to #clear_application_exceptions"
@@ -1562,7 +1569,7 @@ module Roby
                            inhibited_errors = [],
                            framework_errors = [])
 
-                self.called_generators  = called_generators .to_set
+                self.called_generators  = called_generators.to_set
                 self.emitted_events     = emitted_events.to_set
                 self.kill_tasks         = kill_tasks.to_set
                 self.fatal_errors       = fatal_errors
@@ -1799,7 +1806,7 @@ module Roby
         # to Roby's error handling mechanisms), the method will raise
         # SynchronousEventProcessingMultipleErrors to wrap all the exceptions
         # into one.
-        def process_events_synchronous(seeds = {}, initial_errors = [], enable_scheduler: false, raise_errors: true)
+        def process_events_synchronous(seeds = {}, initial_errors = [], enable_scheduler: false, raise_errors: true, &block)
             Roby.warn_deprecated "#process_events_synchronous is deprecated, use the expect_execution harness instead"
 
             if @application_exceptions
@@ -1812,19 +1819,22 @@ module Roby
             # Save early for the benefit of the 'ensure' block
             current_scheduler_enabled = scheduler.enabled?
 
-            if (!seeds.empty? || !initial_errors.empty?) && block_given?
-                raise ArgumentError, "cannot provide both seeds/inital errors and a block"
-            elsif block_given?
-                seeds = gather_propagation do
-                    initial_errors = gather_errors do
-                        yield
+            if block_given?
+                if seeds.empty? && initial_errors.empty?
+                    seeds = gather_propagation do
+                        initial_errors = gather_errors(&block)
                     end
+                else
+                    raise ArgumentError,
+                          "cannot provide both seeds/inital errors and a block"
                 end
             end
 
             scheduler.enabled = enable_scheduler
 
-            propagation_info = propagate_events_and_errors(seeds, initial_errors, garbage_collect_pass: false)
+            propagation_info = propagate_events_and_errors(
+                seeds, initial_errors, garbage_collect_pass: false
+            )
             unless propagation_info.kill_tasks.empty?
                 gc_initial_errors = nil
                 gc_seeds = gather_propagation do
@@ -1832,7 +1842,9 @@ module Roby
                         garbage_collect(propagation_info.kill_tasks)
                     end
                 end
-                gc_errors = propagate_events_and_errors(gc_seeds, gc_initial_errors, garbage_collect_pass: false)
+                gc_errors = propagate_events_and_errors(
+                    gc_seeds, gc_initial_errors, garbage_collect_pass: false
+                )
                 propagation_info.merge(gc_errors)
             end
 
@@ -2174,6 +2186,7 @@ module Roby
 
         # The execution thread if there is one running
         attr_accessor :thread
+
         # True if an execution thread is running
         attr_predicate :running?, true
 
@@ -2524,7 +2537,7 @@ module Roby
         # Block until the given block is executed by the execution thread, at
         # the beginning of the event loop, in propagation context. If the block
         # raises, the exception is raised back in the calling thread.
-        def execute(catch: [], type: :external_events)
+        def execute(catch: [], type: :external_events, &block)
             raise ArgumentError, "a block is required" unless block_given?
             if inside_control?
                 return yield
@@ -2545,7 +2558,7 @@ module Roby
             once(sync: ivar, type: type) do
                 begin
                     if !catch.empty?
-                        result = capture_catch.call(*catch) { yield }
+                        result = capture_catch.call(*catch, &block)
                         ivar.set(result)
                     else
                         ivar.set([:ret, yield])
@@ -2729,8 +2742,8 @@ module Roby
     # wait for its completion like Roby.execute does
     #
     # See ExecutionEngine#once
-    def self.once
-        execution_engine.once { yield }
+    def self.once(&block)
+        execution_engine.once(&block)
     end
 
     # Make the main engine call +block+ during each propagation step.
@@ -2760,10 +2773,8 @@ module Roby
 
     # Execute the given block during the event propagation step of the main
     # engine. See ExecutionEngine#execute
-    def self.execute
-        execution_engine.execute do
-            yield
-        end
+    def self.execute(&block)
+        execution_engine.execute(&block)
     end
 
     # Blocks until the main engine has executed at least one cycle.

--- a/lib/roby/gui/chronicle_view.rb
+++ b/lib/roby/gui/chronicle_view.rb
@@ -162,11 +162,12 @@ module Roby
             slots "stop()"
 
             def updateWindowTitle
-                if parent_title = history_widget.window_title
-                    self.window_title = parent_title + ": Chronicle"
-                else
-                    self.window_title = "roby-display: Chronicle"
-                end
+                self.window_title =
+                    if (parent_title = history_widget.window_title)
+                        "#{parent_title}: Chronicle"
+                    else
+                        "roby-display: Chronicle"
+                    end
             end
             slots "updateWindowTitle()"
 

--- a/lib/roby/gui/chronicle_widget.rb
+++ b/lib/roby/gui/chronicle_widget.rb
@@ -34,6 +34,7 @@ module Roby
             # Internal representation of the desired time scale. Don't use it
             # directly, but use #time_to_pixel or #pixel_to_time
             attr_reader :time_scale
+
             # Change the time scale and update the view
             def time_scale=(new_value)
                 @time_scale = new_value
@@ -116,6 +117,7 @@ module Roby
             # before the current displayed time: it shows the last active tasks
             # first)
             attr_reader :sort_mode
+
             # See #sort_mode
             def sort_mode=(mode)
                 unless %i[start_time last_event].include?(mode)
@@ -625,26 +627,8 @@ module Roby
             end
 
             class TaskLayout
-                attr_reader :base_time
-                attr_reader :time_to_pixel
-                attr_reader :fm
-
-                attr_reader :task
-                attr_reader :state
-
-                attr_reader :add_point
-                attr_reader :start_point
-                attr_reader :end_point
-                attr_reader :finalization_point
-
-                attr_reader :event_height
-                attr_reader :event_max_x
-                attr_reader :events
-                attr_accessor :messages
-
-                attr_accessor :title
-
-                attr_reader :base_height
+                attr_reader :base_time, :time_to_pixel, :fm, :task, :state, :add_point, :start_point, :end_point, :finalization_point, :event_height, :event_max_x, :events, :base_height
+                attr_accessor :messages, :title
 
                 def initialize(task, base_time, time_to_pixel, fm)
                     @task = task
@@ -874,9 +858,8 @@ module Roby
                         job_text << job_task.action_model.name.to_s
                     end
                     if job_task.action_arguments
-                        job_text << "(" + job_task.action_arguments.map do |k, v|
-                            "#{k} => #{v}"
-                        end.join(", ") + ")"
+                        arg_s = job_task.action_arguments.map { |k, v| "#{k}: #{v}" }
+                        job_text << "(#{arg_s.join(', ')})"
                     end
                     text = "#{job_text.join(' ')} / #{text}"
                 end

--- a/lib/roby/gui/model_views/action_interface.rb
+++ b/lib/roby/gui/model_views/action_interface.rb
@@ -5,10 +5,6 @@ module Roby
         module ModelViews
             # Handler class to display information about an action interface
             class ActionInterface < MetaRuby::GUI::HTML::Collection
-                def initialize(page)
-                    super
-                end
-
                 def compute_toplevel_links(model, options)
                     actions = model.each_action.map do |action|
                         arguments = action.arguments.map { |arg| ":#{arg.name}" }.join(", ")
@@ -37,17 +33,18 @@ module Roby
 
                 def self.html_defined_in(page, model, with_require: true, definition_location: nil, format: "<b>Defined in</b> %s")
                     path, lineno = *definition_location || find_definition_place(model)
-                    if path
-                        path = Pathname.new(path)
-                        path_link = page.link_to(path, "#{path}:#{lineno}", lineno: lineno)
-                        page.push(nil, "<p>#{format(format, path_link)}</p>")
-                        if with_require
-                            if req_base = $LOAD_PATH.find { |p| path.fnmatch?(File.join(p, "*")) }
-                                req = path.relative_path_from(Pathname.new(req_base))
-                                page.push(nil, "<code>require '#{req.sub_ext('')}'</code>")
-                            end
-                        end
-                    end
+                    return unless path
+
+                    path = Pathname.new(path)
+                    path_link = page.link_to(path, "#{path}:#{lineno}", lineno: lineno)
+                    page.push(nil, "<p>#{format(format, path_link)}</p>")
+                    return unless with_require
+
+                    req_base = $LOAD_PATH.find { |p| path.fnmatch?(File.join(p, "*")) }
+                    return unless req_base
+
+                    req = path.relative_path_from(Pathname.new(req_base))
+                    page.push(nil, "<code>require '#{req.sub_ext('')}'</code>")
                 end
             end
         end

--- a/lib/roby/gui/model_views/task.rb
+++ b/lib/roby/gui/model_views/task.rb
@@ -31,7 +31,7 @@ module Roby
                     options, push_options = Kernel.filter_options options,
                                                                   external_objects: false, doc: true
                     if external_objects = options[:external_objects]
-                        file = external_objects % "roby_task" + ".svg"
+                        file = "#{external_objects % 'roby_task'}.svg"
                         File.open(file, "w") { |io| io.write(svg) }
                         svg = "<object data=\"#{file}\" type=\"image/svg+xml\"></object>"
                     end

--- a/lib/roby/gui/plan_dot_layout.rb
+++ b/lib/roby/gui/plan_dot_layout.rb
@@ -8,6 +8,7 @@ module Roby
     module GUI
         module GraphvizPlan
             attr_accessor :layout_level
+
             def all_events(display)
                 tasks.inject(free_events.dup) do |events, task|
                     if display.displayed?(task)
@@ -223,8 +224,9 @@ module Roby
 
                     positions[ev.dot_id] += task
                 end
+
                 # Apply the layout on the events
-                each_event do |ev|
+                each_event do |ev| # rubocop:disable Style/CombinableLoops
                     ev.apply_layout(bounding_rects, positions, display)
                 end
                 # And recalculate the bounding box
@@ -236,9 +238,8 @@ module Roby
                     bounding_rect |= graphics.map_rect_to_scene(graphics.bounding_rect)
                     bounding_rect |= graphics.text.map_rect_to_scene(graphics.text.bounding_rect)
                 end
-                unless graphics_item = display[self]
-                    raise "no graphics for #{self}" unless graphics_item = display[self]
-                end
+                raise "no graphics for #{self}" unless (graphics_item = display[self])
+
                 if bounding_rect.null? # no events, we need to take the bounding box from the fake task node
                     bounding_rect = Qt::RectF.new(
                         task.x - DEFAULT_TASK_WIDTH / 2,
@@ -267,7 +268,7 @@ module Roby
             # The set of IDs for the objects in the plan
             attribute(:object_ids) { {} }
 
-            attr_reader :dot_input
+            attr_reader :dot_input, :bounding_rects, :object_pos, :display, :plan
 
             # Add a string to the resulting Dot input file
             def <<(string)
@@ -406,7 +407,7 @@ module Roby
                         p = positions[ev.dot_id]
                         bb |= Qt::RectF.new(p, p)
                     end
-                    t.each_event do |ev|
+                    t.each_event do |ev| # rubocop:disable Style/CombinableLoops
                         next unless display.displayed?(ev)
 
                         event_positions[ev.dot_id] = positions[ev.dot_id] - bb.topLeft
@@ -448,7 +449,6 @@ module Roby
                 @plan = plan
             end
 
-            attr_reader :bounding_rects, :object_pos, :display, :plan
             def apply
                 plan.apply_layout(bounding_rects, object_pos, display)
             end

--- a/lib/roby/gui/plan_rebuilder_widget.rb
+++ b/lib/roby/gui/plan_rebuilder_widget.rb
@@ -170,10 +170,8 @@ module Roby
 
                 result = nil
                 history.each_value do |cycle_time, snapshot, item|
-                    if cycle_time < time
-                        if !result || result[0] < cycle_time
-                            result = [cycle_time, snapshot]
-                        end
+                    if (cycle_time < time) && (!result || result[0] < cycle_time)
+                        result = [cycle_time, snapshot]
                     end
                 end
                 if result
@@ -319,10 +317,8 @@ module Roby
                         disconnect
                         emit warn("Disconnected: #{e.message}")
                         puts e.message
-                        puts "  " + e.backtrace.join("\n  ")
-                        if hostname
-                            connect(hostname, options)
-                        end
+                        puts "  #{e.backtrace.join("\n  ")}"
+                        connect(hostname, options) if hostname
                     end
                 end
                 timer.start(Integer(options[:update_period] * 1000))

--- a/lib/roby/gui/relations_view.rb
+++ b/lib/roby/gui/relations_view.rb
@@ -13,10 +13,7 @@ module Roby
         # Plan display that shows a snapshot of the event/task structure, as
         # well as the events emitted within the last cycle
         class RelationsView < Qt::Widget
-            attr_reader :ui
-            attr_reader :view
-            attr_reader :scheduler_view
-            attr_reader :history_widget
+            attr_reader :ui, :view, :scheduler_view, :history_widget
 
             # In remote connections, this is he period between checking if
             # there is data on the socket, in seconds
@@ -42,8 +39,8 @@ module Roby
             # Slot used to make the widget update its title when e.g. the
             # underlying history widget changed its source
             def updateWindowTitle
-                if parent_title = history_widget.window_title
-                    self.window_title = history_widget.window_title + ": Relations"
+                if (parent_title = history_widget.window_title)
+                    self.window_title = "#{history_widget.window_title}: Relations"
                 else
                     self.window_title = "roby-display: Relations"
                 end
@@ -81,9 +78,7 @@ class Ui::RelationsView
 
     # The underlying RelationsCanvas object
     attr_reader :display
-    attr_reader :prefixActions
-    attr_reader :verticalLayout
-    attr_reader :graphics
+    attr_reader :prefixActions, :verticalLayout, :graphics
 
     # Module used to extend the relation view GraphicsView object, to add
     # double-click and context-menu events
@@ -107,12 +102,7 @@ class Ui::RelationsView
 
         def contextMenuEvent(event)
             item = itemAt(event.pos)
-            if item
-                unless obj = display.object_of(item)
-                    return super(event)
-                end
-            end
-
+            return super(event) if item && !(obj = display.object_of(item))
             return unless obj.kind_of?(Roby::Task)
 
             menu = Qt::Menu.new
@@ -223,7 +213,8 @@ class Ui::RelationsView
         graphics.display = display
 
         @actionShowAll.connect(SIGNAL(:triggered)) do
-            display.graphics.keys.each do |obj|
+            # NOTE: do not use each_key here as set_visibility modifies graphics
+            display.graphics.keys.each do |obj| # rubocop:disable Style/HashEachMethods
                 if obj.kind_of?(Roby::Task::DRoby) ||
                    (obj.kind_of?(Roby::EventGenerator::DRoby) && !obj.respond_to?(:task))
                     display.set_visibility(obj, true)

--- a/lib/roby/gui/relations_view/relations_config.rb
+++ b/lib/roby/gui/relations_view/relations_config.rb
@@ -24,8 +24,8 @@ module Ui
             createIndex(TASK_ROOT_INDEX, 0, -1)
         end
 
-        attr_reader :relations
-        attr_reader :display
+        attr_reader :relations, :display
+
         def initialize(display)
             super()
 
@@ -189,6 +189,7 @@ module Ui
     class LayoutMethodModel < Qt::AbstractListModel
         METHODS = ["Auto", "dot [rankdir=LR]", "dot [rankdir=TB]", "circo", "neato [overlap=false]", "neato [overlap=false,mode=hier]", "twopi", "fdp"].freeze
         attr_reader :display, :combo
+
         def initialize(display, combo)
             super()
             @display, @combo = display, combo
@@ -224,12 +225,7 @@ module Ui
     end
 
     class RelationsConfig
-        attr_reader :current_color
-        attr_reader :relation_color
-        attr_reader :relation_item
-        attr_reader :model
-        attr_reader :delegate
-        attr_reader :display
+        attr_reader :current_color, :relation_color, :relation_item, :model, :delegate, :display
 
         def initialize(widget, display)
             super()
@@ -276,11 +272,12 @@ module Ui
                 display.hidden_labels = hidden_labels.split(",")
                 delayed_update
             end
-            if display.display_policy == :explicit
+            case display.display_policy
+            when :explicit
                 displayExplicit.checked = true
-            elsif display.display_policy == :emitters
+            when :emitters
                 displayEmitters.checked = true
-            elsif display.display_policy == :emitters_and_parents
+            when :emitters_and_parents
                 displayEmittersAndParents.checked = true
             end
 

--- a/lib/roby/gui/stepping.rb
+++ b/lib/roby/gui/stepping.rb
@@ -7,11 +7,7 @@ module Roby
         # GUI dialog that allows to display plans step-by-step instead of
         # cycle-by-cycle
         class Stepping < Qt::Dialog
-            attr_reader :ui
-
-            attr_reader :plan
-            attr_reader :logfile
-            attr_reader :plan_rebuilder
+            attr_reader :ui, :plan, :logfile, :plan_rebuilder
 
             # Create a step-by-step replay starting at the beginning of a cycle
             # in the log stream

--- a/lib/roby/gui/styles.rb
+++ b/lib/roby/gui/styles.rb
@@ -17,10 +17,8 @@ module Roby
             finished: Qt::Color.new("#E2A8A8"),
             finalized: Qt::Color.new("#555555")
         }.freeze
-        TASK_BRUSHES =
-            TASK_BRUSH_COLORS
-            .each_with_object({}) { |(name, color), h| h[name] = Qt::Brush.new(color) }
-            .freeze
+        TASK_BRUSHES = TASK_BRUSH_COLORS.transform_values { |color| Qt::Brush.new(color) }
+                                        .freeze
 
         TASK_PEN_COLORS = {
             pending: Qt::Color.new("#6DF3FF"),
@@ -29,10 +27,8 @@ module Roby
             finished: Qt::Color.new("#E2A8A8"),
             finalized: Qt::Color.new("#555555")
         }.freeze
-        TASK_PENS =
-            TASK_PEN_COLORS
-            .each_with_object({}) { |(name, color), h| h[name] = Qt::Pen.new(color) }
-            .freeze
+        TASK_PENS = TASK_PEN_COLORS.transform_values { |color| Qt::Pen.new(color) }
+                                   .freeze
 
         TASK_NAME_COLOR = Qt::Color.new("black")
         TASK_NAME_PEN = Qt::Pen.new(TASK_NAME_COLOR)
@@ -74,13 +70,10 @@ module Roby
             (EVENT_CONTINGENT | FAILED_EMISSION) => %w[red red]
         }.freeze
 
-        EVENT_STYLES =
-            EVENT_COLORS
-            .each_with_object({}) do |(flags, colors), h|
-                h[flags] = [Qt::Brush.new(Qt::Color.new(colors[0])),
-                            Qt::Pen.new(Qt::Color.new(colors[1]))]
-            end
-            .freeze
+        EVENT_STYLES = EVENT_COLORS.transform_values do |colors|
+            [Qt::Brush.new(Qt::Color.new(colors[0])),
+             Qt::Pen.new(Qt::Color.new(colors[1]))]
+        end.freeze
 
         TIMELINE_RULER_LINE_LENGTH = 10
     end

--- a/lib/roby/interface/async/job_monitor.rb
+++ b/lib/roby/interface/async/job_monitor.rb
@@ -124,10 +124,9 @@ module Roby
                 # Triggers {#on_exception} and {#on_planning_failed} hooks
                 def notify_exception(kind, exception)
                     if exception.exception.kind_of?(PlanningFailedError)
-                        if job_id = exception.exception.planning_task.arguments[:job_id]
-                            if job_id == self.job_id
-                                run_hook :on_planning_failed, kind, exception
-                            end
+                        job_id = exception.exception.planning_task.arguments[:job_id]
+                        if job_id && (job_id == self.job_id)
+                            run_hook :on_planning_failed, kind, exception
                         end
                     end
                     run_hook :on_exception, kind, exception

--- a/lib/roby/interface/async/log.rb
+++ b/lib/roby/interface/async/log.rb
@@ -72,8 +72,7 @@ module Roby
 
                 # @!endgroup
 
-                attr_reader :host
-                attr_reader :port
+                attr_reader :host, :port
                 # @return [Roby::DRoby::Logfile::Client,nil] the object used to communicate
                 #   to the server, or nil if we have not managed to connect yet
                 attr_reader :client

--- a/lib/roby/interface/async/ui_connector.rb
+++ b/lib/roby/interface/async/ui_connector.rb
@@ -70,6 +70,7 @@ module Roby
 
                 class SetArgumentCommand < ActionConnector
                     attr_reader :argument_name
+
                     def initialize(connector, action, argument_name, getter: nil)
                         super(connector, action, getter: nil)
                         @argument_name = argument_name.to_sym
@@ -104,8 +105,7 @@ module Roby
                     end
                 end
 
-                attr_reader :interface
-                attr_reader :widget
+                attr_reader :interface, :widget
 
                 def initialize(interface, widget)
                     @interface = interface
@@ -163,7 +163,7 @@ module Roby
                 end
 
                 def respond_to_missing?(m, include_private = false)
-                    (m =~ /!$/) || widget.respond_to?(m)
+                    (m =~ /!$/) || widget.respond_to?(m) || super
                 end
 
                 def method_missing(m, *args, &block)

--- a/lib/roby/interface/client.rb
+++ b/lib/roby/interface/client.rb
@@ -126,31 +126,30 @@ module Roby
             #
             # @return [Boolean] whether the message was a cycle_end message
             def process_packet(m, *args)
-                if m == :cycle_end
+                case m
+                when :cycle_end
                     @cycle_index, @cycle_start_time = *args
                     return true
-                end
-
-                if m == :bad_call
+                when :bad_call
                     if !pending_async_calls.empty?
                         process_pending_async_call(args.first, nil)
                     else
                         e = args.first
                         raise e, e.message, (e.backtrace + caller)
                     end
-                elsif m == :reply
+                when :reply
                     if !pending_async_calls.empty?
                         process_pending_async_call(nil, args.first)
                     else
                         yield args.first
                     end
-                elsif m == :job_progress
+                when :job_progress
                     queue_job_progress(*args)
-                elsif m == :notification
+                when :notification
                     queue_notification(*args)
-                elsif m == :ui_event
+                when :ui_event
                     queue_ui_event(*args)
-                elsif m == :exception
+                when :exception
                     queue_exception(*args)
                 else
                     raise ProtocolError,
@@ -410,7 +409,7 @@ module Roby
                 # @param [Object] context the underlying interface object
                 def initialize(context)
                     @context = context
-                    @calls = ::Array.new
+                    @calls = []
                 end
 
                 def empty?

--- a/lib/roby/interface/command_library.rb
+++ b/lib/roby/interface/command_library.rb
@@ -42,6 +42,7 @@ module Roby
 
             # @return [Roby::Application] the application
             attr_reader :app
+
             # @return [Roby::Plan] the {#app}'s plan
             def plan
                 app.plan

--- a/lib/roby/interface/droby_channel.rb
+++ b/lib/roby/interface/droby_channel.rb
@@ -7,6 +7,7 @@ module Roby
             # @return [#read_nonblock,#write] the channel that allows us to
             #   communicate to clients
             attr_reader :io
+
             # @return [Boolean] true if the local process is the client or the
             #   server
             attr_predicate :client?

--- a/lib/roby/interface/interface.rb
+++ b/lib/roby/interface/interface.rb
@@ -260,9 +260,10 @@ module Roby
                 end
 
                 job_notifications = self.job_notifications.find_all do |event, job_id, *|
-                    if event == JOB_FINALIZED
+                    case event
+                    when JOB_FINALIZED
                         true
-                    elsif event == JOB_DROPPED
+                    when JOB_DROPPED
                         !final_tracked_jobs.include?(job_id)
                     else
                         tracked_jobs.include?(job_id)
@@ -452,10 +453,9 @@ module Roby
                 end
                 planning_task.success_event.on do |ev|
                     job_task = planning_task.planned_task
-                    if job_task == service.task
-                        if job_task.pending? || job_task.starting?
-                            job_notify(JOB_READY, job_id, job_name)
-                        end
+                    if job_task == service.task &&
+                       (job_task.pending? || job_task.starting?)
+                        job_notify(JOB_READY, job_id, job_name)
                     end
                 end
                 planning_task.stop_event.on do |ev|

--- a/lib/roby/interface/rest/server.rb
+++ b/lib/roby/interface/rest/server.rb
@@ -78,8 +78,7 @@ module Roby
                 # Intermediate Rack middleware used to inject the roby storage
                 # and interface objects that allow {Helpers} to function
                 class RackMiddleware
-                    attr_reader :interface
-                    attr_reader :storage
+                    attr_reader :interface, :storage
 
                     def initialize(api, interface, storage = {})
                         @api = api

--- a/lib/roby/interface/server.rb
+++ b/lib/roby/interface/server.rb
@@ -11,6 +11,7 @@ module Roby
             attr_reader :interface
             # @return [String] a string that allows the user to identify the client
             attr_reader :client_id
+
             # @return [Boolean] whether the messages should be
             #   forwarded to our clients
             attr_predicate :notifications_enabled?, true

--- a/lib/roby/interface/shell_client.rb
+++ b/lib/roby/interface/shell_client.rb
@@ -167,7 +167,7 @@ module Roby
                     msg[0] = Roby.color(msg[0], :red)
                 end
                 puts msg.join("\n")
-                puts "  " + e.backtrace.join("\n  ")
+                puts "  #{e.backtrace.join('\n  ')}"
                 nil
             end
 
@@ -188,10 +188,16 @@ module Roby
             end
 
             def format_exception(kind, error, *args)
-                color = if kind == ExecutionEngine::EXCEPTION_FATAL then [:red]
-                        elsif kind == ExecutionEngine::EXCEPTION_NONFATAL then [:magenta]
-                        else []
-                        end
+                color =
+                    case kind
+                    when ExecutionEngine::EXCEPTION_FATAL
+                        [:red]
+                    when ExecutionEngine::EXCEPTION_NONFATAL
+                        [:magenta]
+                    else
+                        []
+                    end
+
                 if error
                     msg = Roby.format_exception(error.exception)
                     if msg[0]

--- a/lib/roby/interface/tcp.rb
+++ b/lib/roby/interface/tcp.rb
@@ -12,6 +12,7 @@ module Roby
             attr_reader :server
             # @return [Array<Client>] set of currently active clients
             attr_reader :clients
+
             # Whether the server handler should warn about disconnections
             attr_predicate :warn_about_disconnection?, true
             # Whether a non-comm-related failure will cause the whole Roby app

--- a/lib/roby/models/task.rb
+++ b/lib/roby/models/task.rb
@@ -20,9 +20,7 @@ module Roby
 
             class Template < TemplatePlan
                 attr_reader :events_by_name
-                attr_accessor :success_events
-                attr_accessor :failure_events
-                attr_accessor :terminal_events
+                attr_accessor :success_events, :failure_events, :terminal_events
 
                 def initialize
                     super
@@ -172,10 +170,10 @@ module Roby
                 )
 
                 events.each_value do |ev|
-                    if ev.event_model.terminal?
-                        if !success_events.include?(ev) && !failure_events.include?(ev)
-                            terminal_events << ev
-                        end
+                    next unless ev.event_model.terminal?
+
+                    if !success_events.include?(ev) && !failure_events.include?(ev)
+                        terminal_events << ev
                     end
                 end
 

--- a/lib/roby/plan_object.rb
+++ b/lib/roby/plan_object.rb
@@ -58,6 +58,7 @@ module Roby
         class InstanceHandler
             # The poll Proc object
             attr_reader :block
+
             ## :method:copy_on_replace?
             #
             # If true, this poll handler gets copied to the new task when the
@@ -506,7 +507,8 @@ module Roby
                 end
             end
 
-            changes.each_slice(3) do |rel, parents, children|
+            # See comment above about keeping the two loops separate
+            changes.each_slice(3) do |rel, parents, children| # rubocop:disable Style/CombinableLoops
                 parents.each_slice(2) do |parent, info|
                     parent.add_child_object(object, rel, info)
                 end

--- a/lib/roby/promise.rb
+++ b/lib/roby/promise.rb
@@ -133,7 +133,10 @@ module Roby
         # concurrent-ruby promise.
         class Failure < RuntimeError
             attr_reader :actual_exception
+
             def initialize(error)
+                super()
+
                 @actual_exception = error
             end
         end

--- a/lib/roby/queries/and_matcher.rb
+++ b/lib/roby/queries/and_matcher.rb
@@ -7,6 +7,8 @@ module Roby
         class AndMatcher < MatcherBase
             # Create a new AndMatcher object combining the given predicates.
             def initialize(*ops)
+                super()
+
                 @ops = ops
             end
 

--- a/lib/roby/queries/code_error_matcher.rb
+++ b/lib/roby/queries/code_error_matcher.rb
@@ -38,9 +38,9 @@ module Roby
             def to_s
                 description = super
                 if ruby_exception_class
-                    description.concat(".with_ruby_exception(#{ruby_exception_class})")
+                    description + ".with_ruby_exception(#{ruby_exception_class})"
                 else
-                    description.concat(".without_ruby_exception")
+                    description + ".without_ruby_exception"
                 end
             end
 

--- a/lib/roby/queries/code_error_matcher.rb
+++ b/lib/roby/queries/code_error_matcher.rb
@@ -8,6 +8,7 @@ module Roby
         # properties on the Ruby exception that has been thrown
         class CodeErrorMatcher < LocalizedErrorMatcher
             attr_reader :ruby_exception_class
+
             def initialize
                 super
                 @ruby_exception_class = ::Exception
@@ -38,14 +39,14 @@ module Roby
             def to_s
                 description = super
                 if ruby_exception_class
-                    description + ".with_ruby_exception(#{ruby_exception_class})"
+                    "#{description}.with_ruby_exception(#{ruby_exception_class})"
                 else
-                    description + ".without_ruby_exception"
+                    "#{description}.without_ruby_exception"
                 end
             end
 
             def describe_failed_match(exception)
-                if description = super
+                if (description = super)
                     description
                 elsif !(ruby_exception_class === exception.error)
                     if ruby_exception_class

--- a/lib/roby/queries/execution_exception_matcher.rb
+++ b/lib/roby/queries/execution_exception_matcher.rb
@@ -136,7 +136,7 @@ module Roby
 
             # @return [Boolean] true if the given execution exception object
             #   matches self, false otherwise
-            def ===(exception)
+            def ===(exception) # rubocop:disable Metrics/PerceivedComplexity
                 return false unless exception.respond_to?(:to_execution_exception)
 
                 exception = exception.to_execution_exception

--- a/lib/roby/queries/local_query_result.rb
+++ b/lib/roby/queries/local_query_result.rb
@@ -3,8 +3,7 @@
 module Roby
     module Queries
         class LocalQueryResult
-            attr_reader :plan
-            attr_reader :initial_set
+            attr_reader :plan, :initial_set
             attr_accessor :result_set
 
             def initialize(plan, initial_set, result_set)

--- a/lib/roby/queries/not_matcher.rb
+++ b/lib/roby/queries/not_matcher.rb
@@ -8,6 +8,8 @@ module Roby
         class NotMatcher < MatcherBase
             # Create a new TaskMatcher which matches if and only if +op+ does not
             def initialize(op)
+                super()
+
                 @op = op
             end
 

--- a/lib/roby/queries/or_matcher.rb
+++ b/lib/roby/queries/or_matcher.rb
@@ -7,6 +7,8 @@ module Roby
         class OrMatcher < MatcherBase
             # Create a new OrMatcher object combining the given predicates.
             def initialize(*ops)
+                super()
+
                 @ops = ops
             end
 

--- a/lib/roby/queries/plan_object_matcher.rb
+++ b/lib/roby/queries/plan_object_matcher.rb
@@ -57,6 +57,8 @@ module Roby
 
             # Initializes an empty TaskMatcher object
             def initialize(instance = nil)
+                super()
+
                 @instance               = instance
                 @model                  = []
                 @predicates             = []

--- a/lib/roby/queries/task_event_generator_matcher.rb
+++ b/lib/roby/queries/task_event_generator_matcher.rb
@@ -12,6 +12,7 @@ module Roby
             # @return [TaskMatcher] the task matcher that describes this event's
             #   task
             attr_reader :task_matcher
+
             # @return [Boolean] if true, self will match the specified generator
             #   as well as any other generator that is forwarded to it. If false
             #   (the default) only the specified generator will match

--- a/lib/roby/queries/task_matcher.rb
+++ b/lib/roby/queries/task_matcher.rb
@@ -411,7 +411,7 @@ module Roby
             end
 
             # True if +task+ matches all the criteria defined on this object.
-            def ===(task) # rubocop:disable Metrics/CyclomaticComplexity
+            def ===(task) # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
                 return unless task.kind_of?(Roby::Task)
                 return unless task.arguments.slice(*arguments.keys) == arguments
                 return unless super

--- a/lib/roby/relations/bidirectional_directed_adjacency_graph.rb
+++ b/lib/roby/relations/bidirectional_directed_adjacency_graph.rb
@@ -15,8 +15,7 @@ module Roby
         class BidirectionalDirectedAdjacencyGraph
             include RGL::MutableGraph
 
-            attr_reader :forward_edges_with_info
-            attr_reader :backward_edges
+            attr_reader :forward_edges_with_info, :backward_edges
 
             # Shortcut for creating a DirectedAdjacencyGraph:
             #
@@ -82,7 +81,8 @@ module Roby
             def dedupe(source)
                 all_identical = (@forward_edges_with_info.size ==
                                  source.forward_edges_with_info.size)
-                @forward_edges_with_info.keys.each do |v|
+                # Use #keys.each instead of #each_key as we are modifying in-place
+                @forward_edges_with_info.keys.each do |v| # rubocop:disable Style/HashEachMethods
                     self_out_edges   = @forward_edges_with_info[v]
                     source_out_edges = source.forward_edges_with_info[v]
                     if self_out_edges.empty?
@@ -101,7 +101,8 @@ module Roby
                     return
                 end
 
-                @backward_edges.keys.each do |v|
+                # Use #keys.each instead of #each_key as we are modifying in-place
+                @backward_edges.keys.each do |v| # rubocop:disable Style/HashEachMethods
                     self_in_edges   = @backward_edges[v]
                     source_in_edges = source.backward_edges[v]
                     if self_in_edges.empty?

--- a/lib/roby/relations/directed_relation_support.rb
+++ b/lib/roby/relations/directed_relation_support.rb
@@ -115,10 +115,8 @@ module Roby
             def clear_vertex(remove_strong: true)
                 for rel in sorted_relations
                     graph = relation_graphs[rel]
-                    if remove_strong || !graph.strong?
-                        if graph.remove_vertex(self)
-                            removed = true
-                        end
+                    if (remove_strong || !graph.strong?) && graph.remove_vertex(self)
+                        removed = true
                     end
                 end
                 removed

--- a/lib/roby/relations/fork_merge_visitor.rb
+++ b/lib/roby/relations/fork_merge_visitor.rb
@@ -52,8 +52,8 @@ module Roby
             # A visitor that counts the in/out degree of vertices contained in a
             # subgraph
             class SubgraphDegreeCounter < RGL::DFSVisitor
-                attr_reader :out_degree
-                attr_reader :in_degree
+                attr_reader :out_degree, :in_degree
+
                 def initialize(graph)
                     @out_degree = Hash.new(0)
                     @in_degree = Hash.new(0)
@@ -97,9 +97,7 @@ module Roby
             end
 
             def follow_edge?(u, v)
-                if u == origin
-                    return unless origin_neighbours.include?(v)
-                end
+                return if u == origin && !origin_neighbours.include?(v)
 
                 degree = in_degree[v]
                 if degree == 1
@@ -110,9 +108,7 @@ module Roby
             end
 
             def handle_forward_edge(u, v)
-                if u == origin
-                    return unless origin_neighbours.include?(v)
-                end
+                return if u == origin && !origin_neighbours.include?(v)
 
                 obj = vertex_to_object.fetch(u)
                 if obj

--- a/lib/roby/relations/space.rb
+++ b/lib/roby/relations/space.rb
@@ -77,7 +77,7 @@ module Roby
                     g = rel.new(observer: observer)
                     graphs[g] = graphs[rel] = g
                 end
-                relations.each do |rel|
+                relations.each do |rel| # rubocop:disable Style/CombinableLoops
                     rel.subsets.each do |subset_rel|
                         graphs[rel].superset_of(graphs[subset_rel])
                     end
@@ -108,12 +108,10 @@ module Roby
             end
 
             # Yields the relations that are defined on this space
-            def each_relation
+            def each_relation(&block)
                 return enum_for(__method__) unless block_given?
 
-                relations.each do |rel|
-                    yield(rel)
-                end
+                relations.each(&block)
             end
 
             # Yields the root relations that are defined on this space. A relation

--- a/lib/roby/schedulers/null.rb
+++ b/lib/roby/schedulers/null.rb
@@ -11,6 +11,8 @@ module Roby
             attr_reader :plan
 
             def initialize(plan)
+                super()
+
                 @plan = plan
             end
 

--- a/lib/roby/standard_errors.rb
+++ b/lib/roby/standard_errors.rb
@@ -51,6 +51,8 @@ module Roby
         attr_accessor :original_exceptions
 
         def initialize(exceptions = [])
+            super()
+
             @original_exceptions = exceptions
         end
 
@@ -187,9 +189,7 @@ module Roby
             end
         end
 
-        attr_reader :plan
-
-        attr_reader :removed_at
+        attr_reader :plan, :removed_at
 
         def pretty_print(pp)
             pp.text "#{failed_generator.symbol} called but it is not executable on"
@@ -384,8 +384,7 @@ module Roby
 
     # Raised when an exception handler has raised.
     class FailedExceptionHandler < CodeError
-        attr_reader :handled_exception
-        attr_reader :handler
+        attr_reader :handled_exception, :handler
 
         def initialize(error, object, handled_exception, handler)
             super(error, object)
@@ -448,6 +447,8 @@ module Roby
 
         # Create a new InvalidReplace object
         def initialize(from, to)
+            super()
+
             @from, @to = from, to
         end
 
@@ -531,6 +532,8 @@ module Roby
         attr_reader :known_children
 
         def initialize(object, role, known_children)
+            super()
+
             @object, @role, @known_children = object, role, known_children
         end
 

--- a/lib/roby/state/events.rb
+++ b/lib/roby/state/events.rb
@@ -171,9 +171,7 @@ module Roby
 
     # Implementation of StateSpace#trigger_when
     class StateConditionEvent < StateEvent
-        attr_reader :state_space
-        attr_reader :variable_path
-        attr_reader :condition
+        attr_reader :state_space, :variable_path, :condition
 
         def initialize(state_space = nil, variable_path = [], condition = nil)
             @state_space, @variable_path, @condition =

--- a/lib/roby/state/open_struct.rb
+++ b/lib/roby/state/open_struct.rb
@@ -40,7 +40,7 @@ module Roby
     # listed in NOT_OVERRIDABLE
     #
     class OpenStruct
-        attr_reader :model
+        attr_reader :model, :attach_as, :__parent_struct, :__parent_name
 
         # +attach_to+ and +attach_name+
         # are used so that
@@ -137,8 +137,6 @@ module Roby
             marshalled_members.compact!
             Marshal.dump([marshalled_members, @aliases])
         end
-
-        attr_reader :attach_as, :__parent_struct, :__parent_name
 
         # Create a model structure and associate it with this openstruct
         def new_model
@@ -301,7 +299,7 @@ module Roby
             if name
                 name = name.to_s
                 child = @members.delete(name) || @pending.delete(name)
-                child.detached! if child&.respond_to?(:detached!)
+                child.detached! if child.respond_to?(:detached!)
 
                 # We don't detach aliases
                 if !child && !@aliases.delete(name)
@@ -547,8 +545,7 @@ module Roby
             end
 
             if name =~ /^(\w+)=$/
-                ret = set($1, *args)
-                ret
+                set($1, *args)
 
             elsif name =~ /^(\w+)\?$/
                 # Test

--- a/lib/roby/state/pos.rb
+++ b/lib/roby/state/pos.rb
@@ -6,6 +6,7 @@ module Roby::Pos
     class Vector3D
         # The vector coordinates
         attr_accessor :x, :y, :z
+
         # Initializes a 3D vector
         def initialize(x = 0, y = 0, z = 0)
             @x, @y, @z = x, y, z

--- a/lib/roby/state/shapes.rb
+++ b/lib/roby/state/shapes.rb
@@ -2,6 +2,7 @@
 
 class Cylinder
     attr_accessor :radius, :height, :axis
+
     def initialize(radius, height, axis)
         @radius, @height, @axis = radius.to_f, height.to_f, axis.to_f
     end
@@ -25,6 +26,7 @@ end
 
 class Cube
     attr_accessor :length, :width, :height
+
     def initialize(length, width, height)
         @length, @width, @height = length.to_f, width.to_f, height.to_f
     end

--- a/lib/roby/support.rb
+++ b/lib/roby/support.rb
@@ -73,7 +73,7 @@ end
 
 module Enumerable
     def empty?
-        each { return false }
+        each { return false } # rubocop:disable Lint/UnreachableLoop
         true
     end
 end
@@ -100,9 +100,10 @@ end
 
 module Roby
     def self.format_time(time, format = "hms")
-        if format == "sec"
+        case format
+        when "sec"
             time.to_f.to_s
-        elsif format == "hms"
+        when "hms"
             time.strftime("%H:%M:%S.%3N")
         else
             time.strftime(format)
@@ -160,8 +161,7 @@ module Roby
     extend logger_m
 
     class << self
-        attr_accessor :enable_deprecation_warnings
-        attr_accessor :deprecation_warnings_are_errors
+        attr_accessor :enable_deprecation_warnings, :deprecation_warnings_are_errors
     end
     @enable_deprecation_warnings = true
     @deprecation_warnings_are_errors = (ENV["ROBY_ALL_DEPRECATIONS_ARE_ERRORS"] == "1")

--- a/lib/roby/task_arguments.rb
+++ b/lib/roby/task_arguments.rb
@@ -38,8 +38,7 @@ module Roby
     # to the delayed arguments, allowing for instance two default argument
     # to be merged if they have the same value.
     class TaskArguments
-        attr_reader :task
-        attr_reader :values
+        attr_reader :task, :values
 
         def initialize(task)
             @task   = task
@@ -629,7 +628,7 @@ module Roby
 
         def ==(other)
             other.kind_of?(DelayedArgumentFromObject) &&
-                @object.object_id == other.instance_variable_get(:@object).object_id &&
+                @object.equal?(other.instance_variable_get(:@object)) &&
                 @methods == other.instance_variable_get(:@methods)
         end
 

--- a/lib/roby/task_structure/conflicts.rb
+++ b/lib/roby/task_structure/conflicts.rb
@@ -78,8 +78,7 @@ module Roby
         # Note that it is not an exception as a failed conflict is usually
         # handled by calling #failed_to_start! on the newly started task
         class ConflictError
-            attr_reader :starting_task
-            attr_reader :running_tasks
+            attr_reader :starting_task, :running_tasks
 
             def initialize(starting_task, running_tasks)
                 @starting_task, @running_tasks = starting_task, running_tasks

--- a/lib/roby/task_structure/dependency.rb
+++ b/lib/roby/task_structure/dependency.rb
@@ -8,8 +8,7 @@ module Roby
         relation :Dependency, child_name: :child, parent_name: :parent_task
 
         class Dependency < Relations::TaskRelationGraph
-            attr_reader :interesting_events
-            attr_reader :failing_tasks
+            attr_reader :interesting_events, :failing_tasks
 
             def initialize(observer: nil)
                 super(observer: observer)
@@ -942,9 +941,10 @@ module Roby
             parent.pretty_print(pp)
             pp.breakable
             pp.breakable
-            if mode == :failed_event
+            case mode
+            when :failed_event
                 pp.text "Child triggered the failure predicate '#{relation[:failure]}': "
-            elsif mode == :unreachable_success
+            when :unreachable_success
                 pp.text "success condition can no longer be reached '#{relation[:success]}': "
             end
             explanation.pretty_print(pp, context_task: child)

--- a/lib/roby/task_structure/executed_by.rb
+++ b/lib/roby/task_structure/executed_by.rb
@@ -203,6 +203,7 @@ module Roby
         # Exception raised when trying to start a task whose execution agent is not ready
         class ExecutionAgentNotReady < Roby::CommandFailed
             attr_reader :execution_agent
+
             def initialize(task)
                 super(nil, task.start_event)
                 @execution_agent = task.execution_agent

--- a/lib/roby/task_structure/planned_by.rb
+++ b/lib/roby/task_structure/planned_by.rb
@@ -69,6 +69,7 @@ module Roby
     class PlanningFailedError < LocalizedError
         # The planning task
         attr_reader :planning_task
+
         # The planned task
         def planned_task
             failed_task

--- a/lib/roby/tasks/external_process.rb
+++ b/lib/roby/tasks/external_process.rb
@@ -48,14 +48,12 @@ module Roby
             # running
             attr_reader :pid
 
-            def initialize(arguments = {})
-                if arg = arguments[:command_line]
-                    arguments[:command_line] = [arg] unless arg.kind_of?(Array)
-                end
+            def initialize(command_line: [], **arguments)
+                command_line = Array(command_line)
                 @pid = nil
                 @buffer = nil
                 @redirection = {}
-                super(arguments)
+                super(command_line: command_line, **arguments)
             end
 
             # Called to announce that this task has been killed. +result+ is the

--- a/lib/roby/tasks/parallel.rb
+++ b/lib/roby/tasks/parallel.rb
@@ -7,6 +7,7 @@ module Roby::Tasks
         end
 
         attr_reader :children_success
+
         def initialize(arguments = {})
             super
 

--- a/lib/roby/tasks/virtual.rb
+++ b/lib/roby/tasks/virtual.rb
@@ -14,6 +14,7 @@ module Roby
             attr_reader :actual_start_event
             # The success event
             attr_accessor :actual_success_event
+
             # Set the start event
             def actual_start_event=(ev)
                 unless ev.controlable?

--- a/lib/roby/test/assertion.rb
+++ b/lib/roby/test/assertion.rb
@@ -6,6 +6,8 @@ module Roby
             attr_reader :original_error
 
             def initialize(original_error)
+                super()
+
                 @original_error = original_error
             end
 

--- a/lib/roby/test/error.rb
+++ b/lib/roby/test/error.rb
@@ -8,6 +8,8 @@ module Roby
             attr_reader :original_error
 
             def initialize(original_error)
+                super()
+
                 @original_error = original_error
             end
 

--- a/lib/roby/test/execution_expectations.rb
+++ b/lib/roby/test/execution_expectations.rb
@@ -342,11 +342,13 @@ module Roby
             end
 
             def self.format_propagation_info(propagation_info, indent: 0)
-                PP.pp(propagation_info, "".dup).split("\n").join("\n" + " " * indent)
+                PP.pp(propagation_info, "".dup).split("\n").join("\n#{' ' * indent}")
             end
 
             class Unmet < Minitest::Assertion
                 def initialize(expectations_with_explanations, propagation_info)
+                    super()
+
                     @expectations = expectations_with_explanations
                     @propagation_info = propagation_info
                 end
@@ -383,6 +385,8 @@ module Roby
 
             class UnexpectedErrors < Minitest::Assertion
                 def initialize(errors)
+                    super()
+
                     @errors = errors
                 end
 
@@ -423,7 +427,7 @@ module Roby
                         e = e.exception if e.kind_of?(ExecutionException)
                         if e.backtrace && !e.backtrace.empty?
                             formatted_execution_exception +=
-                                "\n    " + e.backtrace.join("\n    ")
+                                "\n    #{e.backtrace.join('\n    ')}"
                         end
 
                         sub_exceptions = Roby.flatten_exception(e)
@@ -434,14 +438,14 @@ module Roby
                                             Roby.format_exception(sub_e).join("\n    ")
                                 backtrace = Roby.format_backtrace(sub_e)
                                 unless backtrace.empty?
-                                    formatted += "    " + backtrace.join("\n    ")
+                                    formatted += "    #{backtrace.join('\n    ')}"
                                 end
                                 formatted
                             end.join("\n  ")
 
                         unless formatted_sub_exceptions.empty?
                             formatted_execution_exception +=
-                                "\n  " + formatted_sub_exceptions
+                                "\n  #{formatted_sub_exceptions}"
                         end
                         formatted_execution_exception
                     end.join("\n")
@@ -1090,7 +1094,7 @@ module Roby
                 def initialize(task, reason, backtrace)
                     super(backtrace)
                     @task = task
-                    return unless reason&.respond_to?(:to_execution_exception_matcher)
+                    return unless reason.respond_to?(:to_execution_exception_matcher)
 
                     @reason = reason.to_execution_exception_matcher
                     @related_error_match = make_related_error_matcher(reason)

--- a/lib/roby/test/expect_execution.rb
+++ b/lib/roby/test/expect_execution.rb
@@ -38,20 +38,20 @@ module Roby
         # Note that the heavy-lifting is done in {ExecutionExpectations}. This
         # is really only the sugar-coating above the test harness itself.
         module ExpectExecution
+            SETUP_METHODS = %i[
+                timeout
+                wait_until_timeout
+                join_all_waiting_work
+                scheduler
+                garbage_collect
+                validate_unexpected_errors
+                display_exceptions
+                poll
+            ].freeze
+
             # The context object that allows the expect_execution { }.to { }
             # syntax
             Context = Struct.new :test, :expectations, :block do
-                SETUP_METHODS = %i[
-                    timeout
-                    wait_until_timeout
-                    join_all_waiting_work
-                    scheduler
-                    garbage_collect
-                    validate_unexpected_errors
-                    display_exceptions
-                    poll
-                ].freeze
-
                 def respond_to_missing?(m, include_private)
                     SETUP_METHODS.include?(m)
                 end

--- a/lib/roby/test/tasks/goto.rb
+++ b/lib/roby/test/tasks/goto.rb
@@ -22,7 +22,7 @@ module Roby
             poll do
                 dx = x - State.pos.x
                 dy = y - State.pos.y
-                d = Math.sqrt(dx * dx + dy * dy)
+                d = Math.sqrt(dx**2 + dy**2)
                 if d > speed
                     State.pos.x += speed * dx / d
                     State.pos.y += speed * dy / d

--- a/lib/roby/test/testcase.rb
+++ b/lib/roby/test/testcase.rb
@@ -168,9 +168,7 @@ module Roby
             end
 
             def run(result) # :nodoc:
-                if self.class == TestCase
-                    return
-                end
+                return if instance_of?(TestCase)
 
                 self.class.apply_robot_setup do
                     yield if block_given?

--- a/lib/roby/test/tools.rb
+++ b/lib/roby/test/tools.rb
@@ -56,7 +56,7 @@ module Roby
                 samples
             end
 
-            Stat = Struct.new :total, :count, :mean, :stddev, :min, :max
+            Stat = Struct.new :total, :count, :mean, :stddev, :min, :max # rubocop:disable Lint/StructNewOverride
 
             # Computes mean and standard deviation about the samples in
             # +samples+ +spec+ describes what to compute:

--- a/lib/roby/transaction.rb
+++ b/lib/roby/transaction.rb
@@ -660,8 +660,9 @@ module Roby
                 end
             end
             proxy_tasks.each do |obj, proxy|
-                if (tr = trigger_matches.delete(proxy))
-                    trigger_matches[obj] = tr unless tr === obj # already triggered
+                # Add to matches if it matches and has not triggered yet
+                if (tr = trigger_matches.delete(proxy)) && !(tr === obj)
+                    trigger_matches[obj] = tr
                 end
             end
             trigger_matches

--- a/lib/roby/transaction/proxying.rb
+++ b/lib/roby/transaction/proxying.rb
@@ -70,6 +70,7 @@ module Roby
             def self.create_forwarder_module(methods)
                 Module.new do
                     attr_accessor :__getobj__
+
                     def transaction_proxy?
                         true
                     end

--- a/roby.gemspec
+++ b/roby.gemspec
@@ -10,6 +10,7 @@ Gem::Specification.new do |s|
     s.authors = ["Sylvain Joyeux"]
     s.email = "sylvain.joyeux@m4x.org"
     s.summary = "A plan-based control framework for autonomous systems"
+    s.required_ruby_version = "2.5.0"
     s.description = <<~DESCRIPTION
         The Roby plan manager is currently developped from within the Robot Construction
         Kit (http://rock-robotics.org). Have a look there. Additionally, the [Roby User

--- a/test/actions/models/test_action.rb
+++ b/test/actions/models/test_action.rb
@@ -5,6 +5,7 @@ require "roby/test/self"
 describe Roby::Actions::Models::Action do
     describe "#plan_pattern" do
         attr_reader :action_m
+
         before do
             task_m = Roby::Task.new_submodel
             interface_m = Roby::Actions::Interface.new_submodel do
@@ -54,6 +55,7 @@ describe Roby::Actions::Models::Action do
 
     describe "#update" do
         attr_reader :action_m, :updated_m
+
         before do
             interface_m = Roby::Actions::Interface.new_submodel
             @action_m   = Roby::Actions::Models::Action.new(interface_m)
@@ -110,6 +112,7 @@ describe Roby::Actions::Models::Action do
     end
     describe "#validate_can_overload" do
         attr_reader :action_m, :updated_m
+
         before do
             interface_m = Roby::Actions::Interface.new_submodel
             @action_m   = Roby::Actions::Models::Action.new(interface_m)
@@ -138,6 +141,7 @@ describe Roby::Actions::Models::Action do
 
     describe "#has_arg?" do
         attr_reader :action_m
+
         before do
             interface_m = Roby::Actions::Interface.new_submodel
             @action_m   = Roby::Actions::Models::Action.new(interface_m)

--- a/test/actions/models/test_coordination_action.rb
+++ b/test/actions/models/test_coordination_action.rb
@@ -7,6 +7,7 @@ module Roby
             describe CoordinationAction do
                 describe "droby marshalling" do
                     attr_reader :interface_m, :action_m, :machine_m
+
                     before do
                         @interface_m = Actions::Interface.new_submodel(name: "Actions")
                         task_m = Roby::Task.new_submodel(name: "RootTask")

--- a/test/actions/models/test_interface.rb
+++ b/test/actions/models/test_interface.rb
@@ -7,6 +7,7 @@ module Roby
         module Models
             describe Interface do
                 attr_reader :interface_m
+
                 before do
                     @interface_m = Actions::Interface.new_submodel
                 end
@@ -66,6 +67,7 @@ module Roby
 
                     describe "argument handling" do
                         attr_reader :action_m
+
                         before do
                             @action_m = interface_m.describe("an action")
                         end
@@ -145,6 +147,7 @@ module Roby
 
                 describe "#find_action_by_name" do
                     attr_reader :description
+
                     before do
                         interface_m.describe "an_action"
                         interface_m.send(:define_method, :an_action) {}

--- a/test/actions/models/test_library.rb
+++ b/test/actions/models/test_library.rb
@@ -16,6 +16,7 @@ module Roby
 
                 describe "#use_library" do
                     attr_reader :library
+
                     before do
                         @library = Actions::Library.new_submodel do
                             describe "test"

--- a/test/actions/models/test_method_action.rb
+++ b/test/actions/models/test_method_action.rb
@@ -7,6 +7,7 @@ module Roby
         module Models
             describe MethodAction do
                 attr_reader :interface_m, :action_m
+
                 before do
                     @interface_m = Actions::Interface.new_submodel(name: "TestActions")
                     @action_m = MethodAction.new(interface_m)

--- a/test/actions/test_action.rb
+++ b/test/actions/test_action.rb
@@ -8,6 +8,7 @@ module Roby
         describe Action do
             describe "#has_missing_required_arg?" do
                 attr_reader :action_m
+
                 before do
                     @action_m = Interface.new_submodel
                 end

--- a/test/actions/test_task.rb
+++ b/test/actions/test_task.rb
@@ -7,6 +7,7 @@ class TC_Actions_Task < Minitest::Test
     class TaskModel < Roby::Task; end
 
     attr_reader :iface_m, :task
+
     def setup
         super
 

--- a/test/app/cucumber/test_controller.rb
+++ b/test/app/cucumber/test_controller.rb
@@ -9,6 +9,7 @@ module Roby
         module Cucumber
             describe Controller do
                 attr_reader :controller, :roby_app_dir, :roby_log_dir
+
                 before do
                     @controller = Controller.new
                     @roby_app_dir = make_tmpdir

--- a/test/app/test_debug.rb
+++ b/test/app/test_debug.rb
@@ -7,6 +7,7 @@ module Roby
     module App
         describe Debug do
             attr_reader :debug
+
             before do
                 @app = Application.new
                 @app.log_dir = make_tmpdir

--- a/test/behaviors/plan_common_behavior.rb
+++ b/test/behaviors/plan_common_behavior.rb
@@ -12,19 +12,18 @@ module Roby
             else
                 assert_equal(plan, task.plan, "task was meant to be included in a plan but PlanObject#plan returns nil")
                 assert(plan.has_task?(task), "task was meant to be included in a plan but Plan#has_task? returned false")
-                if state == :permanent
-                    assert(plan.permanent_task?(task), "task was meant to be permanent but Plan#permanen_taskt? returned false")
-                else
-                    assert(!plan.permanent_task?(task), "task was not meant to be permanent but Plan#permanen_taskt? returned true")
-                end
 
-                if state == :mission
+                case state
+                when :mission
                     assert(plan.mission_task?(task), "task was meant to be a mission, but Plan#mission_task? returned false")
                     assert(task.mission?, "task was meant to be a mission, but Task#mission_task? returned false")
-                elsif state == :permanent
+                    assert(!plan.permanent_task?(task), "task was not meant to be permanent but Plan#permanen_taskt? returned true")
+                when :permanent
+                    assert(plan.permanent_task?(task), "task was meant to be permanent but Plan#permanen_taskt? returned false")
                     assert(!plan.mission_task?(task), "task was meant to be permanent but Plan#mission_task? returned true")
                     assert(!task.mission?, "task was meant to be permanent but Task#mission? returned true")
-                elsif state == :normal
+                when :normal
+                    assert(!plan.permanent_task?(task), "task was not meant to be permanent but Plan#permanen_taskt? returned true")
                     assert(!plan.mission_task?(task), "task was meant to be permanent but Plan#mission_task? returned true")
                     assert(!task.mission?, "task was meant to be permanent but Task#mission? returned true")
                 end

--- a/test/cli/test_display.rb
+++ b/test/cli/test_display.rb
@@ -76,6 +76,7 @@ module Roby
                 include Test::RobyAppHelpers
 
                 attr_reader :logfile_path
+
                 before do
                     @logfile_path, writer = roby_app_create_logfile
                     writer.close
@@ -174,6 +175,7 @@ module Roby
                 include Test::RobyAppHelpers
 
                 attr_reader :logfile_path, :cli
+
                 before do
                     @logfile_path, writer = roby_app_create_logfile
                     writer.close

--- a/test/coordination/models/test_action_state_machine.rb
+++ b/test/coordination/models/test_action_state_machine.rb
@@ -4,6 +4,7 @@ require "roby/test/self"
 
 describe Roby::Coordination::Models::ActionStateMachine do
     attr_reader :task_m, :action_m, :description
+
     before do
         task_m = @task_m = Roby::Task.new_submodel(name: "TaskModel") do
             terminates
@@ -115,6 +116,7 @@ describe Roby::Coordination::Models::ActionStateMachine do
 
     describe "event forwarding" do
         attr_reader :state_machine, :start
+
         before do
             _, @state_machine = @action_m.action_state_machine "test" do
                 start = state(start_task)
@@ -269,6 +271,7 @@ describe Roby::Coordination::Models::ActionStateMachine do
 
     describe "#rebind" do
         attr_reader :state_machine_action, :action_m, :new_action_m
+
         before do
             @state_machine_action, = @action_m.action_state_machine "test" do
                 start_task = state(self.start_task)

--- a/test/coordination/models/test_base.rb
+++ b/test/coordination/models/test_base.rb
@@ -7,6 +7,7 @@ module Roby
         module Models
             describe Base do
                 attr_reader :base_m
+
                 before do
                     @base_m = Class.new
                     base_m.extend Models::Base

--- a/test/coordination/test_action_script.rb
+++ b/test/coordination/test_action_script.rb
@@ -7,6 +7,7 @@ module Roby
     module Coordination
         describe ActionScript do
             attr_reader :task_model, :root_task, :script_task, :script_model
+
             before do
                 @task_model = Class.new(Tasks::Simple) do
                     event :intermediate
@@ -20,6 +21,7 @@ module Roby
 
             describe "#wait" do
                 attr_reader :action_task
+
                 before do
                     script_model.start script_task
                     script_model.wait script_task.intermediate_event

--- a/test/coordination/test_action_state_machine.rb
+++ b/test/coordination/test_action_state_machine.rb
@@ -6,6 +6,7 @@ module Roby
     module Coordination
         describe ActionStateMachine do
             attr_reader :task_m, :action_m, :description
+
             before do
                 task_m = @task_m = Roby::Task.new_submodel(name: "TaskModel") do
                     terminates

--- a/test/coordination/test_fault_handler.rb
+++ b/test/coordination/test_fault_handler.rb
@@ -5,6 +5,7 @@ require "roby/tasks/simple"
 
 describe Roby::Coordination::Models::FaultHandler do
     attr_reader :m0, :m1, :m2, :t0, :t1, :t2, :handler
+
     before do
         @m0, @m1, @m2, @t0, @t1, @t2 = prepare_plan add: 6, model: Roby::Tasks::Simple
         m0.depends_on m1

--- a/test/coordination/test_fault_response_table.rb
+++ b/test/coordination/test_fault_response_table.rb
@@ -111,6 +111,7 @@ describe Roby::Coordination::FaultResponseTable do
     describe "the fault response" do
         attr_reader :error_m, :response_task_m, :table_m, :fault_handler_m
         attr_reader :root_task
+
         before do
             @error_m = Class.new(Roby::LocalizedError)
             @response_task_m = response_task_m = Roby::Task.new_submodel do

--- a/test/coordination/test_task_script.rb
+++ b/test/coordination/test_task_script.rb
@@ -9,6 +9,7 @@ module Roby
         describe TaskScript do
             describe "#wait" do
                 attr_reader :root, :task_m, :event_source_task
+
                 before do
                     @task_m = Tasks::Simple.new_submodel do
                         event :test
@@ -217,6 +218,7 @@ module Roby
 
             describe "#poll_until" do
                 attr_reader :parent, :child, :parent_task_m, :child_task_m
+
                 before do
                     @child_task_m = Tasks::Simple.new_submodel { event :e }
                     @parent_task_m = Tasks::Simple.new_submodel do
@@ -306,6 +308,7 @@ module Roby
 
             describe "#timeout" do
                 attr_reader :task
+
                 before do
                     task_m = Roby::Tasks::Simple.new_submodel do
                         event :intermediate

--- a/test/droby/test_event_logging.rb
+++ b/test/droby/test_event_logging.rb
@@ -11,9 +11,11 @@ module Roby
         # some synthetic tests
         describe "Event logging" do
             attr_reader :logfile, :event_logger, :local_plan, :plan_rebuilder, :rebuilt_plan
+
             before do
                 @logfile = Class.new do
                     attr_reader :cycles
+
                     def initialize
                         @cycles = []
                     end
@@ -436,6 +438,7 @@ module Roby
 
                 describe "handling of event propagation" do
                     attr_reader :source, :target, :r_source, :r_target
+
                     before do
                         local_plan.add(@source = EventGenerator.new)
                         local_plan.add(@target = EventGenerator.new(true))

--- a/test/droby/test_logfile.rb
+++ b/test/droby/test_logfile.rb
@@ -9,6 +9,7 @@ module Roby
     module DRoby
         describe Logfile do
             attr_reader :tmpdir
+
             before do
                 @tmpdir = Dir.mktmpdir
                 @path = File.join(tmpdir, "test-events.log")
@@ -376,7 +377,7 @@ module Roby
 
                     before do
                         @log_path = droby_create_event_log("test.log") {}
-                        @index_path = @log_path + ".idx"
+                        @index_path = "#{@log_path}.idx"
                     end
                     it "returns true if the file exists and is valid" do
                         Logfile::Index.rebuild_file(@log_path, @index_path)

--- a/test/droby/v5/test_builtin.rb
+++ b/test/droby/v5/test_builtin.rb
@@ -32,6 +32,7 @@ module Roby
 
                 describe Builtins::ClassDumper do
                     attr_reader :local_base_class, :remote_base_class, :parent, :child
+
                     before do
                         @local_base_class = Class.new do
                             extend Identifiable

--- a/test/droby/v5/test_droby_dump.rb
+++ b/test/droby/v5/test_droby_dump.rb
@@ -197,6 +197,7 @@ module Roby
 
                     describe TaskDumper do
                         attr_reader :task_m
+
                         before do
                             @task_m = Roby::Task.new_submodel
                             task_m.terminates
@@ -501,8 +502,8 @@ module Roby
                     end
                 end
 
-                module Actions
-                    describe ActionDumper do
+                describe Actions do
+                    describe Actions::ActionDumper do
                         it "resolves the action arguments and model" do
                             task_m = Roby::Task.new_submodel
                             interface_m = Roby::Actions::Interface.new_submodel(name: "Test") do
@@ -522,8 +523,8 @@ module Roby
                         end
                     end
 
-                    module Models
-                        describe ActionDumper do
+                    describe Actions::Models do
+                        describe Actions::Models::ActionDumper do
                             it "resolves them on existing interface models" do
                                 task_m = Roby::Task.new_submodel
                                 interface_m = Roby::Actions::Interface.new_submodel(name: "Test") do
@@ -556,14 +557,14 @@ module Roby
                     end
                 end
 
-                module Queries
-                    describe AndMatcherDumper do
+                describe Queries do
+                    describe Queries::AndMatcherDumper do
                         it "is droby-marshallable" do
                             q0, q1 = flexmock, flexmock
                             and_q  = Roby::Queries::AndMatcher.new(q0, q1)
                             flexmock(marshaller).should_receive(:dump).with(and_q).pass_thru
                             flexmock(marshaller).should_receive(:dump).with([q0, q1]).and_return(42).once
-                            flexmock(demarshaller).should_receive(:local_object).with(AndMatcherDumper::DRoby).pass_thru
+                            flexmock(demarshaller).should_receive(:local_object).with(Queries::AndMatcherDumper::DRoby).pass_thru
                             flexmock(demarshaller).should_receive(:local_object).with(42).and_return([q0, q1]).once
                             q = transfer(and_q)
                             assert_kind_of Roby::Queries::AndMatcher, q
@@ -571,13 +572,13 @@ module Roby
                         end
                     end
 
-                    describe OrMatcherDumper do
+                    describe Queries::OrMatcherDumper do
                         it "is droby-marshallable" do
                             q0, q1 = flexmock, flexmock
                             or_q = Roby::Queries::OrMatcher.new(q0, q1)
                             flexmock(marshaller).should_receive(:dump).with(or_q).pass_thru
                             flexmock(marshaller).should_receive(:dump).with([q0, q1]).and_return(42).once
-                            flexmock(demarshaller).should_receive(:local_object).with(OrMatcherDumper::DRoby).pass_thru
+                            flexmock(demarshaller).should_receive(:local_object).with(Queries::OrMatcherDumper::DRoby).pass_thru
                             flexmock(demarshaller).should_receive(:local_object).with(42).and_return([q0, q1]).once
                             q = transfer(or_q)
                             assert_kind_of Roby::Queries::OrMatcher, q
@@ -585,12 +586,12 @@ module Roby
                         end
                     end
 
-                    describe NotMatcherDumper do
+                    describe Queries::NotMatcherDumper do
                         it "is droby-marshallable" do
                             not_q = Roby::Queries::NotMatcher.new(q = flexmock)
                             flexmock(marshaller).should_receive(:dump).with(not_q).pass_thru
                             flexmock(marshaller).should_receive(:dump).with(q).and_return(42).once
-                            flexmock(demarshaller).should_receive(:local_object).with(NotMatcherDumper::DRoby).pass_thru
+                            flexmock(demarshaller).should_receive(:local_object).with(Queries::NotMatcherDumper::DRoby).pass_thru
                             flexmock(demarshaller).should_receive(:local_object).with(42)
                                 .and_return(q).once
                             unmarshalled = transfer(not_q)
@@ -599,7 +600,7 @@ module Roby
                         end
                     end
 
-                    describe PlanObjectMatcherDumper do
+                    describe Queries::PlanObjectMatcherDumper do
                         let(:matcher) { Roby::Queries::PlanObjectMatcher.new }
 
                         it "demarshals as PlanObjectMatcher" do
@@ -631,6 +632,7 @@ module Roby
 
                         describe "relation matching" do
                             attr_reader :task_m, :r_task_m, :r_dependency
+
                             before do
                                 @task_m = Task.new_submodel
                                 marshaller_object_manager.register_object(task_m)
@@ -667,7 +669,7 @@ module Roby
                         end
                     end
 
-                    describe TaskMatcherDumper do
+                    describe Queries::TaskMatcherDumper do
                         let(:matcher) { Roby::Queries::TaskMatcher.new }
 
                         it "marshals the argument specifications" do
@@ -680,7 +682,7 @@ module Roby
                         end
                     end
 
-                    describe QueryDumper do
+                    describe Queries::QueryDumper do
                         it "maps the plan" do
                             query = local_plan.find_tasks
                             query = transfer(query)

--- a/test/droby/v5/test_droby_model.rb
+++ b/test/droby/v5/test_droby_model.rb
@@ -64,6 +64,7 @@ module Roby
 
                 describe "#update" do
                     attr_reader :provided_m, :local, :droby_model
+
                     before do
                         @provided_m = Module.new { extend Identifiable }
                         @droby_model = DRobyModel.new("", {}, Class.new, [marshalled_m = flexmock])

--- a/test/event_structure/test_temporal_constraints.rb
+++ b/test/event_structure/test_temporal_constraints.rb
@@ -312,6 +312,7 @@ module Roby
 
             describe SchedulingConstraints do
                 attr_reader :constraints, :task_a, :event_a, :task_b, :event_b
+
                 before do
                     @constraints = plan.event_relation_graph_for(SchedulingConstraints)
                     plan.add(@task_a = Roby::Task.new)
@@ -413,6 +414,7 @@ module Roby
             describe "TemporalConstraints" do
                 describe "#should_emit_after?" do
                     attr_reader :receiver, :argument
+
                     before do
                         plan.add(@receiver = EventGenerator.new)
                         plan.add(@argument = EventGenerator.new)

--- a/test/interface/async/test_action_monitor.rb
+++ b/test/interface/async/test_action_monitor.rb
@@ -78,6 +78,7 @@ module Roby
 
                 describe "a monitor with a job" do
                     attr_reader :job
+
                     before do
                         @job = create_mock_job(42, "test", id: 20)
                     end
@@ -128,7 +129,7 @@ module Roby
                 describe "#restart" do
                     it "simply starts the job if there are no running jobs" do
                         flexmock(client.client, :strict).should_receive(:has_action?).with("test").and_return(true)
-                        assert_client_receives_batch [[], :start_job, "test", id: 20] do
+                        assert_client_receives_batch [[], :start_job, "test", { id: 20 }] do
                             subject.restart
                         end
                     end
@@ -136,7 +137,7 @@ module Roby
                         job = create_mock_job(42, "test", id: 20)
                         job.should_receive(:running?).and_return(true)
                         flexmock(client.client, :strict).should_receive(:has_action?).with("test").and_return(true)
-                        assert_client_receives_batch [[], :kill_job, 42], [[], :start_job, "test", id: 20] do
+                        assert_client_receives_batch [[], :kill_job, 42], [[], :start_job, "test", { id: 20 }] do
                             subject.restart
                         end
                     end

--- a/test/interface/async/test_interface.rb
+++ b/test/interface/async/test_interface.rb
@@ -64,6 +64,7 @@ module Roby
                     end
                     describe "when connected" do
                         attr_reader :server, :interface
+
                         before do
                             @server = create_server
                             @interface = connect(server)
@@ -305,6 +306,7 @@ module Roby
 
                 describe "job progress" do
                     attr_reader :client, :server
+
                     before do
                         @server = create_server
                         @client = connect(server)
@@ -380,6 +382,7 @@ module Roby
 
                 describe "notifications" do
                     attr_reader :client, :server
+
                     before do
                         @server = create_server
                         @client = connect(server)

--- a/test/interface/async/test_job_monitor.rb
+++ b/test/interface/async/test_job_monitor.rb
@@ -7,6 +7,7 @@ module Roby
         module Async
             describe JobMonitor do
                 attr_reader :job_monitor
+
                 before do
                     @job_monitor = JobMonitor.new(flexmock, 1)
                 end

--- a/test/interface/test_client.rb
+++ b/test/interface/test_client.rb
@@ -129,6 +129,7 @@ module Roby
 
                 describe "#each_job" do
                     attr_reader :client, :first_job, :second_job
+
                     before do
                         @client = open_client
                         while_polling_server do
@@ -402,6 +403,7 @@ module Roby
 
             describe "#poll" do
                 attr_reader :client
+
                 before do
                     @client = open_client
                 end
@@ -508,6 +510,7 @@ module Roby
             describe "#async_call" do
                 attr_reader :watch
                 attr_reader :async_calls_count
+
                 before do
                     @watch = flexmock("watch")
                     @async_calls_count = 0

--- a/test/interface/test_interface.rb
+++ b/test/interface/test_interface.rb
@@ -96,6 +96,7 @@ describe Roby::Interface::Interface do
 
     describe "job state tracking" do
         attr_reader :job_task, :task, :recorder, :job_listener
+
         before do
             plan.add(@job_task = job_task_m.new(job_id: 10))
             plan.add_mission_task(@task = Roby::Tasks::Simple.new)
@@ -305,19 +306,18 @@ describe Roby::Interface::Interface do
             end
 
             it "supports the workflow of Actions::Task" do
+                ret_m = Roby::Task.new_submodel
                 interface_m = Roby::Actions::Interface.new_submodel do
-                    class Ret < Roby::Task
-                    end
                     describe("test method")
-                        .returns(Ret)
+                        .returns(ret_m)
                     def test_method
                         self.class.other_planning_method
                     end
 
                     describe("test method")
-                        .returns(Ret)
-                    def other_planning_method
-                        Ret.new(id: 20)
+                        .returns(ret_m)
+                    define_method(:other_planning_method) do
+                        ret_m.new(id: 20)
                     end
                 end
                 plan.add_mission_task(action_task = interface_m.test_method
@@ -485,6 +485,7 @@ describe Roby::Interface::Interface do
 
     describe "exception notifications" do
         attr_reader :parent_task, :child_task, :recorder, :exception_listener
+
         before do
             plan.add(@parent_task = Roby::Tasks::Simple.new)
             plan.add(@child_task = Roby::Tasks::Simple.new)
@@ -549,6 +550,7 @@ describe Roby::Interface::Interface do
 
     describe "#kill_job" do
         attr_reader :task
+
         before do
             plan.add(job_task = job_task_m.new(job_id: 10))
             plan.add_mission_task(@task = Roby::Tasks::Simple.new)
@@ -573,6 +575,7 @@ describe Roby::Interface::Interface do
 
     describe "#drop_job" do
         attr_reader :task
+
         before do
             plan.add(@job_task = job_task_m.new(job_id: 10))
             plan.add_mission_task(@task = Roby::Tasks::Simple.new)

--- a/test/interface/test_server.rb
+++ b/test/interface/test_server.rb
@@ -146,6 +146,7 @@ module Roby
 
             describe "remote calls" do
                 attr_reader :interface, :server, :client_channel
+
                 before do
                     @interface = Interface.new(Roby::Application.new)
                     interface.app.execution_engine.display_exceptions = false
@@ -266,6 +267,7 @@ module Roby
 
             describe "error handling" do
                 attr_reader :interface, :server, :server_io, :error_m
+
                 before do
                     @interface = Interface.new(Roby::Application.new)
                     interface.app.execution_engine.display_exceptions = false

--- a/test/models/test_arguments.rb
+++ b/test/models/test_arguments.rb
@@ -6,6 +6,7 @@ module Roby
     module Models
         describe Arguments do
             attr_reader :model
+
             before do
                 @model = Class.new do
                     extend Arguments

--- a/test/models/test_task.rb
+++ b/test/models/test_task.rb
@@ -65,6 +65,7 @@ module Roby
 
             describe "#event" do
                 attr_reader :task_m
+
                 before do
                     @task_m = Tasks::Simple.new_submodel
                 end
@@ -78,6 +79,7 @@ module Roby
 
             describe "#on_exception" do
                 attr_reader :task_m
+
                 before do
                     @task_m = Tasks::Simple.new_submodel
                 end
@@ -91,6 +93,7 @@ module Roby
 
             describe "#on" do
                 attr_reader :task_m
+
                 before do
                     @task_m = Tasks::Simple.new_submodel
                 end

--- a/test/models/test_task_service_model.rb
+++ b/test/models/test_task_service_model.rb
@@ -6,6 +6,7 @@ module Roby
     module Models
         describe TaskServiceModel do
             attr_reader :tag
+
             before do
                 @tag = TaskService.new_submodel
             end

--- a/test/queries/test_execution_exception_matcher.rb
+++ b/test/queries/test_execution_exception_matcher.rb
@@ -7,6 +7,7 @@ module Roby
         describe ExecutionExceptionMatcher do
             describe "#handled" do
                 attr_reader :localized_error_m, :matcher, :error
+
                 before do
                     @localized_error_m = Class.new(LocalizedError)
                     @matcher = localized_error_m.to_execution_exception_matcher

--- a/test/queries/test_index.rb
+++ b/test/queries/test_index.rb
@@ -6,6 +6,7 @@ module Roby
     module Queries
         describe Index do
             attr_reader :index, :task_m
+
             before do
                 @index = Index.new
                 @task_m = Task.new_submodel

--- a/test/queries/test_localized_error_matcher.rb
+++ b/test/queries/test_localized_error_matcher.rb
@@ -6,6 +6,7 @@ require "roby/tasks/simple"
 describe Roby::Queries::LocalizedErrorMatcher do
     describe "#===" do
         attr_reader :task_model, :task
+
         before do
             @task_model = Roby::Task.new_submodel
             plan.add(@task = task_model.new)

--- a/test/queries/test_task_event_generator_matcher.rb
+++ b/test/queries/test_task_event_generator_matcher.rb
@@ -7,6 +7,7 @@ module Roby
     module Queries
         describe TaskEventGeneratorMatcher do
             attr_reader :task_matcher, :task, :generator, :source_generator, :symbol_match
+
             before do
                 @task_matcher = flexmock
                 plan.add(@task = Roby::Task.new)

--- a/test/queries/test_task_matcher.rb
+++ b/test/queries/test_task_matcher.rb
@@ -199,6 +199,7 @@ module Roby
 
             describe "the _event accessor" do
                 attr_reader :task_m
+
                 before do
                     @task_m = Roby::Tasks::Simple.new_submodel do
                         event :extra

--- a/test/relations/test_bidirectional_directed_adjacency_graph.rb
+++ b/test/relations/test_bidirectional_directed_adjacency_graph.rb
@@ -198,6 +198,7 @@ module Roby
 
             describe "#difference" do
                 attr_reader :a, :b, :v_a, :v_b, :mapping
+
                 before do
                     @v_a = (1..3).map { Object.new }
                     @v_b = (1..3).map { Object.new }
@@ -299,6 +300,7 @@ module Roby
 
             describe "#replace" do
                 attr_reader :new, :old
+
                 before do
                     @new = create_graph
                     @old = create_graph(1, 2, 1, 3, 3, 4)
@@ -316,6 +318,7 @@ module Roby
 
             describe "#add_edge" do
                 attr_reader :graph, :parent, :child
+
                 before do
                     @graph = create_graph
                     @parent = Object.new
@@ -347,6 +350,7 @@ module Roby
 
             describe "#remove_vertex" do
                 attr_reader :graph, :obj
+
                 before do
                     @graph = create_graph
                     @obj   = Object.new
@@ -450,6 +454,7 @@ module Roby
 
             describe "#merge" do
                 attr_reader :receiver, :argument
+
                 before do
                     @receiver = create_graph(1, 2, 2, 3, 2, 4)
                     @argument = create_graph(0, 2, 2, 3, 2, 5, 6, 7)

--- a/test/relations/test_directed_relation_support.rb
+++ b/test/relations/test_directed_relation_support.rb
@@ -6,6 +6,7 @@ module Roby
     module Relations
         describe DirectedRelationSupport do
             attr_reader :vertex_m, :graph
+
             before do
                 @graph_m = graph_m = Graph.new_submodel
                 @graph   = graph   = graph_m.new

--- a/test/relations/test_graph.rb
+++ b/test/relations/test_graph.rb
@@ -7,6 +7,7 @@ module Roby
         describe Graph do
             describe "#reachable?" do
                 attr_reader :graph
+
                 before do
                     graph_m = Graph.new_submodel
                     @graph = graph_m.new
@@ -34,6 +35,7 @@ module Roby
             describe "#copy_subgraph_to" do
                 attr_reader :old_graph, :new_graph
                 attr_reader :old_a, :old_b, :new_a, :new_b
+
                 before do
                     graph_m = Graph.new_submodel
                     @old_graph = graph_m.new
@@ -64,6 +66,7 @@ module Roby
             describe "#find_edge_difference" do
                 attr_reader :graph, :mapped_graph
                 attr_reader :a, :b, :mapped_a, :mapped_b
+
                 before do
                     graph_m = Graph.new_submodel
                     @graph = graph_m.new
@@ -114,6 +117,7 @@ module Roby
 
             describe "#try_updating_existing_edge_info" do
                 attr_reader :graph, :a, :b
+
                 before do
                     graph_m = Graph.new_submodel
                     @graph = graph_m.new
@@ -154,6 +158,7 @@ module Roby
             describe "#replace_vertex" do
                 attr_reader :graph
                 attr_reader :old, :new, :parent, :child
+
                 before do
                     graph_m = Graph.new_submodel
                     @graph = graph_m.new
@@ -207,6 +212,7 @@ module Roby
 
             describe "#remove_vertex" do
                 attr_reader :graph_m
+
                 before do
                     @graph_m = Graph.new_submodel
                 end
@@ -251,6 +257,7 @@ module Roby
                     Class.new do
                         include DirectedRelationSupport
                         attr_reader :relation_graphs
+
                         def initialize(relation_graphs = {})
                             @relation_graphs = relation_graphs
                         end
@@ -286,6 +293,7 @@ module Roby
 
                 describe "subgraph handling" do
                     attr_reader :graph_m, :graph, :superset_graph_m, :superset_graph
+
                     before do
                         @graph_m = Graph.new_submodel
                         @superset_graph_m = Graph.new_submodel
@@ -344,6 +352,7 @@ module Roby
 
             describe "the observer" do
                 attr_reader :graph, :parent, :grandparent, :observer, :a, :b
+
                 before do
                     @observer = flexmock
                     @graph = Graph.new_submodel.new(observer: observer)
@@ -406,6 +415,7 @@ module Roby
 
             describe "#subset?" do
                 attr_reader :graph, :parent, :parent_sibling, :grandparent
+
                 before do
                     graph_m = Graph.new_submodel
                     @graph = graph_m.new
@@ -465,6 +475,7 @@ module Roby
 
             describe "#has_edge_in_hierarchy?" do
                 attr_reader :graph, :parent
+
                 before do
                     graph_m = Graph.new_submodel
                     @graph = graph_m.new

--- a/test/relations/test_space.rb
+++ b/test/relations/test_space.rb
@@ -8,6 +8,7 @@ module Roby
             let(:support_class) do
                 Class.new do
                     attr_reader :relation_graphs
+
                     def initialize(graphs = {})
                         @relation_graphs = graphs
                     end

--- a/test/task_structure/test_conflicts.rb
+++ b/test/task_structure/test_conflicts.rb
@@ -7,6 +7,7 @@ module Roby
     module TaskStructure
         describe Conflicts do
             attr_reader :task_m_1, :task_m_2
+
             before do
                 @task_m_1 = Tasks::Simple.new_submodel
                 @task_m_2 = Tasks::Simple.new_submodel
@@ -30,6 +31,7 @@ module Roby
 
             describe "runtime handling" do
                 attr_reader :task_1, :task_2
+
                 before do
                     task_m_1.conflicts_with task_m_2
                     plan.add(@task_1 = task_m_1.new)

--- a/test/task_structure/test_dependency.rb
+++ b/test/task_structure/test_dependency.rb
@@ -102,8 +102,8 @@ class TC_Dependency < Minitest::Test
         [p1, child]
     end
 
-    def assert_child_fails(child, reason, plan)
-        error = assert_raises(ChildFailedError) { yield }
+    def assert_child_fails(child, reason, plan, &block)
+        error = assert_raises(ChildFailedError, &block)
         assert_child_failed(child, error, reason.last, plan)
     end
 
@@ -807,6 +807,7 @@ module Roby
 
             describe "failure on pending relation" do
                 attr_reader :parent, :child, :decision_control
+
                 before do
                     @decision_control = flexmock
                     plan.execution_engine.control = @decision_control
@@ -856,6 +857,7 @@ module Roby
 
             describe "structure check" do
                 attr_reader :parent, :child_m
+
                 before do
                     plan.add(@parent = Tasks::Simple.new)
                     @child_m = Roby::Tasks::Simple.new_submodel do

--- a/test/task_structure/test_error_handling.rb
+++ b/test/task_structure/test_error_handling.rb
@@ -7,6 +7,7 @@ module Roby
         describe ErrorHandling do
             describe "#handle_with" do
                 attr_reader :task_m, :repair_task, :localized_error_m
+
                 before do
                     @task_m = Task.new_submodel
                     plan.add(@repair_task = task_m.new)
@@ -64,6 +65,7 @@ module Roby
 
             describe "#find_all_matching_repair_tasks" do
                 attr_reader :task_m, :task, :localized_error_m
+
                 before do
                     @task_m = Task.new_submodel
                     task_m.terminates
@@ -93,6 +95,7 @@ module Roby
 
             describe "#can_repair_error?" do
                 attr_reader :task_m, :task, :repair_task, :localized_error_m
+
                 before do
                     @task_m = Task.new_submodel
                     task_m.terminates
@@ -133,6 +136,7 @@ module Roby
 
             describe "#repairs_error?" do
                 attr_reader :task_m, :task, :repair_task, :localized_error_m
+
                 before do
                     @task_m = Task.new_submodel
                     task_m.terminates

--- a/test/task_structure/test_executed_by.rb
+++ b/test/task_structure/test_executed_by.rb
@@ -4,19 +4,19 @@ require "roby/test/self"
 
 module Roby
     module TaskStructure
-        describe ExecutionAgent do
-            class BaseExecutionAgent < Tasks::Simple
-                event :ready
-            end
-            class ExecutionAgentModel < Tasks::Simple
-                event :ready
-                forward start: :ready
-            end
-            class SecondExecutionModel < Tasks::Simple
-                event :ready
-                forward start: :ready
-            end
+        class BaseExecutionAgent < Tasks::Simple
+            event :ready
+        end
+        class ExecutionAgentModel < Tasks::Simple
+            event :ready
+            forward start: :ready
+        end
+        class SecondExecutionModel < Tasks::Simple
+            event :ready
+            forward start: :ready
+        end
 
+        describe ExecutionAgent do
             before do
                 @agent_m = Roby::Tasks::Simple.new_submodel do
                     event :ready

--- a/test/task_structure/test_planned_by.rb
+++ b/test/task_structure/test_planned_by.rb
@@ -25,6 +25,7 @@ module Roby
 
             describe "structure check" do
                 attr_reader :task, :planner
+
                 before do
                     plan.add(@task = Roby::Task.new)
                     task.planned_by(@planner = Roby::Test::Tasks::Simple.new)

--- a/test/tasks/test_external_process.rb
+++ b/test/tasks/test_external_process.rb
@@ -6,14 +6,11 @@ require "roby/tasks/external_process"
 module Roby
     module Tasks
         describe ExternalProcess do
-            MOCKUP = File.expand_path(
-                File.join("..", "mockups", "external_process"),
-                File.dirname(__FILE__))
-
-            class MockupTask < Roby::Tasks::ExternalProcess
-                event :stop do |context|
-                    FileUtils.touch "/tmp/external_process_mockup_stop"
-                end
+            def mock_command
+                File.expand_path(
+                    File.join("..", "mockups", "external_process"),
+                    File.dirname(__FILE__)
+                )
             end
 
             describe "#handle_redirection" do
@@ -168,18 +165,18 @@ module Roby
 
             describe "the execution workflow" do
                 it "passes on command-line arguments" do
-                    plan.add(task = Tasks::ExternalProcess.new(command_line: [MOCKUP, "--no-output"]))
+                    plan.add(task = Tasks::ExternalProcess.new(command_line: [mock_command, "--no-output"]))
                     expect_execution { task.start! }.to { emit task.success_event }
                 end
 
                 it "accepts a command line with a single command argument" do
-                    plan.add(task = Tasks::ExternalProcess.new(command_line: [MOCKUP]))
+                    plan.add(task = Tasks::ExternalProcess.new(command_line: [mock_command]))
                     task.redirect_output :close
                     expect_execution { task.start! }.to { emit task.success_event }
                 end
 
                 it "accepts a single command as string" do
-                    plan.add(task = Tasks::ExternalProcess.new(command_line: MOCKUP))
+                    plan.add(task = Tasks::ExternalProcess.new(command_line: mock_command))
                     task.redirect_output :close
                     expect_execution { task.start! }.to { emit task.success_event }
                 end
@@ -191,13 +188,13 @@ module Roby
                 end
 
                 it "emits failed with the program status object if the program fails" do
-                    plan.add(task = Tasks::ExternalProcess.new(command_line: [MOCKUP, "--error"]))
+                    plan.add(task = Tasks::ExternalProcess.new(command_line: [mock_command, "--error"]))
                     expect_execution { task.start! }.to { emit task.failed_event }
                     assert_equal 1, task.event(:failed).last.context.first.exitstatus
                 end
 
                 it "emits signaled with the program status if the program is terminated by a signal" do
-                    plan.add(task = Tasks::ExternalProcess.new(command_line: [MOCKUP, "--block"]))
+                    plan.add(task = Tasks::ExternalProcess.new(command_line: [mock_command, "--block"]))
                     expect_execution { task.start! }.to { emit task.start_event }
                     expect_execution { Process.kill("KILL", task.pid) }
                         .to { emit task.failed_event }
@@ -210,7 +207,7 @@ module Roby
 
             describe "redirection" do
                 def do_redirection(expected)
-                    plan.add(task = Tasks::ExternalProcess.new(command_line: [MOCKUP]))
+                    plan.add(task = Tasks::ExternalProcess.new(command_line: [mock_command]))
                     yield(task)
 
                     expect_execution { task.start! }.to { emit task.success_event }
@@ -222,13 +219,14 @@ module Roby
                 end
 
                 it "redirects stdout to file" do
-                    do_redirection `#{MOCKUP}` do |task|
+                    do_redirection `#{mock_command}` do |task|
                         task.redirect_output stdout: "mockup-%p.log"
                     end
                 end
 
                 pipe_task_m = ExternalProcess.new_submodel do
                     attr_reader :received_data
+
                     def initialize(args = {})
                         super
                         @received_data = Hash[stderr: String.new, stdout: String.new]
@@ -247,21 +245,21 @@ module Roby
                 end
 
                 it "redirects stdout to the task's handler" do
-                    plan.add(task = pipe_task_m.new(command_line: [MOCKUP]))
+                    plan.add(task = pipe_task_m.new(command_line: [mock_command]))
                     task.redirect_output(stdout: :pipe, stderr: :close)
                     expect_execution { task.start! }.to { emit task.success_event }
                     assert_equal Hash[stdout: "FIRST LINE\nSECOND LINE\n", stderr: ""], task.received_data
                 end
 
                 it "redirects stderr to the task's handler" do
-                    plan.add(task = pipe_task_m.new(command_line: [MOCKUP, "--stderr"]))
+                    plan.add(task = pipe_task_m.new(command_line: [mock_command, "--stderr"]))
                     task.redirect_output(stdout: :close, stderr: :pipe)
                     expect_execution { task.start! }.to { emit task.success_event }
                     assert_equal Hash[stdout: "", stderr: "FIRST LINE\nSECOND LINE\n"], task.received_data
                 end
 
                 it "redirects both to the task's handlers at the same time" do
-                    plan.add(task = pipe_task_m.new(command_line: [MOCKUP, "--common"]))
+                    plan.add(task = pipe_task_m.new(command_line: [mock_command, "--common"]))
                     task.redirect_output(stdout: :pipe, stderr: :pipe)
                     expect_execution { task.start! }.to { emit task.success_event }
                     assert_equal Hash[stdout: "O: FIRST LINE\nO: SECOND LINE\n", stderr: "E: FIRST LINE\nE: SECOND LINE\n"],
@@ -269,7 +267,7 @@ module Roby
                 end
 
                 it "redirects stderr to file" do
-                    do_redirection `#{MOCKUP}` do |task|
+                    do_redirection `#{mock_command}` do |task|
                         task.command_line << "--stderr"
                         task.redirect_output stderr: "mockup-%p.log"
                     end
@@ -280,7 +278,7 @@ module Roby
                         task.command_line << "--common"
                         task.redirect_output "mockup-%p.log"
                     end
-                    expected = `#{MOCKUP} --common 2>&1`
+                    expected = `#{mock_command} --common 2>&1`
                     assert_equal expected, output
                 end
             end

--- a/test/test/test_execution_expectations.rb
+++ b/test/test/test_execution_expectations.rb
@@ -58,6 +58,7 @@ module Roby
 
             describe "#verify" do
                 attr_reader :expectations
+
                 before do
                     @expectations = ExecutionExpectations.new(self, plan)
                     flexmock(@expectations)
@@ -113,6 +114,7 @@ module Roby
 
                 describe "cycle_end" do
                     attr_reader :recorder
+
                     before do
                         @handler_ids = []
                         @recorder = flexmock
@@ -123,10 +125,8 @@ module Roby
                         end
                     end
 
-                    def at_cycle_end
-                        @handler_ids << execution_engine.at_cycle_end do
-                            yield
-                        end
+                    def at_cycle_end(&block)
+                        @handler_ids << execution_engine.at_cycle_end(&block)
                     end
 
                     it "executes cycle_end handlers" do
@@ -400,6 +400,7 @@ module Roby
                 end
                 describe "#emit a task event query" do
                     attr_reader :task_m
+
                     before do
                         @task_m = Roby::Tasks::Simple.new_submodel
                     end
@@ -545,6 +546,7 @@ module Roby
 
                 describe "#have_handled_error_matching" do
                     attr_reader :matcher, :error_m
+
                     before do
                         @error_m = Class.new(LocalizedError)
                         @task_m = Roby::Task.new_submodel
@@ -675,6 +677,7 @@ module Roby
 
                 describe "#fail_to_start" do
                     attr_reader :task, :error_m
+
                     before do
                         task_m = Task.new_submodel
                         task_m.terminates
@@ -737,6 +740,7 @@ module Roby
 
                 describe "#have_framework_error_matching" do
                     attr_reader :error_m
+
                     before do
                         @error_m = Class.new(RuntimeError)
                     end
@@ -1018,6 +1022,7 @@ module Roby
 
             describe "#execute" do
                 attr_reader :achieve_without_memory
+
                 before do
                     @achieve_without_memory = Class.new(ExecutionExpectations::Achieve) do
                         def update_match(all_propagation_info)
@@ -1055,6 +1060,7 @@ module Roby
 
             describe "#start" do
                 attr_reader :task
+
                 before do
                     plan.add(@task = Roby::Tasks::Simple.new)
                 end
@@ -1099,6 +1105,7 @@ module Roby
 
             describe "#have_running" do
                 attr_reader :task
+
                 before do
                     plan.add(@task = Roby::Tasks::Simple.new)
                 end

--- a/test/test_app.rb
+++ b/test/test_app.rb
@@ -340,6 +340,7 @@ module Roby
 
         describe "#start_log_server" do
             attr_reader :logfile_path
+
             before do
                 @logfile_path, writer = roby_app_create_logfile
                 writer.close
@@ -631,6 +632,7 @@ module Roby
 
         describe ".common_optparse_setup" do
             attr_reader :parser
+
             before do
                 @parser = OptionParser.new
                 Application.common_optparse_setup(parser)
@@ -664,6 +666,7 @@ module Roby
             end
             describe "discovery through the 'current' symlink" do
                 attr_reader :log_dir, :current_path
+
                 before do
                     app.log_base_dir = make_tmpdir
                     @log_dir = make_tmpdir

--- a/test/test_event_generator.rb
+++ b/test/test_event_generator.rb
@@ -607,6 +607,7 @@ module Roby
     describe EventGenerator do
         describe "context propagation" do
             attr_reader :mock
+
             before do
                 @mock = flexmock
             end
@@ -648,6 +649,7 @@ module Roby
 
                 describe "from signals" do
                     attr_reader :source, :generator
+
                     before do
                         plan.add(@source = EventGenerator.new)
                         @generator = EventGenerator.new { |context| mock.called(context) }
@@ -684,6 +686,7 @@ module Roby
 
             describe "passed to emission" do
                 attr_reader :generator
+
                 before do
                     plan.add(@generator = EventGenerator.new)
                 end
@@ -702,6 +705,7 @@ module Roby
 
                 describe "from forwarding" do
                     attr_reader :source
+
                     before do
                         plan.add(@source = EventGenerator.new)
                         source.forward_to generator
@@ -845,6 +849,7 @@ module Roby
 
         describe "#check_call_validity" do
             attr_reader :generator
+
             before do
                 plan.add(@generator = EventGenerator.new(true))
                 flexmock(execution_engine)
@@ -901,6 +906,7 @@ module Roby
 
         describe "#call_without_propagation" do
             attr_reader :generator, :command_hook
+
             before do
                 @command_hook = flexmock
                 command_hook.should_receive(:call).by_default
@@ -1005,6 +1011,7 @@ module Roby
 
         describe "#check_emission_validity" do
             attr_reader :generator
+
             before do
                 plan.add(@generator = Roby::EventGenerator.new(true))
                 flexmock(execution_engine)
@@ -1044,6 +1051,7 @@ module Roby
 
         describe "#emit_without_propagation" do
             attr_reader :generator
+
             before do
                 plan.add(@generator = Roby::EventGenerator.new(true))
                 flexmock(generator)
@@ -1183,6 +1191,7 @@ module Roby
 
         describe "#emit_failed" do
             attr_reader :generator
+
             before do
                 plan.add(@generator = EventGenerator.new)
             end
@@ -1230,6 +1239,7 @@ module Roby
 
         describe "#achieve_with" do
             attr_reader :master, :slave
+
             before do
                 @slave  = EventGenerator.new
                 @master = EventGenerator.new do
@@ -1295,6 +1305,7 @@ module Roby
 
         describe "#call" do
             attr_reader :generator
+
             before do
                 plan.add(@generator = EventGenerator.new(true))
                 flexmock(generator)
@@ -1325,6 +1336,7 @@ module Roby
 
         describe "#emit" do
             attr_reader :generator
+
             before do
                 plan.add(@generator = EventGenerator.new)
                 flexmock(generator)
@@ -1357,6 +1369,7 @@ module Roby
 
         describe "#forward_to" do
             attr_reader :source, :target, :context
+
             before do
                 @source = EventGenerator.new
                 @context = flexmock
@@ -1388,6 +1401,7 @@ module Roby
 
         describe "#signals" do
             attr_reader :source, :target
+
             before do
                 @source = EventGenerator.new
                 plan.add(source)
@@ -1423,6 +1437,7 @@ module Roby
 
         describe "#filter" do
             attr_reader :source, :mock
+
             before do
                 @mock = flexmock
                 plan.add(@source = EventGenerator.new)
@@ -1471,6 +1486,7 @@ module Roby
 
         describe "preconditions" do
             attr_reader :generator
+
             before do
                 plan.add(@generator = EventGenerator.new(true))
             end
@@ -1521,6 +1537,7 @@ module Roby
 
         describe "#on" do
             attr_reader :generator
+
             before do
                 plan.add(@generator = EventGenerator.new)
             end
@@ -1544,6 +1561,7 @@ module Roby
 
         describe "#replace_by" do
             attr_reader :generator, :new, :mock
+
             before do
                 plan.add(@generator = EventGenerator.new)
                 plan.add(@new = EventGenerator.new)

--- a/test/test_exceptions.rb
+++ b/test/test_exceptions.rb
@@ -56,6 +56,7 @@ describe Roby do
         let :stub_m do
             Class.new(Roby::ExceptionBase) do
                 attr_reader :text
+
                 def initialize(text)
                     super([])
                     @text = text

--- a/test/test_executable_plan.rb
+++ b/test/test_executable_plan.rb
@@ -13,6 +13,7 @@ module Roby
                 vertex_m = Class.new do
                     include Relations::DirectedRelationSupport
                     attr_reader :relation_graphs
+
                     def initialize(relation_graphs = {})
                         @relation_graphs = relation_graphs
                     end
@@ -230,6 +231,7 @@ module Roby
 
         describe "#quarantine_task" do
             attr_reader :task
+
             before do
                 plan.add(@task = Tasks::Simple.new)
                 flexmock(task)
@@ -257,6 +259,7 @@ module Roby
 
         describe "handling of garbage objects" do
             attr_reader :task, :garbage_task, :free_event, :garbage_free_event
+
             before do
                 plan.add(@task = Tasks::Simple.new)
                 plan.add(@garbage_task = Tasks::Simple.new)
@@ -363,6 +366,7 @@ module Roby
 
         describe "#garbage_task" do
             attr_reader :task
+
             before do
                 plan.add(@task = Tasks::Simple.new)
                 flexmock(plan)

--- a/test/test_execution_engine.rb
+++ b/test/test_execution_engine.rb
@@ -576,6 +576,7 @@ module Roby
 
         describe "#add_error" do
             attr_reader :task_m, :root, :child, :localized_error_m, :recorder, :other_root, :child, :child_e
+
             before do
                 @task_m = Roby::Task.new_submodel { argument :name, default: nil }
                 plan.add(@root = @task_m.new(name: "root"))
@@ -589,8 +590,8 @@ module Roby
                 @child_e = localized_error_m.new(child).to_execution_exception
             end
 
-            def assert_raises_error_with_trace(*trace)
-                expect_execution { yield }.to do
+            def assert_raises_error_with_trace(*trace, &block)
+                expect_execution(&block).to do
                     have_error_matching localized_error_m.match
                         .with_origin(child)
                         .to_execution_exception_matcher
@@ -626,6 +627,7 @@ module Roby
 
         describe "#gather_framework_errors" do
             attr_reader :error_m
+
             before do
                 @error_m = Class.new(RuntimeError)
             end
@@ -705,6 +707,7 @@ module Roby
 
         describe "#gather_errors" do
             attr_reader :error
+
             before do
                 plan.add(task = Task.new)
                 @error = Class.new(LocalizedError).new(task).to_execution_exception
@@ -745,6 +748,7 @@ module Roby
 
         describe "#propagate_exception_in_plan" do
             attr_reader :task_m, :root, :child, :localized_error_m, :recorder
+
             before do
                 @task_m = Roby::Task.new_submodel { argument :name, default: nil }
                 plan.add(@root = @task_m.new(name: "root"))
@@ -754,10 +758,9 @@ module Roby
             end
 
             def match_exception(*edges, handled: nil)
-                matcher = localized_error_m.to_execution_exception_matcher
+                localized_error_m.to_execution_exception_matcher
                     .with_trace(*edges)
                     .handled(handled)
-                matcher
             end
 
             it "propagates a given exception up in the dependency graph and yields the exception and the task at each step, finishing by the plan" do
@@ -1039,6 +1042,7 @@ module Roby
 
         describe "#remove_inhibited_exceptions" do
             attr_reader :task_m, :root, :child, :localized_error_m, :recorder
+
             before do
                 @task_m = Roby::Task.new_submodel { argument :name, default: nil }
                 plan.add(@root = @task_m.new(name: "root"))
@@ -1085,6 +1089,7 @@ module Roby
 
         describe "#propagate_exceptions" do
             attr_reader :task_m, :root, :child, :localized_error_m, :recorder
+
             before do
                 @task_m = Roby::Task.new_submodel { argument :name, default: nil }
                 plan.add(@root = @task_m.new(name: "root"))
@@ -1194,9 +1199,11 @@ module Roby
 
         describe "the error propagation" do
             attr_reader :task_m, :root, :localized_error_m
+
             before do
                 @task_m = Task.new_submodel do
                     attr_accessor :hold_stop
+
                     event(:stop) do |_|
                         unless hold_stop
                             stop_event.emit
@@ -1219,10 +1226,9 @@ module Roby
             end
 
             def match_exception(*edges, handled: nil)
-                matcher = localized_error_m.to_execution_exception_matcher
+                localized_error_m.to_execution_exception_matcher
                     .with_trace(*edges)
                     .handled(handled)
-                matcher
             end
 
             it "reports handled structure exceptions" do
@@ -1466,6 +1472,7 @@ module Roby
 
             describe "the error handling relation" do
                 attr_reader :task_m, :localized_error_m, :repair_task, :root, :root_e
+
                 before do
                     @task_m = Task.new_submodel
                     task_m.terminates
@@ -1513,6 +1520,7 @@ module Roby
 
             describe "free events errors" do
                 attr_reader :event, :localized_error_m
+
                 before do
                     plan.add(@event = EventGenerator.new)
                     @localized_error_m = Class.new(LocalizedError)
@@ -1927,6 +1935,7 @@ module Roby
 
     describe "#at_cycle_end" do
         attr_reader :error_m
+
         before do
             @error_m = Class.new(RuntimeError)
         end
@@ -1952,10 +1961,8 @@ module Roby
     end
 
     describe "propagation handlers" do
-        def add_propagation_handler(**options)
-            @handler_ids << execution_engine.add_propagation_handler(**options) do |plan|
-                yield(plan)
-            end
+        def add_propagation_handler(**options, &block)
+            @handler_ids << execution_engine.add_propagation_handler(**options, &block)
         end
 
         def remove_propagation_handlers
@@ -1965,6 +1972,7 @@ module Roby
         end
 
         attr_reader :recorder
+
         before do
             @recorder = flexmock
             @handler_ids = []
@@ -2107,6 +2115,7 @@ module Roby
 
         describe "error handling" do
             attr_reader :exception_m
+
             before do
                 @exception_m = Class.new(RuntimeError)
             end

--- a/test/test_plan.rb
+++ b/test/test_plan.rb
@@ -9,6 +9,7 @@ module Roby
         include PlanCommonBehavior
 
         attr_reader :plan
+
         before do
             @plan = Plan.new
         end
@@ -241,6 +242,7 @@ module Roby
 
         describe "#add_trigger" do
             attr_reader :task_m, :task, :recorder
+
             before do
                 @task_m = Roby::Task.new_submodel
                 @task   = task_m.new
@@ -300,6 +302,7 @@ module Roby
 
         describe "#remove_trigger" do
             attr_reader :task_m, :task, :recorder
+
             before do
                 @task_m = Roby::Task.new_submodel
                 @task   = task_m.new
@@ -317,6 +320,7 @@ module Roby
 
         describe "#compute_subplan_replacement" do
             attr_reader :graph
+
             before do
                 @graph = Roby::Relations::Graph.new
             end
@@ -531,6 +535,7 @@ module Roby
 
         describe "#same_plan?" do
             attr_reader :plan, :copy
+
             before do
                 @plan = Plan.new
                 @copy = Plan.new

--- a/test/test_plan_object.rb
+++ b/test/test_plan_object.rb
@@ -78,6 +78,7 @@ module Roby
     describe PlanObject do
         describe "#executable?" do
             attr_reader :plan_object
+
             before do
                 @plan_object = PlanObject.new
             end

--- a/test/test_plan_service.rb
+++ b/test/test_plan_service.rb
@@ -6,6 +6,7 @@ module Roby
         let(:spy) { flexmock }
 
         attr_reader :t1, :t2, :service
+
         before do
             root, @t1, @t2 = prepare_plan add: 3, model: Tasks::Simple
             root.depends_on @t1, model: Tasks::Simple
@@ -69,6 +70,7 @@ module Roby
 
         describe "#on_plan_status_change" do
             attr_reader :task, :service
+
             before do
                 plan.add(@task = Roby::Task.new)
                 @service = Roby::PlanService.new(task)

--- a/test/test_promise.rb
+++ b/test/test_promise.rb
@@ -5,6 +5,7 @@ require "roby/test/self"
 module Roby
     describe Promise do
         attr_reader :recorder
+
         before do
             @recorder = flexmock
         end
@@ -134,6 +135,7 @@ module Roby
 
         describe "#before" do
             attr_reader :promise
+
             before do
                 @promise = execution_engine.promise
             end

--- a/test/test_robot.rb
+++ b/test/test_robot.rb
@@ -4,6 +4,7 @@ require "roby/test/self"
 
 describe Robot do
     attr_reader :interface_m
+
     before do
         @interface_m = Roby::Actions::Interface.new_submodel do
             describe "test_action"

--- a/test/test_task.rb
+++ b/test/test_task.rb
@@ -350,6 +350,7 @@ module Roby
 
         describe "event validation" do
             attr_reader :task
+
             before do
                 model = Tasks::Simple.new_submodel do
                     event(:inter, command: true)
@@ -429,6 +430,7 @@ module Roby
 
         describe "model-level event handlers" do
             attr_reader :task_m
+
             before do
                 @task_m = Tasks::Simple.new_submodel
             end
@@ -498,6 +500,7 @@ module Roby
                 it "does parallel-assignment of arguments given to it at initialization" do
                     task_m = Class.new(self.task_m) do
                         attr_reader :parallel_assignment
+
                         def assign_arguments(**args)
                             @parallel_assignment = args
                             super
@@ -521,6 +524,7 @@ module Roby
 
         describe "#last_event" do
             attr_reader :task
+
             before do
                 plan.add(@task = Roby::Tasks::Simple.new)
             end
@@ -698,6 +702,7 @@ module Roby
 
             describe "on_replace: :copy" do
                 attr_reader :task, :replacement
+
                 before do
                     plan.add(@task = Roby::Tasks::Simple.new(id: 1))
                     @replacement = Roby::Tasks::Simple.new(id: 1)
@@ -877,6 +882,7 @@ module Roby
 
         describe "polling" do
             attr_reader :task_m
+
             before do
                 @task_m = Tasks::Simple.new_submodel
             end
@@ -1171,6 +1177,7 @@ module Roby
 
         describe "#clear_relations" do
             attr_reader :task, :strong_graph, :ev
+
             before do
                 strong_relation_m = Relations::Graph.new_submodel(strong: true)
                 EventStructure.add_relation(strong_relation_m)
@@ -1314,6 +1321,7 @@ module Roby
 
         describe "#reusable?" do
             attr_reader :task
+
             before do
                 task_m = Roby::Task.new_submodel do
                     event(:start) { |context| start_event.emit }
@@ -1423,6 +1431,7 @@ module Roby
 
             describe "pending tasks" do
                 attr_reader :task
+
                 before do
                     plan.add(@task = Tasks::Simple.new)
                 end
@@ -1431,6 +1440,7 @@ module Roby
 
             describe "starting tasks" do
                 attr_reader :task
+
                 before do
                     task_m = Roby::Task.new_submodel do
                         terminates
@@ -1456,6 +1466,7 @@ module Roby
 
         describe "#handle_exception" do
             attr_reader :task_m, :localized_error_m, :recorder
+
             before do
                 @task_m = Roby::Task.new_submodel
                 @localized_error_m = Class.new(LocalizedError)
@@ -1505,6 +1516,7 @@ module Roby
 
         describe "#promise" do
             attr_reader :task
+
             before do
                 plan.add(@task = Roby::Tasks::Simple.new)
             end

--- a/test/test_task_arguments.rb
+++ b/test/test_task_arguments.rb
@@ -4,6 +4,7 @@ require "roby/test/self"
 
 describe Roby::TaskArguments do
     attr_reader :task_m, :task
+
     before do
         @task_m = Roby::Task.new_submodel { argument :arg }
         @task = task_m.new
@@ -457,6 +458,7 @@ module Roby
     describe DelayedArgumentFromObject do
         describe "#evaluate_delayed_argument" do
             attr_reader :task, :arg
+
             before do
                 @task_m = Task.new_submodel { argument(:arg) }
                 @task = @task_m.new

--- a/test/test_transactions.rb
+++ b/test/test_transactions.rb
@@ -10,8 +10,8 @@ class TC_TransactionAsPlan < Minitest::Test
     include Roby::PlanCommonBehavior
     include Roby::SelfTest
 
-    attr_reader :real_plan
-    attr_reader :plan
+    attr_reader :real_plan, :plan
+
     def engine
         (real_plan || plan).engine
     end
@@ -1410,6 +1410,7 @@ class TC_RecursiveTransaction < Minitest::Test
     include TC_TransactionBehaviour
 
     attr_reader :real_plan
+
     def engine
         (real_plan || plan).engine
     end

--- a/test/test_transactions_proxy.rb
+++ b/test/test_transactions_proxy.rb
@@ -4,6 +4,7 @@ require "roby/test/self"
 
 class TC_TransactionsProxy < Minitest::Test
     attr_reader :transaction
+
     def setup
         super
         @transaction = Roby::Transaction.new(plan)


### PR DESCRIPTION
Migration to 1.0 will be painful as rock has been stuck on 0.82 for a
long while. This commit fixes most rubocop offenses on 1.0. There will be
a corresponding commit on the rubocop configuration for the rest once
we are ready to switch to 1.0 (on branch rubocop-1.0)

This still passes on the rubocop version pinned by rock-core