### PR TITLE
test: fix ignore_errors_from(have_error_matching ...)

### DIFF
--- a/lib/roby/test/execution_expectations.rb
+++ b/lib/roby/test/execution_expectations.rb
@@ -782,8 +782,17 @@ module Roby
                     @expectations = Array(expectations)
                 end
 
+                def update_match(propagation_info)
+                    # Call the underlying #update_match as some matchers cache
+                    # information there
+                    @expectations.each { |e| e.update_match(propagation_info) }
+                    true
+                end
+
                 def relates_to_error?(error)
-                    @expectations.any? { |e| e.relates_to_error?(error) }
+                    @expectations.any? do |e|
+                        e.relates_to_error?(error)
+                    end
                 end
 
                 def filter_result(_result)

--- a/test/test/test_execution_expectations.rb
+++ b/test/test/test_execution_expectations.rb
@@ -1013,6 +1013,17 @@ module Roby
                             ignore_errors_from quarantine(task)
                         end
                     end
+
+                    it "calls update_match on the underlying predicates "\
+                       "and ignores the result" do
+                        plan.add_mission_task(task = Roby::Task.new)
+                        expect_execution { task.quarantined! }.to do
+                            matcher = quarantine(task)
+                            flexmock(matcher).should_receive(:update_match).at_least.once
+                                             .and_return(true)
+                            ignore_errors_from matcher
+                        end
+                    end
                 end
             end
 


### PR DESCRIPTION
Some predicates, namely have_error_matching, caches information
in update_match that it uses in other methods (in this case,
relates_to_error?)

Make sure IgnoreErrorFrom#update_match calls them so that the rest
works as expected