### PR TITLE
fix(droby): race condition in Logfile::Server

### DIFF
--- a/lib/roby/droby/logfile/server.rb
+++ b/lib/roby/droby/logfile/server.rb
@@ -84,6 +84,7 @@ module Roby
                         # Incoming connections
                         if readable_sockets && !readable_sockets.empty?
                             socket = server.accept
+                            @pending_data[socket] = []
                             socket.setsockopt(Socket::IPPROTO_TCP, Socket::TCP_NODELAY, true)
                             socket.fcntl(Fcntl::FD_CLOEXEC, 1)
 


### PR DESCRIPTION
There is a small window between the server's #accept and the time
where the socket is registered. This causes this particular socket
to not be closed if the server gets interrupted in the middle

Yet another reason why it's a bad idea to have exceptions getting
raised in the middle of anywhere.

Register the socket right away to avoid this problem.