### PR TITLE
fix(core): do not set Task#failure_reason to an arbitrary object in Task#mark_failed_to_start

### DIFF
--- a/lib/roby/standard_errors.rb
+++ b/lib/roby/standard_errors.rb
@@ -427,6 +427,26 @@ module Roby
         end
     end
 
+    # Representation of a task's failure to start
+    class FailedToStart < LocalizedError
+        attr_reader :time
+        attr_reader :reason
+
+        def initialize(failed_task, reason, time)
+            super(failed_task)
+
+            report_exceptions_from(reason)
+            @time = time
+            @reason = reason
+        end
+
+        def pretty_print(pp)
+            pp.text "#{self} failed to start at #{Roby.format_time(time)} because of"
+            pp.breakable
+            @reason.pretty_print(pp)
+        end
+    end
+
     # Exception raised when the event loop aborts because of an unhandled
     # exception
     class Aborting < ExceptionBase

--- a/lib/roby/task.rb
+++ b/lib/roby/task.rb
@@ -596,13 +596,25 @@ module Roby
 
             @failed_to_start = true
             @failed_to_start_time = time
-            @failure_reason = reason
+            @failure_reason =
+                if reason.kind_of?(LocalizedError) && reason.failed_task == self
+                    reason
+                else
+                    FailedToStart.new(self, reason, time)
+                end
+
             @pending = false
             @starting = false
             @failed   = true
             plan.task_index.set_state(self, :failed?)
         end
 
+        # Declares that this task has failed to start
+        #
+        # @param [Object] reason the failure reason. Can either be an exception
+        #   or an event
+        #
+        # {#failure_reason} will be set to {FailedToStart} with the given reason
         def failed_to_start!(reason, time = Time.now)
             mark_failed_to_start(reason, time)
             each_event do |ev|

--- a/test/task_structure/test_executed_by.rb
+++ b/test/task_structure/test_executed_by.rb
@@ -50,7 +50,9 @@ module Roby
                     reason
                 end
                 assert task.failed_to_start?
-                assert_equal reason, task.failure_reason
+                assert_kind_of FailedToStart, task.failure_reason
+                assert_equal task, task.failure_reason.failed_task
+                assert_equal reason, task.failure_reason.reason
             end
 
             it "lets the control object decide what to do with executed tasks if the "\
@@ -75,7 +77,9 @@ module Roby
                 end
                 execute { execution_agent.stop! }
                 assert task.failed_to_start?
-                assert_equal execution_agent.failed_event.last, task.failure_reason
+                assert_kind_of FailedToStart, task.failure_reason
+                assert_equal task, task.failure_reason.failed_task
+                assert_equal execution_agent.failed_event.last, task.failure_reason.reason
             end
 
             it "lets the control object decide what to do with pending executed tasks "\

--- a/test/test_task.rb
+++ b/test/test_task.rb
@@ -1411,8 +1411,16 @@ module Roby
                     task.mark_failed_to_start(flexmock, t = Time.now)
                     assert_equal t, task.failed_to_start_time
                 end
-                it "sets the failure reason" do
+                it "sets the failure reason to FailedToStart "\
+                   "if it is not localized on the task already" do
                     task.mark_failed_to_start(reason = flexmock, Time.now)
+                    assert_kind_of FailedToStart, task.failure_reason
+                    assert_equal reason, task.failure_reason.reason
+                end
+                it "sets the failure reason to the given reason "\
+                   "if it is already localized on the task" do
+                    reason = LocalizedError.new(task)
+                    task.mark_failed_to_start(reason, Time.now)
                     assert_equal reason, task.failure_reason
                 end
                 it "sets the task as failed in the index" do
@@ -1449,7 +1457,7 @@ module Roby
                     assert_raises(InternalError) do
                         task.mark_failed_to_start(flexmock, Time.now)
                     end
-                    assert !task.failed_to_start?
+                    refute task.failed_to_start?
                 end
             end
         end
@@ -1563,6 +1571,30 @@ module Roby
                 execute { task.start! }
                 execute { task.stop_event.emit }
                 assert_equal :finished, task.current_state
+            end
+        end
+
+        describe "#failed_to_start!" do
+            before do
+                plan.add(@task = Roby::Test::Tasks::Simple.new)
+                execute { @task.failed_to_start!("test") }
+            end
+
+            it "marks the task as failed to start" do
+                assert @task.failed_to_start?
+            end
+            it "marks the task as failed" do
+                assert @task.failed?
+                assert_equal [@task], plan.find_tasks.failed.to_a
+            end
+            it "resets the pending flag" do
+                refute @task.pending?
+                assert_equal [], plan.find_tasks.pending.to_a
+            end
+
+            it "sets failure_reason to FailedToStart" do
+                assert_kind_of FailedToStart, @task.failure_reason
+                assert_equal "test", @task.failure_reason.reason
             end
         end
     end
@@ -2573,19 +2605,6 @@ class TC_Task < Minitest::Test
 
         assert(task.running?)
         assert(new.running?)
-    end
-
-    def test_failed_to_start
-        plan.add(task = Roby::Test::Tasks::Simple.new)
-        execute { task.failed_to_start!("test") }
-        assert task.failed_to_start?
-        assert_equal "test", task.failure_reason
-        assert task.failed?
-        assert !task.pending?
-        assert !task.running?
-        assert_equal [], plan.find_tasks.pending.to_a
-        assert_equal [], plan.find_tasks.running.to_a
-        assert_equal [task], plan.find_tasks.failed.to_a
     end
 
     def test_cannot_call_event_on_task_that_failed_to_start


### PR DESCRIPTION
In most cases, the reason would be a CodeError centered on the task
itself. However, that's not always the case. For instance, if the
task fails to start because of an execution agent failure, we end
up breaking the chain of explanations (we get Task#failure_reason
the terminal event of the deployment, without explanation about why
they are related).

This commit transform non-errors, non-localized errors and/or
localized errors from other objects into a FailedToStart exception
to be stored in failure_reason. It fixes issues in execution
expectations, where MissionFailed errors would be reported as
unexpected even if the source event was indeed expected.