### PR TITLE
feat(log): add time in PlanRebuilder's event-related arrays

### DIFF
--- a/lib/roby/droby/plan_rebuilder.rb
+++ b/lib/roby/droby/plan_rebuilder.rb
@@ -303,7 +303,7 @@ module Roby
             def task_failed_to_start(time, task, reason)
                 task   = local_object(task)
                 reason = local_object(reason)
-                task.plan.failed_to_start << [task, reason]
+                task.plan.failed_to_start << [time, task, reason]
                 task.mark_failed_to_start(reason, time)
                 announce_event_propagation_update
                 [task, reason]
@@ -318,7 +318,7 @@ module Roby
                 if generator.respond_to?(:task)
                     generator.task.fired_event(event)
                 end
-                generator.plan.emitted_events << event
+                generator.plan.emitted_events << [time, event]
                 announce_event_propagation_update
                 event
             end
@@ -326,7 +326,7 @@ module Roby
             def generator_emit_failed(time, generator, error)
                 generator = local_object(generator)
                 error = local_object(error)
-                generator.plan.failed_emissions << [generator, error]
+                generator.plan.failed_emissions << [time, generator, error]
                 announce_event_propagation_update
                 [generator, error]
             end
@@ -334,7 +334,7 @@ module Roby
             def generator_propagate_events(time, is_forwarding, events, generator)
                 events    = local_object(events)
                 generator = local_object(generator)
-                generator.plan.propagated_events << [is_forwarding, events, generator]
+                generator.plan.propagated_events << [time, is_forwarding, events, generator]
                 announce_event_propagation_update
                 [events, generator]
             end
@@ -351,7 +351,7 @@ module Roby
                 involved_objects = local_object(involved_objects)
                 plan = local_object(plan_id)
                 plan.propagated_exceptions <<
-                    [mode, error, involved_objects]
+                    [time, mode, error, involved_objects]
                 [plan, error, involved_objects]
             end
 

--- a/lib/roby/gui/plan_dot_layout.rb
+++ b/lib/roby/gui/plan_dot_layout.rb
@@ -377,7 +377,7 @@ module Roby
                             task.to_dot_events(display, self)
                         end
                         all_tasks.merge(p_tasks)
-                        p.propagated_events.each do |_, sources, to, _|
+                        p.propagated_events.each do |_, _, sources, to, _|
                             sources.each do |from|
                                 if from.respond_to?(:task) && to.respond_to?(:task) && from.task == to.task
                                     from_id, to_id = from.dot_id, to.dot_id
@@ -422,7 +422,7 @@ module Roby
                     # Take the signalling into account for the layout. At this stage,
                     # task events are represented by their tasks
                     display.plans.each do |p|
-                        p.propagated_events.each do |_, sources, to, _|
+                        p.propagated_events.each do |_, _, sources, to, _|
                             to_id =
                                 if to.respond_to?(:task) then to.task.dot_id
                                 else to.dot_id

--- a/lib/roby/gui/relations_view/relations_canvas.rb
+++ b/lib/roby/gui/relations_view/relations_canvas.rb
@@ -260,13 +260,13 @@ module Roby
                 task.model.all_forwardings.each do |source_name, targets|
                     source = task.event(source_name)
                     targets.each do |target_name|
-                        plan.propagated_events << [true, [source.new([], 0)], task.event(target_name)]
+                        plan.propagated_events << [Time.at(0), true, [source.new([], 0)], task.event(target_name)]
                     end
                 end
                 task.model.all_signals.each do |source_name, targets|
                     source = task.event(source_name)
                     targets.each do |target_name|
-                        plan.propagated_events << [false, [source.new([], 0)], task.event(target_name)]
+                        plan.propagated_events << [Time.at(0), false, [source.new([], 0)], task.event(target_name)]
                     end
                 end
                 display.update
@@ -887,10 +887,10 @@ module Roby
                     if display_plan_bounding_boxes?
                         visible_objects << p
                     end
-                    p.emitted_events.each do |event|
+                    p.emitted_events.each do |_, event|
                         visible_objects << event.generator
                     end
-                    p.propagated_events.each do |_, sources, to, _|
+                    p.propagated_events.each do |_, _, sources, to, _|
                         sources.each do |src|
                             visible_objects << src.generator
                         end
@@ -1016,17 +1016,17 @@ module Roby
                 plans.each do |p|
                     flags = Hash.new(0)
 
-                    p.called_generators.each_with_index do |generator, priority|
+                    p.called_generators.each_with_index do |time, generator, priority|
                         flags[generator] |= EVENT_CALLED
                     end
                     base_priority = p.called_generators.size
 
-                    p.emitted_events.each_with_index do |event, priority|
+                    p.emitted_events.each_with_index do |(_, event), priority|
                         generator = event.generator
                         flags[generator] |= EVENT_EMITTED
                     end
 
-                    p.failed_emissions.each do |generator, reason|
+                    p.failed_emissions.each do |time, generator, reason|
                         flags[generator] = FAILED_EMISSION
                     end
 
@@ -1042,7 +1042,7 @@ module Roby
                 end
 
                 plans.each do |p|
-                    p.propagated_events.each do |_, sources, to, _|
+                    p.propagated_events.each do |_, _, sources, to, _|
                         sources.each do |from|
                             RelationsCanvasEventGenerator.priorities[from] ||= (event_priority += 1)
                             RelationsCanvasEventGenerator.priorities[to] ||= (event_priority += 1)
@@ -1082,7 +1082,7 @@ module Roby
                 # Display the signals
                 signal_arrow_idx = -1
                 plans.each do |p|
-                    p.propagated_events.each_with_index do |(flag, sources, to), signal_arrow_idx|
+                    p.propagated_events.each_with_index do |(_, flag, sources, to), signal_arrow_idx|
                         relation =
                             if flag
                                 Roby::EventStructure::Forwarding

--- a/test/droby/test_event_logging.rb
+++ b/test/droby/test_event_logging.rb
@@ -420,9 +420,9 @@ module Roby
                         .to { fail_to_start task }
 
                     process_logged_events
-                    assert_equal r_task, rebuilt_plan.failed_to_start[0][0]
-                    assert_kind_of EmissionFailed, rebuilt_plan.failed_to_start[0][1]
-                    assert_kind_of ArgumentError, rebuilt_plan.failed_to_start[0][1].original_exceptions[0]
+                    assert_equal r_task, rebuilt_plan.failed_to_start[0][1]
+                    assert_kind_of EmissionFailed, rebuilt_plan.failed_to_start[0][2]
+                    assert_kind_of ArgumentError, rebuilt_plan.failed_to_start[0][2].original_exceptions[0]
                 end
 
                 it "propagates event emission" do
@@ -450,7 +450,7 @@ module Roby
                         process_logged_events
 
                         assert(
-                            rebuilt_plan.propagated_events.find do |is_forward, events, generator|
+                            rebuilt_plan.propagated_events.find do |_, is_forward, events, generator|
                                 !is_forward &&
                                     generator == r_target &&
                                     events.size == 1 &&
@@ -467,7 +467,7 @@ module Roby
 
                         assert(
                             rebuilt_plan
-                            .propagated_events.any? do |is_forward, events, generator|
+                            .propagated_events.any? do |_, is_forward, events, generator|
                                 !is_forward &&
                                     generator == r_target &&
                                     events.size == 1 &&
@@ -483,7 +483,7 @@ module Roby
                         process_logged_events
 
                         assert(
-                            rebuilt_plan.propagated_events.any? do |is_forward, events, generator|
+                            rebuilt_plan.propagated_events.any? do |_, is_forward, events, generator|
                                 is_forward &&
                                     generator == r_target &&
                                     events.size == 1 &&
@@ -499,7 +499,7 @@ module Roby
                         process_logged_events
 
                         assert(
-                            rebuilt_plan.propagated_events.any? do |is_forward, events, generator|
+                            rebuilt_plan.propagated_events.any? do |_, is_forward, events, generator|
                                 is_forward &&
                                     generator == r_target &&
                                     events.size == 1 &&


### PR DESCRIPTION
PlanRebuilder keeps arrays for event-related propagation information,
but was not storing the time these propagation events happened. This
was fine so far for roby-log display, which is not listing anything,
but fails utterly to analyze the list of propagation.

Change the format of these arrays. This does not change the log format