### PR TITLE
fix: missing require

### DIFF
--- a/lib/roby/app.rb
+++ b/lib/roby/app.rb
@@ -1,18 +1,19 @@
 # frozen_string_literal: true
 
+require "facets/string/camelcase"
 require "fileutils"
 require "find"
-require "facets/string/camelcase"
-require "roby/support"
-require "roby/robot"
+require "singleton"
+require "yaml"
+
+require "roby/app/base"
 require "roby/app/robot_names"
 require "roby/interface"
-require "singleton"
+require "roby/robot"
+require "roby/support"
 require "utilrb/hash/recursive_merge"
 require "utilrb/module/attr_predicate"
-require "yaml"
 require "utilrb/pathname/find_matching_parent"
-require "roby/app/base"
 
 module Roby
     # Regular expression that matches backtrace paths that are within the

--- a/lib/roby/app.rb
+++ b/lib/roby/app.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "fileutils"
 require "find"
 require "facets/string/camelcase"
 require "roby/support"


### PR DESCRIPTION
Triggered during CI when a starting app was killed, which changed the order of requires (it seems)