### PR TITLE
fix: wrong format for RebuiltPlan#emitted_events and called_generators in RelationsCanvasTask

### DIFF
--- a/lib/roby/droby/logfile/server.rb
+++ b/lib/roby/droby/logfile/server.rb
@@ -185,6 +185,8 @@ module Roby
 
                             begin
                                 written = socket.write_nonblock(buffer)
+                            rescue Interrupt
+                                raise
                             rescue Errno::EAGAIN
                                 Server.debug "cannot send: send buffer full"
                                 chunks.unshift(buffer)

--- a/lib/roby/droby/rebuilt_plan.rb
+++ b/lib/roby/droby/rebuilt_plan.rb
@@ -20,14 +20,13 @@ module Roby
             # purposes, they only get removed from the plan at the next cycle.
             attr_reader :garbaged_events
             # The set of generators that have been called since the last call to
-            # #clear_integrated
+            # {#clear_integrated}
             #
             # @return [Array<EventGenerator>]
             attr_reader :called_generators
-            # The set of events emitted since the last call to
-            # #clear_integrated
+            # The set of events emitted since the last call to {#clear_integrated}
             #
-            # @return [Array<Event>]
+            # @return [Array<[Time, Event]>]
             attr_reader :emitted_events
             # The set of event propagations that have been recorded since the
             # last call to # #clear_integrated

--- a/lib/roby/gui/relations_view/relations_canvas.rb
+++ b/lib/roby/gui/relations_view/relations_canvas.rb
@@ -1016,12 +1016,12 @@ module Roby
                 plans.each do |p|
                     flags = Hash.new(0)
 
-                    p.called_generators.each_with_index do |generator, priority|
+                    p.called_generators.each do |generator|
                         flags[generator] |= EVENT_CALLED
                     end
                     base_priority = p.called_generators.size
 
-                    p.emitted_events.each_with_index do |(_, event), priority|
+                    p.emitted_events.each do |_, event|
                         generator = event.generator
                         flags[generator] |= EVENT_EMITTED
                     end

--- a/lib/roby/gui/relations_view/relations_canvas.rb
+++ b/lib/roby/gui/relations_view/relations_canvas.rb
@@ -251,11 +251,11 @@ module Roby
                 display = RelationsCanvas.new([plan])
                 display.display_plan_bounding_boxes = false
                 display.layout_options.merge!(options.slice(:scale_x, :scale_y))
-                task.each_event do |ev|
-                    if ev.controlable?
-                        plan.called_generators << ev
+                task.each_event do |generator|
+                    if generator.controlable?
+                        plan.called_generators << generator
                     end
-                    plan.emitted_events << ev.new([], 0)
+                    plan.emitted_events << [Time.now, generator.new([], 0)]
                 end
                 task.model.all_forwardings.each do |source_name, targets|
                     source = task.event(source_name)
@@ -1016,7 +1016,7 @@ module Roby
                 plans.each do |p|
                     flags = Hash.new(0)
 
-                    p.called_generators.each_with_index do |time, generator, priority|
+                    p.called_generators.each_with_index do |generator, priority|
                         flags[generator] |= EVENT_CALLED
                     end
                     base_priority = p.called_generators.size


### PR DESCRIPTION
We (mis)use the relations canvas to display a task's "event cloud". After the last changes in the format of emitted_events,
how this code was using the arrays got broken. This fixes it.

Fixes https://github.com/rock-core/tools-syskit/issues/313