### PR TITLE
feat(cli): define --index-file to roby-log display

### DIFF
--- a/lib/roby/cli/log.rb
+++ b/lib/roby/cli/log.rb
@@ -323,11 +323,15 @@ module Roby
                 end
             end
 
-            desc "display", "start roby-display to visualize the log file's contents"
+            desc "display FILE",
+                 "start roby-display to visualize the log file's contents"
+            option :index_path,
+                   type: :string, default: nil,
+                   desc: "explicitly give the path to the log file's index file"
             def display(file = nil)
                 file = handle_file_argument(file)
                 require "roby/cli/display"
-                Display.new.file(file)
+                Display.new.file(file, index_path: options[:index_path])
             end
         end
     end


### PR DESCRIPTION
This allows to specify a log file in a non-standard location (e.g.
from a syskit datastore)