### PR TITLE
fix(cli): DRoby::Logfile::Server not always quitting after a SIGINT

### DIFF
--- a/lib/roby/droby/logfile/server.rb
+++ b/lib/roby/droby/logfile/server.rb
@@ -185,6 +185,8 @@ module Roby
 
                             begin
                                 written = socket.write_nonblock(buffer)
+                            rescue Interrupt
+                                raise
                             rescue Errno::EAGAIN
                                 Server.debug "cannot send: send buffer full"
                                 chunks.unshift(buffer)


### PR DESCRIPTION
If the signal arrives during the write_nonblock call, it would
be interpreted as a communication error, which removes the client
but does not quit the server.