### PR TITLE
fix(test): reset Roby.app.plan in test setup

### DIFF
--- a/lib/roby/test/self.rb
+++ b/lib/roby/test/self.rb
@@ -59,6 +59,7 @@ module Roby
 
                 @plan    = ExecutablePlan.new(event_logger: EventReporter.new(STDOUT))
                 @control = DecisionControl.new
+                Roby.app.reset_plan(@plan)
 
                 super
 


### PR DESCRIPTION
Tests still rely on the existence of the global Roby.app. However,
while we do reset the test's plan instance at every run, Roby.app.plan
does not get reset which creates inconsistencies.

Use Application#reset_plan to make sure the two are in sync.