### PR TITLE
feat(test): add the 'within' argument to not_emit

### DIFF
--- a/lib/roby/coordination/task_script.rb
+++ b/lib/roby/coordination/task_script.rb
@@ -141,7 +141,7 @@ module Roby
             #   it has already been emitted.
             def wait(event, options = {})
                 event, model_event = resolve_event(event)
-                model.wait(model_event, options)
+                model.wait(model_event, **options)
                 event
             end
 

--- a/lib/roby/tasks/external_process.rb
+++ b/lib/roby/tasks/external_process.rb
@@ -48,14 +48,13 @@ module Roby
             # running
             attr_reader :pid
 
-            def initialize(arguments = {})
-                if arg = arguments[:command_line]
-                    arguments[:command_line] = [arg] unless arg.kind_of?(Array)
-                end
+            def initialize(command_line: nil, **arguments)
+                command_line = Array(command_line) if command_line
+
                 @pid = nil
                 @buffer = nil
                 @redirection = {}
-                super(arguments)
+                super(command_line: command_line, **arguments)
             end
 
             # Called to announce that this task has been killed. +result+ is the

--- a/lib/roby/test/execution_expectations.rb
+++ b/lib/roby/test/execution_expectations.rb
@@ -473,7 +473,7 @@ module Roby
             # Whether the execution will run until the timeout if the
             # expectations have not been met yet.
             #
-            # The default is 5s
+            # The default is true
             #
             # @param [Boolean] wait
             dsl_attribute :wait_until_timeout

--- a/lib/roby/test/execution_expectations.rb
+++ b/lib/roby/test/execution_expectations.rb
@@ -32,12 +32,18 @@ module Roby
             # cannot test for the non-existence of a delayed emission
             #
             # @return [nil]
-            def not_emit(*generators, backtrace: caller(1))
+            def not_emit(*generators, within: 0, backtrace: caller(1))
                 generators.map do |generator|
                     if generator.kind_of?(EventGenerator)
-                        add_expectation(NotEmitGenerator.new(generator, backtrace))
+                        add_expectation(
+                            NotEmitGenerator.new(generator, backtrace, within: within)
+                        )
                     else
-                        add_expectation(NotEmitGeneratorModel.new(generator, backtrace))
+                        add_expectation(
+                            NotEmitGeneratorModel.new(
+                                generator, backtrace, within: within
+                            )
+                        )
                     end
                 end
             end
@@ -801,14 +807,17 @@ module Roby
             end
 
             class NotEmitGenerator < Expectation
-                def initialize(generator, backtrace)
+                def initialize(generator, backtrace, within: 0.5)
                     super(backtrace)
                     @generator = generator
+                    @emitted_events = []
                     @related_error_matcher =
                         Queries::LocalizedErrorMatcher
                         .new
                         .with_origin(@generator)
                         .to_execution_exception_matcher
+
+                    @deadline = Time.now + within
                 end
 
                 def to_s
@@ -816,11 +825,12 @@ module Roby
                 end
 
                 def update_match(propagation_info)
-                    @emitted_events =
+                    @emitted_events +=
                         propagation_info
                         .emitted_events
                         .find_all { |ev| ev.generator == @generator }
-                    @emitted_events.empty?
+
+                    @emitted_events.empty? if Time.now > @deadline
                 end
 
                 def unachievable?(_propagation_info)
@@ -834,17 +844,23 @@ module Roby
                 def relates_to_error?(error)
                     @related_error_matcher === error
                 end
+
+                def format_unachievable_explanation(pp, explanation)
+                    pp.text "but it was: "
+                    explanation.pretty_print(pp)
+                end
             end
 
             class NotEmitGeneratorModel < Expectation
                 attr_reader :generator_model
 
-                def initialize(event_query, backtrace)
+                def initialize(event_query, backtrace, within: 0.5)
                     super(backtrace)
                     @event_query = event_query
                     @generators = []
                     @related_error_matchers = []
                     @emitted_events = []
+                    @deadline = Time.now + within
                 end
 
                 def to_s
@@ -852,7 +868,7 @@ module Roby
                 end
 
                 def update_match(propagation_info)
-                    @emitted_events =
+                    @emitted_events +=
                         propagation_info
                         .emitted_events
                         .find_all do |ev|
@@ -865,7 +881,8 @@ module Roby
                                 .with_origin(ev.generator)
                                 .to_execution_exception_matcher
                         end
-                    @emitted_events.empty?
+
+                    @emitted_events.empty? if Time.now > @deadline
                 end
 
                 def unachievable?(_propagation_info)
@@ -878,6 +895,11 @@ module Roby
 
                 def relates_to_error?(error)
                     @related_error_matchers.any? { |match| match === error }
+                end
+
+                def format_unachievable_explanation(pp, explanation)
+                    pp.text "but one was: "
+                    explanation.pretty_print(pp)
                 end
             end
 

--- a/lib/roby/test/execution_expectations.rb
+++ b/lib/roby/test/execution_expectations.rb
@@ -830,7 +830,7 @@ module Roby
                         .emitted_events
                         .find_all { |ev| ev.generator == @generator }
 
-                    @emitted_events.empty? if Time.now > @deadline
+                    @emitted_events.empty? if Time.now >= @deadline
                 end
 
                 def unachievable?(_propagation_info)

--- a/lib/roby/transaction/event_generator_proxy.rb
+++ b/lib/roby/transaction/event_generator_proxy.rb
@@ -27,7 +27,7 @@ module Roby
                     real_object.handlers.each do |h|
                         if h.copy_on_replace?
                             event ||= yield
-                            event.on(h.as_options, &h.block)
+                            event.on(**h.as_options, &h.block)
                         end
                     end
                     real_object.unreachable_handlers.each do |cancel, h|

--- a/test/interface/async/test_action_monitor.rb
+++ b/test/interface/async/test_action_monitor.rb
@@ -5,8 +5,6 @@ require "roby/interface/async"
 require "roby/interface/tcp"
 require_relative "client_server_test_helpers"
 
-Concurrent.disable_at_exit_handlers!
-
 module Roby
     module Interface
         module Async

--- a/test/interface/async/test_interface.rb
+++ b/test/interface/async/test_interface.rb
@@ -5,8 +5,6 @@ require "roby/interface/async"
 require "roby/interface/tcp"
 require_relative "client_server_test_helpers"
 
-Concurrent.disable_at_exit_handlers!
-
 module Roby
     module Interface
         module Async

--- a/test/test/test_execution_expectations.rb
+++ b/test/test/test_execution_expectations.rb
@@ -422,6 +422,7 @@ module Roby
                             end
                     end
                 end
+
                 describe "#emit a task event query" do
                     attr_reader :task_m
                     before do
@@ -474,6 +475,81 @@ module Roby
                             execute: proc { task.start! },
                             predicates: proc { emit find_tasks(task_m).start_event }
                         )
+                    end
+                end
+
+                describe "#not_emit a generator instance" do
+                    it "validates when the event is not emitted" do
+                        plan.add(generator = EventGenerator.new)
+                        expect_execution.to { not_emit generator }
+                    end
+                    it "fails if the event is emitted within the first cycle" do
+                        plan.add(generator = EventGenerator.new)
+                        e = assert_raises(ExecutionExpectations::Unmet) do
+                            expect_execution { generator.emit }
+                                .to { not_emit generator }
+                        end
+                        assert e.message.start_with?(
+                            "1 unmet expectations\n#{generator} "\
+                            "should not be emitted, but it was:"
+                        )
+                    end
+                    it "passes by default after the first cycle" do
+                        plan.add(generator = EventGenerator.new)
+                        count = 0
+                        expect_execution
+                            .poll { count += 1; generator.emit if count > 2 }
+                            .to { not_emit generator }
+                    end
+                    it "may be told given a timespan with the within argument" do
+                        plan.add(generator = EventGenerator.new)
+                        count = 0
+                        assert_raises(ExecutionExpectations::Unmet) do
+                            expect_execution
+                                .poll { count += 1; generator.emit if count > 2 }
+                                .to { not_emit generator, within: 0.1 }
+                        end
+                    end
+                end
+
+                describe "#not_emit a task event query" do
+                    attr_reader :task_m
+                    before do
+                        @task_m = Roby::Tasks::Simple.new_submodel
+                    end
+                    it "validates when the event is not emitted" do
+                        plan.add(task_m.new)
+                        expect_execution.to { not_emit find_tasks(task_m).start_event }
+                    end
+                    it "fails if a matching event is emitted within the first cycle" do
+                        plan.add(task = task_m.new)
+                        query = plan.find_tasks(task_m).start_event
+                        e = assert_raises(ExecutionExpectations::Unmet) do
+                            expect_execution { task.start! }
+                                .to { not_emit query }
+                        end
+                        assert e.message.start_with?(
+                            "1 unmet expectations\nno events matching #{query} should "\
+                            "be emitted, but one was:"
+                        ), e.message
+                    end
+                    it "does not fail by default if it is emitted in the 2nd cycle" do
+                        plan.add(task = task_m.new)
+                        count = 0
+                        expect_execution
+                            .poll { count += 1; task.start! if count > 2 }
+                            .to { not_emit find_tasks(task_m).start_event }
+                    end
+                    it "allows to specify a time to wait with the within option" do
+                        plan.add(task = task_m.new)
+                        count = 0
+                        assert_raises(ExecutionExpectations::Unmet) do
+                            expect_execution
+                                .poll { count += 1; task.start! if count > 2 }
+                                .to do
+                                    not_emit find_tasks(task_m).start_event, within: 0.1
+                                end
+                        end
                     end
                 end
 

--- a/test/test/test_execution_expectations.rb
+++ b/test/test/test_execution_expectations.rb
@@ -498,7 +498,7 @@ module Roby
                         plan.add(generator = EventGenerator.new)
                         count = 0
                         expect_execution
-                            .poll { count += 1; generator.emit if count > 2 }
+                            .poll { count += 1; generator.emit if count == 2 }
                             .to { not_emit generator }
                     end
                     it "may be told given a timespan with the within argument" do
@@ -506,7 +506,7 @@ module Roby
                         count = 0
                         assert_raises(ExecutionExpectations::Unmet) do
                             expect_execution
-                                .poll { count += 1; generator.emit if count > 2 }
+                                .poll { count += 1; generator.emit if count == 3 }
                                 .to { not_emit generator, within: 0.1 }
                         end
                     end


### PR DESCRIPTION
I somehow had the wrong idea that timeout(...) was controlling how
long we would wait to make sure that the event is not emitted.
That turns out to not be the case. Add the `within:` argument
to specify that time, and set it to 0 by default. This matches
the current behavior (raise if an event is emitted within the first
cycle of execution)