### PR TITLE
fix: define make_tmppath

### DIFF
--- a/lib/roby/test/self.rb
+++ b/lib/roby/test/self.rb
@@ -98,6 +98,23 @@ module Roby
                 end
             end
 
+            # Create a temporary directory
+            #
+            # The directory is removed on test teardown. Unlike {#make_tmpdir},
+            # this returns a Pathname. Prefer this method over {#make_tmpdir}
+            #
+            # @return [Pathname]
+            def make_tmppath
+                @temp_dirs << (dir = Dir.mktmpdir)
+                Pathname.new(dir)
+            end
+
+            # Create a temporary directory
+            #
+            # The directory is removed on test teardown. Unlike {#make_tmppath},
+            # this returns a string. Prefer {#make_tmppath}
+            #
+            # @return [String]
             def make_tmpdir
                 @temp_dirs << (dir = Dir.mktmpdir)
                 dir


### PR DESCRIPTION
There is already make_tmpdir, but I'd like to slowly migrate to Pathname
for filesystem access ... so define tmppath