### PR TITLE
fix: remove double-definition of #execute between test/common and test/expect_execution

### DIFF
--- a/lib/roby/test/common.rb
+++ b/lib/roby/test/common.rb
@@ -86,10 +86,6 @@ module Roby
             plan.execution_engine if plan&.executable?
         end
 
-        def execute(&block)
-            execution_engine.execute(&block)
-        end
-
         # Clear the plan and return it
         def new_plan
             plan.clear

--- a/lib/roby/test/teardown_plans.rb
+++ b/lib/roby/test/teardown_plans.rb
@@ -10,6 +10,8 @@ module Roby
         module TeardownPlans
             attr_reader :registered_plans
 
+            include ExpectExecution
+
             def initialize(name)
                 super
                 @default_teardown_poll = 0.01


### PR DESCRIPTION
The latter has a `plan` argument that is not present in the former
(and older) version.