### PR TITLE
feat: define Roby::Tasks::ExternalProcess.interruptible

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -5,6 +5,8 @@ require "rake/testtask"
 require "yard"
 require "yard/rake/yardoc_task"
 
+ENV.delete("ROBY_PLUGIN_PATH")
+
 task :default
 
 TESTOPTS = ENV.delete("TESTOPTS") || ""

--- a/lib/roby/tasks/external_process.rb
+++ b/lib/roby/tasks/external_process.rb
@@ -273,6 +273,27 @@ module Roby
                 @out_pipe&.close
                 @err_pipe&.close
             end
+
+            # Create an ExternalProcess task that can be interrupted with the
+            # given signal
+            def self.interruptible_with_signal(signal: "INT", **arguments)
+                InterruptibleWithSignal.new(signal: signal, **arguments)
+            end
+
+            # A subclass of {ExternalProcess} that terminates its underlying
+            # process with a signal (default is INT)
+            #
+            # You usually don't create this directly, but use
+            # {ExternalProcess.interruptible_with_signal}
+            class InterruptibleWithSignal < ExternalProcess
+                argument :signal, default: "INT"
+
+                event :failed, terminal: true do |_|
+                    kill(signal)
+                end
+
+                interruptible
+            end
         end
     end
 end

--- a/lib/roby/tasks/external_process.rb
+++ b/lib/roby/tasks/external_process.rb
@@ -75,19 +75,21 @@ module Roby
                 end
             end
 
-            ##
-            # If set to a string, the process' standard output will be redirected to
-            # the given file. The following replacement is done:
-            # * '%p' is replaced by the process PID
+            # @overload redirect_output(common)
+            # @overload redirect_output(stdout: nil, stderr: nil)
+            #   Redirect either stdout and stderr. The redirection target can either be
+            #   a string, which is interpreted as a path, or one of :pipe and :close.
             #
-            # The last form (with nil argument) removes any redirection. A specific
-            # redirection can also be disabled using the hash form:
-            #   redirect_output stdout: nil
+            #   If redirecting to a string, %p is replaced by the process actual
+            #   PID. Both can be redirected to the same output file
             #
-            # :call-seq:
-            #   redirect_output "file"
-            #   redirect_output stdout: "file-out", stderr: "another-file"
-            #   redirect_output nil
+            #   The special value :pipe shall be used to make the task read the
+            #   process output and call {#stdout_received} (resp.
+            #   {#stderr_received}) with it. :close will make the task close
+            #   this output
+            #
+            #   Pass `nil` to not redirect this particular output. Calling the method
+            #   with a single argument applies this redirection to both outputs.
             #
             def redirect_output(common = nil, stdout: nil, stderr: nil)
                 if @pid

--- a/test/mockups/interruptible_external_process
+++ b/test/mockups/interruptible_external_process
@@ -1,0 +1,17 @@
+#! /usr/bin/env ruby
+# frozen_string_literal: true
+
+STDOUT.sync = true
+
+trap("INT") do
+    STDOUT.puts "INT"
+    exit 1
+end
+
+trap("USR1") do
+    STDOUT.puts "USR1"
+    exit 1
+end
+
+STDOUT.puts "READY"
+STDIN.readline

--- a/test/mockups/interruptible_external_process
+++ b/test/mockups/interruptible_external_process
@@ -1,17 +1,20 @@
 #! /usr/bin/env ruby
 # frozen_string_literal: true
 
-STDOUT.sync = true
+io = File.open(ARGV.first, "w")
 
 trap("INT") do
-    STDOUT.puts "INT"
+    io.puts "INT"
+    io.close
     exit 1
 end
 
 trap("USR1") do
-    STDOUT.puts "USR1"
+    io.puts "USR1"
+    io.close
     exit 1
 end
 
-STDOUT.puts "READY"
+io.puts "READY"
+io.flush
 STDIN.readline

--- a/test/mockups/interruptible_external_process
+++ b/test/mockups/interruptible_external_process
@@ -2,19 +2,24 @@
 # frozen_string_literal: true
 
 io = File.open(ARGV.first, "w")
+io.sync
+
+queue = Queue.new
 
 trap("INT") do
-    io.puts "INT"
-    io.close
-    exit 1
+    queue.push "INT"
 end
 
 trap("USR1") do
-    io.puts "USR1"
-    io.close
-    exit 1
+    queue.push "USR1"
 end
 
 io.puts "READY"
 io.flush
-STDIN.readline
+loop do
+    io.puts queue.pop(true)
+    io.close
+    exit 0
+rescue ThreadError
+    sleep 0.01
+end

--- a/test/tasks/test_external_process.rb
+++ b/test/tasks/test_external_process.rb
@@ -297,7 +297,9 @@ module Roby
 
                 after do
                     if @task.running?
-                        expect_execution { task.stop! }.to { emit task.stop_event }
+                        task = @task
+                        Process.kill("KILL", task.pid)
+                        expect_execution.to { emit task.stop_event }
                     end
                 end
 
@@ -310,25 +312,25 @@ module Roby
                     plan.add(@task)
                     expect_execution { task.start! }.to { emit task.start_event }
 
-                    assert_outfile_contents_eventually_match(/READY/)
+                    assert_outfile_contents_eventually_match(@task, /READY/)
                     task
                 end
 
                 it "creates a process that gets interrupted with SIGINT by default" do
                     task = prepare_task
                     expect_execution { task.stop! }.to { emit task.stop_event }
-                    contents = assert_outfile_contents_eventually_match(/INT/)
+                    contents = assert_outfile_contents_eventually_match(@task, /INT/)
                     refute_match(/USR1/, contents)
                 end
 
                 it "allows changing the signal" do
                     task = prepare_task(signal: "USR1")
                     expect_execution { task.stop! }.to { emit task.stop_event }
-                    contents = assert_outfile_contents_eventually_match(/USR1/)
+                    contents = assert_outfile_contents_eventually_match(@task, /USR1/)
                     refute_match(/INT/, contents)
                 end
 
-                def assert_outfile_contents_eventually_match(regexp)
+                def assert_outfile_contents_eventually_match(task, regexp)
                     deadline = Time.now + 5
                     while Time.now < deadline
                         if File.read(@out_file) =~ regexp
@@ -336,6 +338,8 @@ module Roby
                             return
                         end
 
+                        execute_one_cycle
+                        assert task.running?, "task stopped unexpectedly"
                         sleep 0.01
                     end
                     assert_match regexp, File.read(@out_file)


### PR DESCRIPTION
Because one cannot turn an interruptible task into non-interruptible,
Roby::Tasks::ExternalProcess is not interruptible by default to let
downstream users decide how it should be stopped.

Nonetheless, an easy way to use ExternalProcess was lacking. This commit
defines Roby::Tasks::ExternalProcess.interruptible_with_signal, as a way
to get an external process that can simply be interrupted with a signal
(SIGINT by default).