### PR TITLE
fix: remove excessive files in test file discovery

### DIFF
--- a/lib/roby/app.rb
+++ b/lib/roby/app.rb
@@ -3079,18 +3079,6 @@ module Roby
                 end
             end
 
-            find_files("test", "actions", "ROBOT", "test_main.rb", order: :specific_first, all: true).each do |path|
-                models_per_file[path] = Set[main_action_interface]
-            end
-
-            find_dirs("test", "lib", order: :specific_first, all: true).each do |path|
-                Pathname.new(path).find do |p|
-                    if p.basename.to_s =~ /^test_.*.rb$/ || p.basename.to_s =~ /_test\.rb$/
-                        models_per_file[p.to_s] = Set.new
-                    end
-                end
-            end
-
             models_per_file.each(&block)
         end
     end


### PR DESCRIPTION
The current discovery in `all` mode would add all libs from all dependent bundles. Libs are really the part that should be config-independent, and testing in a given bundle should be enough for another.

Moreover, it was also loading the test/actions/test_main.rb from all dependent bundles. This is nonsensical as Main is built by the robot config itself.

Both functionalities were introduced before the migration to the name-based test discovery in the local bundle, which now naturally covers both cases.