### PR TITLE
fix: do not let a { emit EVENT } statement hide a handler error

### DIFF
--- a/lib/roby/event_generator.rb
+++ b/lib/roby/event_generator.rb
@@ -629,7 +629,7 @@ module Roby
                 rescue LocalizedError => e
                     execution_engine.add_error(e)
                 rescue Exception => e
-                    execution_engine.add_error(EventHandlerError.new(e, event))
+                    execution_engine.add_error(EventHandlerError.new(e, event.generator))
                 end
                 h.once?
             end

--- a/lib/roby/queries/localized_error_matcher.rb
+++ b/lib/roby/queries/localized_error_matcher.rb
@@ -20,6 +20,7 @@ module Roby
                 super
                 @model = LocalizedError
                 @failure_point_matcher = Queries.any
+                @emitted = false
                 @original_exception_model = nil
             end
 
@@ -58,10 +59,18 @@ module Roby
                 self
             end
 
+            # If the failure point matcher is a generator matcher, require that
+            # the failure origin is an actual emission
+            def emitted
+                @emitted = true
+                self
+            end
+
             # @return [Boolean] true if the given execution exception object
             #   matches self, false otherwise
             def ===(exception)
                 return false unless model === exception
+                return false if @emitted && !exception.failed_event
 
                 if original_exception_model
                     original_exception = exception.original_exceptions

--- a/lib/roby/test/execution_expectations.rb
+++ b/lib/roby/test/execution_expectations.rb
@@ -934,6 +934,7 @@ module Roby
                                 Queries::LocalizedErrorMatcher
                                 .new
                                 .with_origin(ev.generator)
+                                .emitted
                                 .to_execution_exception_matcher
                         end
                     !@emitted_events.empty?
@@ -958,6 +959,7 @@ module Roby
                         Queries::LocalizedErrorMatcher
                         .new
                         .with_origin(@generator)
+                        .emitted
                         .to_execution_exception_matcher
                 end
 

--- a/test/queries/test_localized_error_matcher.rb
+++ b/test/queries/test_localized_error_matcher.rb
@@ -36,6 +36,22 @@ describe Roby::Queries::LocalizedErrorMatcher do
             origin_match.should_receive(:===).with(task.success_event).and_return(true).once
             assert (Roby::LocalizedError.match.with_origin(origin_match) === error)
         end
+        it "does not match a generator if emitted is set" do
+            error = Roby::LocalizedError.new(task.success_event)
+            origin_match = flexmock
+            origin_match.should_receive(:task_matcher).and_return(origin_match)
+            origin_match.should_receive(:match).and_return(origin_match)
+            origin_match.should_receive(:===).with(task.success_event).and_return(true)
+            refute (Roby::LocalizedError.match.with_origin(origin_match).emitted === error)
+        end
+        it "matches an event from a matching generator if emitted is set" do
+            error = Roby::LocalizedError.new(task.success_event.new([]))
+            origin_match = flexmock
+            origin_match.should_receive(:task_matcher).and_return(origin_match)
+            origin_match.should_receive(:match).and_return(origin_match)
+            origin_match.should_receive(:===).with(task.success_event).and_return(true).once
+            assert (Roby::LocalizedError.match.with_origin(origin_match).emitted === error)
+        end
         it "should return false if given a generator matcher and the error originates only from a task" do
             error = Roby::LocalizedError.new(task)
             origin_match = flexmock

--- a/test/test/test_execution_expectations.rb
+++ b/test/test/test_execution_expectations.rb
@@ -421,6 +421,29 @@ module Roby
                                 emit agent.stop_event
                             end
                     end
+
+                    it "does not relate to a handler error" do
+                        task_m = Task.new_submodel do
+                            event(:start, controlable: true) { |_| start_event.emit }
+                        end
+                        plan.add_mission_task(task = task_m.new)
+                        task.stop_event.on { raise ArgumentError }
+
+                        execute do
+                            task.start!
+                        end
+
+                        e = assert_raises(ExecutionExpectations::UnexpectedErrors) do
+                            expect_execution { task.stop_event.emit }
+                                .to { emit task.stop_event }
+                        end
+
+                        errors = e.each_execution_exception.to_a
+                        assert_kind_of EventHandlerError, errors[0].exception
+                        assert_kind_of ArgumentError,
+                                       errors[0].exception.each_original_exception.first
+                        assert_kind_of MissionFailedError, errors[1].exception
+                    end
                 end
 
                 describe "#emit a task event query" do
@@ -476,6 +499,49 @@ module Roby
                             execute: proc { task.start! },
                             predicates: proc { emit find_tasks(task_m).start_event }
                         )
+                    end
+                    it "handles a toplevel task error caused by the event" do
+                        execution_agent_m = Tasks::Simple.new_submodel { event :ready }
+                        task_m = Task.new_submodel do
+                            event(:start) { |_| }
+                        end
+                        plan.add_mission_task(task = task_m.new)
+                        plan.add(agent = execution_agent_m.new)
+                        task.executed_by agent
+
+                        execute do
+                            agent.start!
+                            agent.ready_event.emit
+                            task.start!
+                        end
+
+                        expect_execution { agent.stop! }
+                            .to do
+                                fail_to_start task
+                                emit execution_agent_m.match.stop_event
+                            end
+                    end
+                    it "does not relate to a handler error" do
+                        task_m = Task.new_submodel do
+                            event(:start, controlable: true) { |_| start_event.emit }
+                        end
+                        plan.add_mission_task(task = task_m.new)
+                        task.stop_event.on { raise ArgumentError }
+
+                        execute do
+                            task.start!
+                        end
+
+                        e = assert_raises(ExecutionExpectations::UnexpectedErrors) do
+                            expect_execution { task.stop_event.emit }
+                                .to { emit task_m.match.stop_event }
+                        end
+
+                        errors = e.each_execution_exception.to_a
+                        assert_kind_of EventHandlerError, errors[0].exception
+                        assert_kind_of ArgumentError,
+                                       errors[0].exception.each_original_exception.first
+                        assert_kind_of MissionFailedError, errors[1].exception
                     end
                 end
 
@@ -1101,7 +1167,10 @@ module Roby
 
                 describe "#ignore_errors_from" do
                     it "passes if the predicate matches" do
-                        plan.add(task = Roby::Task.new)
+                        plan.add(parent_task = Tasks::Simple.new)
+                        task = parent_task.depends_on(Tasks::Simple.new, failure: :start)
+
+                        execute { parent_task.start! }
                         expect_execution { task.start! }
                             .to { ignore_errors_from emit(task.start_event) }
                     end


### PR DESCRIPTION
The error handling code would currently determine that an exception
raised by an event handler is caused by the event. Because of this
relationship,

```
expect_execution { CODE }
  .to { emit EVENT }
```

would not report an exception raised by an event handler of EVENT.
This commit makes sure that it's not the case anymore.