### PR TITLE
fix: search folder documentation

### DIFF
--- a/lib/roby/app.rb
+++ b/lib/roby/app.rb
@@ -2231,7 +2231,7 @@ module Roby
         #   finally an empty string.
         # @return [Array<String>]
         #
-        # Given a search dir of [app2, app1]
+        # Given a search dir of [app1, app2]
         #
         #   app1/models/tasks/goto.rb
         #   app1/models/tasks/v3/goto.rb
@@ -2326,7 +2326,7 @@ module Roby
         #   the first matching directory is searched
         # @return [Array<String>]
         #
-        # Given a search dir of [app2, app1]
+        # Given a search dir of [app1, app2]
         #
         #   app1/models/tasks/goto.rb
         #   app1/models/tasks/v3/goto.rb
@@ -2392,7 +2392,7 @@ module Roby
         #   finally an empty string.
         # @return [Array<String>]
         #
-        # Given a search dir of [app2, app1], a robot name of v3 and a robot
+        # Given a search dir of [app1, app2], a robot name of v3 and a robot
         # type of asguard,
         #
         #   app1/config/v3.rb

--- a/test/test_app.rb
+++ b/test/test_app.rb
@@ -471,6 +471,19 @@ module Roby
         end
 
         describe "#find_dirs" do
+            it "interprets the first element of search_path "\
+               "as being the most specific" do
+                least_specific = make_tmppath
+                (least_specific / "test").mkdir
+                most_specific = make_tmppath
+                (most_specific / "test").mkdir
+                app.search_path = [most_specific, least_specific].map(&:to_s)
+                actual = app.find_dirs("test", all: true, order: :specific_first)
+
+                expected = [most_specific, least_specific].map { |p| (p / "test").to_s }
+                assert_equal expected, actual
+            end
+
             it "raises ArgumentError if no path is given" do
                 exception = assert_raises(ArgumentError) { app.find_dirs }
                 assert_equal "no path given", exception.message


### PR DESCRIPTION
This PR fixes the search folder priority order in documentation and add a test to ensure that the order between general and specific configurations is always followed.