### PR TITLE
feat: create the app shutdown handlers

### DIFF
--- a/lib/roby/cli/gen/roby_app/config/robots/robot.rb.erb
+++ b/lib/roby/cli/gen/roby_app/config/robots/robot.rb.erb
@@ -15,13 +15,19 @@ Robot.init do
     # Roby.app.register_app('../separate_path')
 end
 
+# Block evaluated to configure the system, that is set up values in Roby's Conf
+# and State
+Robot.setup do
+end
+
 # Block evaluated to load the models this robot requires
+#
+# This is called after `setup`
 Robot.requires do
 end
 
-# Block evaluated to configure the system, that is set up values in Roby's Conf
-# and State
-Robot.config do
+# The opposite of 'setup' (and 'requires')
+Robot.cleanup do
 end
 
 # Setup of the robot's main action interface
@@ -40,4 +46,11 @@ end
 # Block evaluated when the Roby app is fully setup, and the robot ready to
 # start. This is where one usually adds permanent tasks and/or status lines
 Robot.controller do
+end
+
+# Block evaluated right after the execution, but before the cleanup
+#
+# In particular, this is executed at teardown between each tests. Mostly, undo
+# things here that the controller block would have registered.
+Robot.shutdown do
 end

--- a/lib/roby/robot.rb
+++ b/lib/roby/robot.rb
@@ -96,6 +96,10 @@ module Robot
         Roby.app.controller(reset: reset, user: true, &block)
     end
 
+    def self.shutdown(&block)
+        Roby.app.on_shutdown(user: true, &block)
+    end
+
     def self.actions(&block)
         Roby.app.actions(user: true, &block)
     end

--- a/lib/roby/test/spec.rb
+++ b/lib/roby/test/spec.rb
@@ -86,6 +86,7 @@ module Roby
                 end
 
                 teardown_registered_plans
+                app.run_shutdown_blocks
             ensure
                 clear_registered_plans
                 if teardown_failure


### PR DESCRIPTION
"shutdown" happens at the end of a run, but before cleanup. I've created this handler because the tests don't cleanup (way too costly), but we still need to remove the stuff that the controller / test itself might have been adding to the app.

Note that 'shutdown' as a stage in the app lifecycle already existed (which really shows its usefulness). What was missing is a user-visible handler.