### PR TITLE
feat: add a stub mode to ExternalProcess, and a global flag to control it

### DIFF
--- a/lib/roby/cli/gen/roby_app/config/init.rb
+++ b/lib/roby/cli/gen/roby_app/config/init.rb
@@ -17,3 +17,13 @@ Roby.app.backward_compatible_naming = false
 # FlatFish
 #
 # Roby.app.module_name = 'Override'
+
+# Whether Roby::Tasks::ExternalProcess should start the subprocess when executed
+# under `roby test` (false) or not (true)
+#
+# The default is false for backward compatibility reasons. We recommend setting it
+# to true, and overriding it in tests as needed by setting the specific task's
+# stub_in_roby_simulation_mode argument
+#
+# require "roby/tasks/external_process"
+# Roby::Tasks::ExternalProcess.stub_in_roby_simulation_mode = false

--- a/lib/roby/support.rb
+++ b/lib/roby/support.rb
@@ -179,4 +179,31 @@ module Roby
         Roby.fatal "Deprecation Error: #{msg} at #{caller[1, caller_depth].join("\n")}"
         raise NotImplementedError
     end
+
+    # Cross-platform way of finding a file in the $PATH.
+    #
+    #   which('ruby') #=> /usr/bin/ruby
+    def self.find_in_path(cmd)
+        if cmd =~ /#{File::SEPARATOR}/
+            return cmd if File.file?(cmd)
+        end
+
+        exts = ENV["PATHEXT"] ? ENV["PATHEXT"].split(";") : [""]
+        ENV["PATH"].split(File::PATH_SEPARATOR).each do |path|
+            exts.each do |ext|
+                exe = File.join(path, "#{cmd}#{ext}")
+                return exe if File.file?(exe)
+            end
+        end
+        nil
+    end
+
+    # Cross-platform way of finding an executable in the $PATH.
+    #
+    #   which('ruby') #=> /usr/bin/ruby
+    def self.which(cmd)
+        return unless (path = find_in_path(cmd))
+
+        path if File.executable?(path)
+    end
 end


### PR DESCRIPTION
ExternalProcess are actually spawning subprocesses in roby tests, which goes against the point of the "simulation" mode, where we don't start subprocesses / external processes.

This commit adds a stub_subprocess argument to the task, and a global ExternalProcess.stub_in_roby_simulation_mode flag to set it automatically during tests. This flag is false for backward compatibility reasons.