### PR TITLE
feat: example arguments for action required arguments

### DIFF
--- a/lib/roby/actions/action.rb
+++ b/lib/roby/actions/action.rb
@@ -30,7 +30,7 @@ module Roby
             # @param [Hash] arguments new arguments
             # @return [self]
             def with_arguments(**arguments)
-                @arguments.merge!(arguments)
+                @arguments = @arguments.merge(arguments)
                 self
             end
 

--- a/lib/roby/actions/models/action.rb
+++ b/lib/roby/actions/models/action.rb
@@ -5,14 +5,21 @@ module Roby
         module Models
             # Basic description of an action
             class Action
+                Void = Object.new
+
                 # Structure that stores the information about planning method arguments
                 #
                 # See MethodDescription
-                Argument = Struct.new :name, :doc, :required, :default do
+                Argument = Struct.new :name, :doc, :required, :default, :example do
                     def pretty_print(pp)
                         pp.text "#{name}: #{doc}"
                         pp.text required ? " (required)" : " (optional)"
                         pp.text " default=#{default}" if default
+                        pp.text " example=#{example}" if example_defined?
+                    end
+
+                    def example_defined?
+                        example != Void
                     end
 
                     def required?
@@ -129,8 +136,10 @@ module Roby
                 end
 
                 # Documents a new required argument to the method
-                def required_arg(name, doc = nil)
-                    arguments << Argument.new(name.to_s, doc, true)
+                def required_arg(name, doc = nil, example: Void)
+                    arg = Argument.new(name.to_s, doc, true)
+                    arg.example = example
+                    arguments << arg
                     self
                 end
 
@@ -139,6 +148,7 @@ module Roby
                     doc = doc.to_str if doc
                     arg = Argument.new(name.to_s, doc, false)
                     arg.default = default
+                    arg.example = Void
                     arguments << arg
                     self
                 end

--- a/lib/roby/actions/models/interface_base.rb
+++ b/lib/roby/actions/models/interface_base.rb
@@ -357,14 +357,14 @@ module Roby
                 # Returns an action description if 'm' is the name of a known action
                 #
                 # @return [Action]
-                def method_missing(name, *args)
+                def method_missing(name, *args, **kw)
                     if (model = find_action_by_name(name.to_s))
                         if args.size > 1
                             raise ArgumentError,
                                   "expected zero or one argument, got #{args.size}"
                         end
 
-                        return model.new(*args)
+                        return model.new(*args, **kw)
                     end
 
                     super

--- a/test/actions/test_action.rb
+++ b/test/actions/test_action.rb
@@ -6,56 +6,124 @@ require "roby/tasks/simple"
 module Roby
     module Actions
         describe Action do
-            describe "#has_missing_required_arg?" do
-                attr_reader :action_m
+            describe "#missing_required_arguments" do
+                attr_reader :interface_m
 
                 before do
-                    @action_m = Interface.new_submodel
+                    @interface_m = Interface.new_submodel
                 end
-                it "returns true if a required argument is unset" do
-                    action_m.describe("test_action").required_arg("arg")
-                    action_m.class_eval { def test_action(*args); end }
-                    assert action_m.test_action
-                        .has_missing_required_arg?
+                it "returns required arguments that are not set" do
+                    action_m = interface_m.describe("test_action").required_arg("arg")
+                    interface_m.class_eval { def test_action(*args); end }
+                    assert_equal(
+                        [action_m.find_arg("arg")],
+                        interface_m.test_action.missing_required_arguments
+                    )
                 end
-                it "returns true if a required argument is set using a delayed argument object" do
-                    action_m.describe("test_action").required_arg("arg")
-                    action_m.class_eval { def test_action(*args); end }
-                    assert action_m.test_action(arg: flexmock(evaluate_delayed_argument: nil))
-                        .has_missing_required_arg?
+                it "returns required arguments set using a delayed argument object" do
+                    action_m = interface_m.describe("test_action").required_arg("arg")
+                    interface_m.class_eval { def test_action(*args); end }
+                    assert_equal(
+                        [action_m.find_arg("arg")],
+                        interface_m.test_action(
+                            arg: flexmock(evaluate_delayed_argument: nil)
+                        ).missing_required_arguments
+                    )
                 end
-                it "returns false if an optional argument is unset" do
-                    action_m.describe("test_action").optional_arg("arg", "", 10)
-                    action_m.class_eval { def test_action(*args); end }
-                    refute action_m.test_action
-                        .has_missing_required_arg?
+                it "does not return unset optional arguments" do
+                    interface_m.describe("test_action").optional_arg("arg", "", 10)
+                    interface_m.class_eval { def test_action(*args); end }
+                    assert_equal [], interface_m.test_action.missing_required_arguments
                 end
-                it "returns true if an optional argument is set using a delayed argument object" do
-                    action_m.describe("test_action").optional_arg("arg", "", 10)
-                    action_m.class_eval { def test_action(*args); end }
-                    assert action_m.test_action(arg: flexmock(evaluate_delayed_argument: nil))
-                        .has_missing_required_arg?
+                it "returns optional arguments set using a delayed argument object" do
+                    action_m = interface_m.describe("test_action")
+                                          .optional_arg("arg", "", 10)
+                    interface_m.class_eval { def test_action(*args); end }
+                    assert_equal(
+                        [action_m.find_arg("arg")],
+                        interface_m.test_action(
+                            arg: flexmock(evaluate_delayed_argument: nil)
+                        ).missing_required_arguments
+                    )
                 end
-                it "returns false if there are no arguments" do
-                    action_m.describe("test_action")
-                    action_m.class_eval { def test_action(*args); end }
-                    refute action_m.test_action
-                        .has_missing_required_arg?
+                it "returns an empty array if there are no arguments" do
+                    interface_m.describe("test_action")
+                    interface_m.class_eval { def test_action(*args); end }
+                    assert_equal [], interface_m.test_action.missing_required_arguments
                 end
-                it " returns false if all required arguments are set" do
-                    action_m.describe("test_action").required_arg("arg")
-                    action_m.class_eval { def test_action(*args); end }
-                    refute action_m.test_action(arg: 10)
-                        .has_missing_required_arg?
+                it "returns an empty array if all required arguments are set" do
+                    interface_m.describe("test_action").required_arg("arg")
+                    interface_m.class_eval { def test_action(*args); end }
+                    assert_equal [], interface_m.test_action(arg: 10)
+                                                .missing_required_arguments
                 end
-                it " returns false if all required arguments are set and some optional arguments are set" do
-                    action_m.describe("test_action")
+                it "returns an empty array if all required arguments are set "\
+                   "and some optional arguments are set" do
+                    interface_m.describe("test_action")
                         .required_arg("required_arg")
                         .optional_arg("optional_arg")
                         .optional_arg("unset_optional_arg")
-                    action_m.class_eval { def test_action(*args); end }
-                    refute action_m.test_action(required_arg: 10, optional_arg: 20)
-                        .has_missing_required_arg?
+                    interface_m.class_eval { def test_action(*args); end }
+                    assert_equal [], interface_m
+                                     .test_action(required_arg: 10, optional_arg: 20)
+                                     .missing_required_arguments
+                end
+            end
+            describe "#has_missing_required_arg?" do
+                before do
+                    @interface_m = Interface.new_submodel
+                    @interface_m.describe("test_action")
+                    @interface_m.class_eval { def test_action(*args); end }
+                end
+                it "returns true if there are missing required arguments" do
+                    action = flexmock(@interface_m.test_action)
+                    action.should_receive(missing_required_arguments: [flexmock])
+                    assert action.has_missing_required_arg?
+                end
+                it "returns false if there are no missing required arguments" do
+                    action = flexmock(@interface_m.test_action)
+                    action.should_receive(missing_required_arguments: [])
+                    refute action.has_missing_required_arg?
+                end
+            end
+            describe "#with_example_arguments" do
+                before do
+                    @interface_m = Interface.new_submodel
+                end
+
+                it "leaves required arguments that are set" do
+                    @interface_m.describe("test_action")
+                                .required_arg("t", "", example: 20)
+                    @interface_m.class_eval { def test_action(*args); end }
+                    action = @interface_m.test_action(t: 10)
+                    action.with_example_arguments
+                    assert_equal 10, action.arguments[:t]
+                end
+                it "fills unset required arguments with their example" do
+                    @interface_m.describe("test_action")
+                                .required_arg("t", "", example: 20)
+                    @interface_m.class_eval { def test_action(*args); end }
+                    action = @interface_m.test_action
+                    action.with_example_arguments
+                    assert_equal 20, action.arguments[:t]
+                end
+                it "does not change unset required arguments "\
+                   "if they do not have an example" do
+                    @interface_m.describe("test_action")
+                                .required_arg("t", "")
+                    @interface_m.class_eval { def test_action(*args); end }
+                    action = @interface_m.test_action
+                    action.with_example_arguments
+                    refute action.arguments.key?(:t)
+                end
+                it "does not modify an original action after a copy" do
+                    @interface_m.describe("test_action")
+                                .required_arg("t", "", example: 20)
+                    @interface_m.class_eval { def test_action(*args); end }
+                    action1 = @interface_m.test_action
+                    action2 = action1.dup.with_example_arguments
+                    refute action1.arguments.key?(:t)
+                    assert_equal 20, action2.arguments[:t]
                 end
             end
         end

--- a/test/actions/test_action.rb
+++ b/test/actions/test_action.rb
@@ -6,6 +6,23 @@ require "roby/tasks/simple"
 module Roby
     module Actions
         describe Action do
+            describe "#with_arguments" do
+                before do
+                    @interface_m = Interface.new_submodel
+                end
+
+                it "does not modify an original action after a copy" do
+                    @interface_m.describe("test_action")
+                                .required_arg("t", "")
+                    @interface_m.class_eval { def test_action(*args); end }
+
+                    action1 = @interface_m.test_action(t: 10)
+                    action2 = action1.dup.with_arguments(t: 20)
+                    assert_equal 10, action1.arguments[:t]
+                    assert_equal 20, action2.arguments[:t]
+                end
+            end
+
             describe "#missing_required_arguments" do
                 attr_reader :interface_m
 


### PR DESCRIPTION
These are meant for the model-based tools to be able to call simple
actions that have required arguments, when the resulting plan is not
argument-dependent and needs to be analyzed. For instance, Syskit
mass-check predicates (e.g. assert_can_deploy) can get action state
machines and/or method actions to be called and check that the Syskit
bits are viable.

This covers the 80% of the use-cases, for the rest the calls will
have still to be done manually.