### PR TITLE
feat: set state name in action state machine

### DIFF
--- a/lib/roby/coordination/models/action_state_machine.rb
+++ b/lib/roby/coordination/models/action_state_machine.rb
@@ -97,8 +97,10 @@ module Roby
                     @starting_state = validate_task(state)
                 end
 
-                def state(object, task_model = Roby::Task)
-                    task(object, task_model)
+                def state(object, task_model = Roby::Task, as: nil)
+                    state = task(object, task_model)
+                    state.name = as
+                    state
                 end
 
                 # Capture the value of an event context

--- a/lib/roby/coordination/models/base.rb
+++ b/lib/roby/coordination/models/base.rb
@@ -121,7 +121,7 @@ module Roby
                         object = definition_context.local_variable_get(var)
                         suffixes.each do |klass, suffix|
                             if object.kind_of?(klass)
-                                object.name = "#{var}#{suffix}"
+                                object.name ||= "#{var}#{suffix}"
                             end
                         end
                     end

--- a/test/coordination/test_action_state_machine.rb
+++ b/test/coordination/test_action_state_machine.rb
@@ -591,13 +591,12 @@ module Roby
 
             it "set state name explicitly" do
                 task_m = self.task_m
-                state_name = "explicit-state-name"
                 s0 = nil
                 action_m.action_state_machine "test" do
-                    s0 = state(task_m, state_name, as: state_name)
+                    s0 = state(task_m, as: "explicit-state-name")
                     start(s0)
                 end
-                assert_equal state_name, s0.name
+                assert_equal "explicit-state-name", s0.name
             end
         end
     end

--- a/test/coordination/test_action_state_machine.rb
+++ b/test/coordination/test_action_state_machine.rb
@@ -588,6 +588,17 @@ module Roby
                     task.current_task_child.success_event.emit
                 end
             end
+
+            it "set state name explicitly" do
+                task_m = self.task_m
+                state_name = "explicit-state-name"
+                s0 = nil
+                action_m.action_state_machine "test" do
+                    s0 = state(task_m, state_name, as: state_name)
+                    start(s0)
+                end
+                assert_equal state_name, s0.name
+            end
         end
     end
 end


### PR DESCRIPTION
Creates a way for setting states' names explicitly in action state machines 