### PR TITLE
feat: define Roby::Task#action_state_machine

### DIFF
--- a/lib/roby/coordination/models/actions.rb
+++ b/lib/roby/coordination/models/actions.rb
@@ -186,7 +186,7 @@ module Roby
                 end
 
                 def method_missing(m, *args, **kw)
-                    action = action_interface.find_action_by_name(m.to_s)
+                    action = action_interface&.find_action_by_name(m.to_s)
                     return super unless action
 
                     action.new(*args, **kw)

--- a/lib/roby/task.rb
+++ b/lib/roby/task.rb
@@ -1766,6 +1766,17 @@ module Roby
         def remove_coordination_object(object)
             @coordination_objects.delete(object)
         end
+
+        # Create an action state machine and attach it to this task
+        #
+        # Unlike `Actions::Interface#action_state_machine`, states must be
+        # defined from explicit action objects
+        def action_state_machine(&block)
+            model = Coordination::ActionStateMachine
+                .new_submodel(action_interface: nil, root: self.model)
+            model.parse(&block)
+            model.new(self)
+        end
     end
 
     unless defined? TaskStructure

--- a/test/coordination/models/test_action_state_machine.rb
+++ b/test/coordination/models/test_action_state_machine.rb
@@ -69,6 +69,17 @@ describe Roby::Coordination::Models::ActionStateMachine do
         assert_nil state_arg.default
     end
 
+    it "handles not having an action interface in method_missing" do
+        model = Roby::Coordination::ActionStateMachine
+            .new_submodel(action_interface: nil, root: Roby::Task.new_submodel)
+
+        refute model.respond_to?(:does_not_exist)
+        e = assert_raises(NoMethodError) do
+            model.does_not_exist
+        end
+        assert_equal :does_not_exist, e.name
+    end
+
     describe "#transition" do
         it "raises if the source state if not reachable" do
             assert_raises(Roby::Coordination::Models::UnreachableStateUsed) do


### PR DESCRIPTION
Action state machines do not need to be tied to an action interface.
This pull request adds Task#action_state_machine to create one
on-the-fly on a task instance.