### PR TITLE
fix: the MiniTest namespace has been removed, it is only Minitest now

### DIFF
--- a/lib/roby/test/assertion.rb
+++ b/lib/roby/test/assertion.rb
@@ -2,7 +2,7 @@
 
 module Roby
     module Test
-        class Assertion < MiniTest::Assertion
+        class Assertion < Minitest::Assertion
             attr_reader :original_error
 
             def initialize(original_error)


### PR DESCRIPTION
The old namespace was removed in 5.19