### PR TITLE
fix: fix a longstanding problem during log replay

### DIFF
--- a/lib/roby/droby/plan_rebuilder.rb
+++ b/lib/roby/droby/plan_rebuilder.rb
@@ -275,11 +275,27 @@ module Roby
                 event.finalization_time = time
                 if !plan.garbaged_events.include?(event) && event.root_object?
                     plan.finalized_events << event
-                    plan.remove_free_event(event)
+                    plan.at_cycle_end.remove_free_event << event
+                end
+
+                plan.at_cycle_end.deregister_object << event
+                [plan, event]
+            end
+
+            def apply_at_cycle_end
+                plan.at_cycle_end.remove_free_event.each do |ev|
+                    plan.remove_free_event(ev)
+                end
+                plan.at_cycle_end.remove_task.each do |task|
+                    plan.remove_task(task)
+                end
+                plan.at_cycle_end.deregister_object.each do |obj|
+                    object_manager.deregister_object(obj)
+                end
+                unless plan.at_cycle_end.remove_free_event.empty? &&
+                       plan.at_cycle_end.remove_task.empty?
                     announce_structure_update
                 end
-                object_manager.deregister_object(event)
-                [plan, event]
             end
 
             def finalized_task(time, plan_id, task)
@@ -288,10 +304,9 @@ module Roby
                 task.finalization_time = time
                 unless plan.garbaged_tasks.include?(task)
                     plan.finalized_tasks << task
-                    plan.remove_task(task)
-                    announce_structure_update
+                    plan.at_cycle_end.remove_task << task
                 end
-                object_manager.deregister_object(task)
+                plan.at_cycle_end.deregister_object << task
                 [plan, task]
             end
 
@@ -389,6 +404,7 @@ module Roby
                 @state = timings.delete(:state)
                 @stats = timings
                 @start_time ||= self.cycle_start_time
+                apply_at_cycle_end
                 announce_state_update
             end
 

--- a/lib/roby/droby/rebuilt_plan.rb
+++ b/lib/roby/droby/rebuilt_plan.rb
@@ -7,6 +7,16 @@ module Roby
         # It stores additional event propagation information extracted from the
         # stream
         class RebuiltPlan < Roby::Plan
+            AtCycleEnd =
+                Struct.new :remove_free_event, :remove_task, :deregister_object do
+                    def clear
+                        self.remove_free_event = []
+                        self.remove_task = []
+                        self.deregister_object = []
+                    end
+                end
+            # Set of operations that are scheduled to be done at cycle end
+            attr_reader :at_cycle_end
             # The set of tasks that have been finalized since the last call to
             # #clear_integrated
             attr_reader :finalized_tasks
@@ -59,6 +69,7 @@ module Roby
                 @failed_to_start = []
                 @propagated_exceptions = []
                 @scheduler_states = []
+                @at_cycle_end = AtCycleEnd.new([], [], [])
             end
 
             def merge(plan)

--- a/test/droby/test_event_logging.rb
+++ b/test/droby/test_event_logging.rb
@@ -226,7 +226,7 @@ module Roby
                     assert rebuilt_plan.garbaged_events.empty?
                 end
 
-                it "remove a non-garbaged task immediately" do
+                it "remove a non-garbaged event immediately" do
                     local_plan.add(event = EventGenerator.new)
                     process_logged_events
                     r_event = rebuilt_plan.free_events.first


### PR DESCRIPTION
Regularly, but not often, log replay would fail with

    undefined method `failed_emissions' for #<Roby::TemplatePlan`

I finally took the time to get into it. Turns out that the Roby logs (and therefore the engine) sometimes finalizes a task while there are still some events pending - in this case a failed_event

What happens is that the exception leads to a finalization, and later (during processing), some exception handler marks events as emission_failed.

While the right fix would be to stop this behavior altogether, we also have to deal with existing logs that show this behavior. Process finalizations at the end of the cycle instead of immediately to workaround. Note that this is probably what also will be done at runtime.