### PR TITLE
fix: manage loading older log files

### DIFF
--- a/lib/roby/droby/logfile.rb
+++ b/lib/roby/droby/logfile.rb
@@ -167,6 +167,19 @@ module Roby
 
                     raise
                 end
+            rescue TypeError => e
+                case e.message
+                when /^struct Roby::Actions::Models::Action::Argument not compatible/
+                    Roby::Actions::Models::Action.const_set(
+                        :Argument,
+                        Struct.new(:name, :doc, :required, :default)
+                    )
+                    retry
+                else
+                    raise e, "#{e.message}, running roby-log repair "\
+                             "might repair the file", e.backtrace
+                end
+
             rescue Exception => e # rubocop:disable Lint/RescueException
                 raise e, "#{e.message}, running roby-log repair "\
                          "might repair the file", e.backtrace


### PR DESCRIPTION
A few months ago, we extended Roby::Actions::Models::Action::Argument to add the "example" fields. Unfortunately, ruby won't load struct of the old type because the amount of fields have changed - something that does not happen with classes.

Beyond showing again that the current log format is simply wrong, it makes all older log files un-readable. This commit hacks its way around the problem by re-defining the constant with the old struct definition.