### PR TITLE
fix: access to relation-related methods on finalized tasks

### DIFF
--- a/lib/roby/event_generator.rb
+++ b/lib/roby/event_generator.rb
@@ -99,8 +99,9 @@ module Roby
         attr_predicate :pending?, true
 
         def plan=(plan)
+            null = self.plan.null_event_relation_graphs
             super
-            @relation_graphs = plan&.event_relation_graphs
+            @relation_graphs = plan&.event_relation_graphs || null
         end
 
         # call-seq:

--- a/lib/roby/event_generator.rb
+++ b/lib/roby/event_generator.rb
@@ -99,9 +99,10 @@ module Roby
         attr_predicate :pending?, true
 
         def plan=(plan)
-            null = self.plan.null_event_relation_graphs
+            null = self.plan&.null_event_relation_graphs
             super
-            @relation_graphs = plan&.event_relation_graphs || null
+            @relation_graphs =
+                plan&.event_relation_graphs || null || @relation_graphs
         end
 
         # call-seq:

--- a/lib/roby/plan.rb
+++ b/lib/roby/plan.rb
@@ -103,8 +103,18 @@ module Roby
 
             @graph_observer = graph_observer
             create_relations
+            create_null_relations
 
             super()
+        end
+
+        def create_null_relations
+            @null_task_relation_graphs, @null_event_relation_graphs =
+                self.class.instanciate_relation_graphs(graph_observer: graph_observer)
+            @null_task_relation_graphs.freeze
+            @null_task_relation_graphs.each_value(&:freeze)
+            @null_event_relation_graphs.freeze
+            @null_event_relation_graphs.each_value(&:freeze)
         end
 
         def create_relations
@@ -121,6 +131,7 @@ module Roby
 
         def refresh_relations
             create_relations
+            create_null_relations
         end
 
         def self.instanciate_relation_graphs(graph_observer: nil)
@@ -159,11 +170,21 @@ module Roby
         # @see each_task_relation_graph
         attr_reader :task_relation_graphs
 
+        # A set of empty graphs that match {#task_relation_graphs}
+        #
+        # Used for finalized tasks
+        attr_reader :null_task_relation_graphs
+
         # The graphs that make event relations, formatted as required by
         # {Relations::DirectedRelationSupport#relation_graphs}
         #
         # @see each_event_relation_graph
         attr_reader :event_relation_graphs
+
+        # A set of empty graphs that match {#event_relation_graphs}
+        #
+        # Used for finalized events
+        attr_reader :null_event_relation_graphs
 
         # Enumerate all graphs (event and tasks) that form this plan
         def each_relation_graph(&block)

--- a/lib/roby/relations/bidirectional_directed_adjacency_graph.rb
+++ b/lib/roby/relations/bidirectional_directed_adjacency_graph.rb
@@ -413,12 +413,14 @@ module Roby
             end
 
             def freeze
-                @vertices_dict.each_value do |out_e, in_e|
-                    out_e.freeze
-                    in_e.freeze
-                end
-                @vertices_dict.freeze
-                @edge_info_map.freeze
+                return if frozen?
+
+                @forward_edges_with_info.transform_values!(&:freeze)
+                @forward_edges_with_info.freeze
+                @backward_edges.transform_values!(&:freeze)
+                @backward_edges.freeze
+
+                super
             end
 
             # Returns a set of removed edges and a set of new edges between elements

--- a/lib/roby/task.rb
+++ b/lib/roby/task.rb
@@ -405,10 +405,11 @@ module Roby
         end
 
         def plan=(new_plan) # :nodoc:
+            null = self.plan.null_task_relation_graphs
+
             super
 
-            @relation_graphs =
-                plan&.task_relation_graphs
+            @relation_graphs = plan&.task_relation_graphs || null
             for ev in bound_events.each_value
                 ev.plan = plan
             end

--- a/lib/roby/task.rb
+++ b/lib/roby/task.rb
@@ -405,11 +405,12 @@ module Roby
         end
 
         def plan=(new_plan) # :nodoc:
-            null = self.plan.null_task_relation_graphs
+            null = self.plan&.null_task_relation_graphs
 
             super
 
-            @relation_graphs = plan&.task_relation_graphs || null
+            @relation_graphs =
+                plan&.task_relation_graphs || null || @relation_graphs
             for ev in bound_events.each_value
                 ev.plan = plan
             end

--- a/test/relations/test_bidirectional_directed_adjacency_graph.rb
+++ b/test/relations/test_bidirectional_directed_adjacency_graph.rb
@@ -196,6 +196,35 @@ module Roby
                 assert_equal expected_edges, dg.each_edge.to_set
             end
 
+            describe "#freeze" do
+                it "does not allow adding a new source vertex" do
+                    dg = create_graph
+                    dg.freeze
+                    assert_raises(FrozenError) { dg.add_edge(1, 3, 5) }
+                end
+
+                it "does not allow adding a new target vertex" do
+                    dg = create_graph
+                    dg.add_edge(1, 2, 2)
+                    dg.freeze
+                    assert_raises(FrozenError) { dg.add_edge(1, 3, 5) }
+                end
+
+                it "does not allow adding a new edge between existing vertices" do
+                    dg = create_graph
+                    dg.add_edge(1, 2, 2)
+                    dg.add_edge(2, 3, 2)
+                    dg.freeze
+                    assert_raises(FrozenError) { dg.add_edge(1, 3, 5) }
+                end
+
+                it "can be called more than once" do
+                    dg = create_graph
+                    dg.freeze
+                    dg.freeze
+                end
+            end
+
             describe "#difference" do
                 attr_reader :a, :b, :v_a, :v_b, :mapping
 

--- a/test/test_event_generator.rb
+++ b/test/test_event_generator.rb
@@ -1641,5 +1641,18 @@ module Roby
                 refute event.pending?
             end
         end
+
+        describe "a finalized event" do
+            attr_reader :event
+
+            before do
+                plan.add(@event = EventGenerator.new)
+                execute { plan.remove_free_event(event) }
+            end
+
+            it "can use relation methods" do
+                event.each_out_neighbour(EventStructure::Forwarding).to_a
+            end
+        end
     end
 end

--- a/test/test_task.rb
+++ b/test/test_task.rb
@@ -1666,6 +1666,30 @@ module Roby
                 assert_kind_of interface_m::SomeAction, task.current_task_child
             end
         end
+
+        describe "a finalized task" do
+            attr_reader :task
+
+            before do
+                plan.add(@task = Roby::Task.new)
+                execute { plan.remove_task(task) }
+            end
+
+            it "raises NoMethodError when a non-existent _child handler is called" do
+                e = assert_raises(NoMethodError) { task.some_child }
+                assert_equal :some_child, e.name
+            end
+
+            it "returns false when respond_to? is called on a _child handler" do
+                plan.add(task = Roby::Task.new)
+                execute { plan.remove_task(task) }
+                refute task.respond_to?(:some_child)
+            end
+
+            it "has access to relation-related methods" do
+                assert_equal [], task.each_out_neighbour(TaskStructure::Dependency).to_a
+            end
+        end
     end
 end
 


### PR DESCRIPTION
The current implementation of plan= would nil @relation_graphs on
plan objects, which led to any relation-related method to fail on
a finalized object.

This commit sets instead null relation graphs, which will then treat
finalized tasks as single tasks without any relations.

[sc-33156]