### PR TITLE
fix: force-merge arguments coming from the DRoby protocol

### DIFF
--- a/lib/roby/droby/v5/droby_dump.rb
+++ b/lib/roby/droby/v5/droby_dump.rb
@@ -562,7 +562,7 @@ module Roby
                         end
 
                         unless fresh_proxy
-                            task.arguments.merge!(peer.local_object(arguments))
+                            task.arguments.force_merge!(peer.local_object(arguments))
                         end
                         task.instance_variable_set("@data", peer.local_object(data))
                     end


### PR DESCRIPTION
The is used for log replaying. Checking for equality makes no sense there since the remote *is* the source of truth. Define TaskArguments#force_merge! and use it there.

This should solve the all-too-common "can't merge arguments" error in the Syskit IDE.