### PR TITLE
fix; show complete exception traces when displaying exceptions as reason for unachievability

### DIFF
--- a/lib/roby/exceptions.rb
+++ b/lib/roby/exceptions.rb
@@ -332,14 +332,20 @@ module Roby
         message.split("\n")
     end
 
-    def self.format_exception(exception, with_original_exceptions: true)
+    def self.format_exception(exception, with_original_exceptions: true, with_backtrace: false)
         message = format_one_exception(exception)
-        if with_original_exceptions && exception.respond_to?(:original_exceptions)
-            exception.original_exceptions.each do |original_e|
-                message.concat(format_exception(original_e, with_original_exceptions: true))
-            end
+        message += format_backtrace(exception) if with_backtrace
+        return message unless with_original_exceptions
+        return message unless exception.respond_to?(:original_exceptions)
+
+        original_exception_msgs = exception.original_exceptions.flat_map do |original_e|
+            format_exception(
+                original_e,
+                with_original_exceptions: true,
+                with_backtrace: with_backtrace
+            )
         end
-        message
+        message + original_exception_msgs
     end
 
     LOG_SYMBOLIC_TO_NUMERIC = Array[

--- a/lib/roby/test/execution_expectations.rb
+++ b/lib/roby/test/execution_expectations.rb
@@ -764,7 +764,27 @@ module Roby
 
                 def format_unachievable_explanation(pp, explanation)
                     pp.text "but it did not because of "
-                    explanation.pretty_print(pp)
+                    case explanation
+                    when Exception
+                        msg = Roby.format_exception(explanation, with_backtrace: true)
+                        msg.each do |line|
+                            pp.text line
+                            pp.breakable
+                        end
+                    when Event
+                        explanation.pretty_print(pp)
+                        if (e = explanation.context.first).kind_of?(Exception)
+                            msg = Roby.format_exception(e, with_backtrace: true)
+                            pp.nest(2) do
+                                msg.each do |line|
+                                    pp.breakable
+                                    pp.text line
+                                end
+                            end
+                        end
+                    else
+                        explanation.pretty_print(pp)
+                    end
                 end
 
                 # Add a block that should be used to filter the result of this

--- a/test/test/test_expect_execution.rb
+++ b/test/test/test_expect_execution.rb
@@ -69,6 +69,83 @@ module Roby
                     assert_equal expected_ret, ret
                 end
             end
+
+            it "properly formats an exception "\
+               "when it is the reason of an unachievable message" do
+                plan.add(task = Tasks::Simple.new)
+                exception =
+                    begin
+                        raise "something"
+                    rescue RuntimeError => e
+                        e
+                    end
+
+                begin
+                    expect_execution { task.success_event.unreachable!(exception) }
+                        .to { emit task.success_event }
+                rescue ExecutionExpectations::Unmet => unmet # rubocop:disable Lint/SuppressedException,Naming/RescuedExceptionsVariableName
+                end
+
+                expected = <<~MSG
+                    1 unmet expectations
+                    Roby::Tasks::Simple<id:XX>(id:XX)/success should be emitted, but it did not because of something (RuntimeError)
+
+                      test/test/test_expect_execution.rb:XXX:in `block (2 levels) in <module:Test>'
+                MSG
+
+                assert_error_message_start_with(expected, unmet.message)
+            end
+
+            it "properly formats an exception when it is the context of an event "\
+               "that is the reason the expectation is unmet" do
+                plan.add(task = Tasks::Simple.new)
+                task.poll { raise "something" }
+                begin
+                    expect_execution { task.start! }
+                        .to { emit task.success_event }
+                rescue ExecutionExpectations::Unmet => unmet # rubocop:disable Lint/SuppressedException,Naming/RescuedExceptionsVariableName
+                end
+
+                expected = <<~MSG
+                    1 unmet expectations
+                    Roby::Tasks::Simple<id:XX>(id:XX)/success should be emitted, but it did not because of event 'internal_error' emitted at [XX] from
+                      Roby::Tasks::Simple<id:XX>
+                        no owners
+                        arguments:
+                          id:XX
+                      Roby::CodeError: user code raised an exception Roby::Tasks::Simple<id:XX>
+                        no owners
+                        arguments:
+                          id:XX
+                      Roby::CodeError: user code raised an exception Roby::Tasks::Simple<id:XX>
+                        no owners
+                        arguments:
+                          id:XX
+                      something (RuntimeError)
+
+                        test/test/test_expect_execution.rb:XXX:in `block (3 levels) in <module:Test>'
+                        test/test/test_expect_execution.rb:XXX:in `block (2 levels) in <module:Test>'
+                MSG
+
+                assert_error_message_start_with(expected, unmet.message)
+            end
+
+            def normalize_error_message(msg)
+                msg.gsub(/id:\s*"?\d+"?/, "id:XX")
+                   .gsub(/\[[\d:.]* @\d+\]/, "[XX]")
+                   .gsub(/^\s+$/, "")
+                   .gsub(/\.rb:\d+:/, ".rb:XXX:")
+                   .gsub(%r{/.*tools/roby/}, "") # paths may be absolute or relative
+            end
+
+            def assert_error_message_start_with(expected, actual)
+                actual = normalize_error_message(actual)
+                actual_dbg = actual.split("\n").map(&:inspect).join("\n")
+                expected_dbg = expected.split("\n").map(&:inspect).join("\n")
+                assert actual.start_with?(expected),
+                       "expected\n```\n#{actual_dbg}\n```\nto start with\n"\
+                       "```\n#{expected_dbg}\n```"
+            end
         end
     end
 end


### PR DESCRIPTION
Exception#pretty_print only shows the exception message nowadays.