### PR TITLE
feat: define the "prepare" lifecycle hook

### DIFF
--- a/lib/roby/cli/gen/roby_app/config/robots/robot.rb.erb
+++ b/lib/roby/cli/gen/roby_app/config/robots/robot.rb.erb
@@ -48,6 +48,14 @@ end
 Robot.controller do
 end
 
+# Block evaluated right before execution, but before the cleanup
+#
+# In particular, this is executed at teardown between each tests. Mostly,
+# create things here that are needed only during execution. Anything done here
+# must be undone in the shutdown block
+Robot.prepare do
+end
+
 # Block evaluated right after the execution, but before the cleanup
 #
 # In particular, this is executed at teardown between each tests. Mostly, undo

--- a/lib/roby/plan.rb
+++ b/lib/roby/plan.rb
@@ -110,11 +110,11 @@ module Roby
 
         def create_null_relations
             @null_task_relation_graphs, @null_event_relation_graphs =
-                self.class.instanciate_relation_graphs(graph_observer: graph_observer)
-            @null_task_relation_graphs.freeze
+                self.class.instanciate_relation_graphs
             @null_task_relation_graphs.each_value(&:freeze)
-            @null_event_relation_graphs.freeze
+            @null_task_relation_graphs.freeze
             @null_event_relation_graphs.each_value(&:freeze)
+            @null_event_relation_graphs.freeze
         end
 
         def create_relations

--- a/lib/roby/robot.rb
+++ b/lib/roby/robot.rb
@@ -94,6 +94,10 @@ module Robot
         Roby.app.controller(reset: reset, user: true, &block)
     end
 
+    def self.prepare(&block)
+        Roby.app.on_prepare(user: true, &block)
+    end
+
     def self.shutdown(&block)
         Roby.app.on_shutdown(user: true, &block)
     end

--- a/lib/roby/test/spec.rb
+++ b/lib/roby/test/spec.rb
@@ -73,6 +73,7 @@ module Roby
                 end
                 register_plan(plan)
 
+                app.run_prepare_blocks
                 super
             end
 


### PR DESCRIPTION
So far we had

    setup
    controller (== run)
    shutdown
    cleanuṕ

The shutdown pair did not exist. Create it in this commit