### PR TITLE
fix: race condition in Logfile::Server between acceptation of a socket and its registration

### DIFF
--- a/lib/roby/droby/logfile/server.rb
+++ b/lib/roby/droby/logfile/server.rb
@@ -83,8 +83,12 @@ module Roby
 
                         # Incoming connections
                         if readable_sockets && !readable_sockets.empty?
-                            socket = server.accept
-                            @pending_data[socket] = []
+                            socket = Thread.handle_interrupt(Interrupt => :never) do
+                                s = server.accept
+                                @pending_data[s] = []
+                                s
+                            end
+
                             socket.setsockopt(Socket::IPPROTO_TCP, Socket::TCP_NODELAY, true)
                             socket.fcntl(Fcntl::FD_CLOEXEC, 1)
 

--- a/test/cli/test_display.rb
+++ b/test/cli/test_display.rb
@@ -164,9 +164,11 @@ module Roby
                     )
                     client = DRoby::Logfile::Client.new("localhost")
                     stop_log_server_thread
-                    select([client.socket], nil, nil, 5)
-                    assert_raises(Errno::ECONNRESET) do
-                        client.socket.read_nonblock(1)
+                    assert select([client.socket], nil, nil, 5)
+                    assert_raises(Errno::ECONNRESET, EOFError) do
+                        loop do
+                            client.socket.read_nonblock(1024)
+                        end
                     end
                     client.close
                 end


### PR DESCRIPTION
In tests, this led to the client socket not being closed, which in turn means that the connection is not closed. In practice, the display server is executed in its own thread which means that the socket was closed nonetheless.

The tests were passing if they finished the server thread before it accepted the socket, and would fail otherwise. Moreover, there was another race if the server thread would have time to send initial data.