### PR TITLE
fix: start the shell interfaces on random ports during tests

### DIFF
--- a/lib/roby/app.rb
+++ b/lib/roby/app.rb
@@ -722,12 +722,28 @@ module Roby
 
         # The host to which the shell interface server should bind
         #
+        # This is ignored if {#shell_interface_fd} is set
+        #
         # @return [String]
+        # @see shell_interface_host shell_interface_fd
         attr_accessor :shell_interface_host
+
         # The port on which the shell interface server should be
         #
+        # This is ignored if {#shell_interface_fd} is set
+        #
         # @return [Integer]
+        # @see shell_interface_host shell_interface_fd
         attr_accessor :shell_interface_port
+
+        # A file descriptor that should be used as-is for the interface server
+        #
+        # It supersedes the setting for {#shell_interface_port} and
+        # {#shell_interface_host}
+        #
+        # @return [Integer]
+        # @see shell_interface_host shell_interface_port
+        attr_accessor :shell_interface_fd
 
         # Whether an unexpected (non-comm-related) failure in the shell should
         # cause an abort
@@ -767,6 +783,7 @@ module Roby
             @shell_interface = nil
             @shell_interface_host = nil
             @shell_interface_port = Interface::DEFAULT_PORT
+            @shell_interface_fd = nil
             @shell_abort_on_exception = true
 
             @rest_interface = nil
@@ -2027,10 +2044,15 @@ module Roby
             end
 
             @shell_interface = Interface::TCPServer.new(
-                self, host: shell_interface_host, port: shell_interface_port
+                self,
+                host: shell_interface_host, port: shell_interface_port,
+                server_fd: shell_interface_fd
             )
             shell_interface.abort_on_exception = shell_abort_on_exception?
-            if shell_interface_port != Interface::DEFAULT_PORT
+            if shell_interface_fd
+                Robot.info "shell interface started on file descriptor "\
+                           "#{shell_interface_fd}"
+            elsif shell_interface_port != Interface::DEFAULT_PORT
                 Robot.info "shell interface started on port #{shell_interface_port}"
             else
                 Robot.debug "shell interface started on port #{shell_interface_port}"

--- a/lib/roby/app/scripts/run.rb
+++ b/lib/roby/app/scripts/run.rb
@@ -35,6 +35,10 @@ options = OptionParser.new do |opt|
         app.log_dir = dir
         app.log_create_current = false
     end
+    opt.on "--interface-fd=FD", Integer,
+           "file descriptor to use for the interface server" do |fd|
+        app.shell_interface_fd = fd
+    end
     opt.on "--port=PORT", Integer, "the interface port" do |port|
         app.shell_interface_port = port
     end

--- a/lib/roby/cli/base.rb
+++ b/lib/roby/cli/base.rb
@@ -35,6 +35,8 @@ module Roby
                         require "roby/app/debug"
                     end
 
+                    Roby.app.shell_interface_port = options[:port] if options[:port]
+
                     nil
                 end
 

--- a/lib/roby/exceptions.rb
+++ b/lib/roby/exceptions.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "pp"
+
 module Roby
     class UserError < RuntimeError
         def user_error?

--- a/lib/roby/test/aruba_minitest.rb
+++ b/lib/roby/test/aruba_minitest.rb
@@ -37,6 +37,13 @@ module Roby
                 super
             end
 
+            def roby_allocate_port
+                server = ::TCPServer.new(0)
+                server.local_address.ip_port
+            ensure
+                server&.close
+            end
+
             def run_command_and_stop(*args, fail_on_error: true)
                 cmd = run_command(*args)
                 cmd.stop

--- a/lib/roby/test/roby_app_helpers.rb
+++ b/lib/roby/test/roby_app_helpers.rb
@@ -186,7 +186,7 @@ module Roby
             end
 
             ROBY_PORT_COMMANDS = %w[run].freeze
-            ROBY_NO_INTERFACE_COMMANDS = %w[check].freeze
+            ROBY_NO_INTERFACE_COMMANDS = %w[check test].freeze
 
             # Spawn the roby app process
             #

--- a/lib/roby/test/roby_app_helpers.rb
+++ b/lib/roby/test/roby_app_helpers.rb
@@ -82,7 +82,7 @@ module Roby
             end
 
             def assert_roby_app_is_running(
-                pid, timeout: 10, host: "localhost", port: Interface::DEFAULT_PORT
+                pid, timeout: 20, host: "localhost", port: Interface::DEFAULT_PORT
             )
                 start_time = Time.now
                 while (Time.now - start_time) < timeout
@@ -118,7 +118,7 @@ module Roby
             # itself
             #
             # @see assert_roby_app_quits
-            def assert_roby_app_exits(pid, timeout: 5)
+            def assert_roby_app_exits(pid, timeout: 20)
                 deadline = Time.now + timeout
                 while Time.now < deadline
                     _, status = Process.waitpid2(pid, Process::WNOHANG)

--- a/lib/roby/test/roby_app_helpers.rb
+++ b/lib/roby/test/roby_app_helpers.rb
@@ -99,15 +99,33 @@ module Roby
                 flunk "could not get a connection within #{timeout} seconds"
             end
 
+            # Call the `quit` command and wait for the app to exit
+            #
+            # @see assert_roby_app_exits
             def assert_roby_app_quits(pid, interface: nil)
                 interface_owned = !interface
                 interface ||= assert_roby_app_is_running(pid)
                 interface.quit
-                _, status = Process.waitpid2(pid)
-                assert status.exited?
-                assert_equal 0, status.exitstatus
+                assert_roby_app_exits(pid)
             ensure
                 interface&.close if interface_owned
+            end
+
+            # Wait for the app to exit
+            #
+            # Unlike {#assert_roby_app_quits}, this method does not explicitly
+            # call quit or send a SIGINT signal. The app is expected to quit by
+            # itself
+            #
+            # @see assert_roby_app_quits
+            def assert_roby_app_exits(pid, timeout: 5)
+                deadline = Time.now + timeout
+                while Time.now < deadline
+                    _, status = Process.waitpid2(pid, Process::WNOHANG)
+                    return status if status
+
+                    sleep 0.01
+                end
             end
 
             def assert_roby_app_has_job(
@@ -160,15 +178,34 @@ module Roby
                 dir
             end
 
+            def roby_app_allocate_interface_port
+                server = TCPServer.new(0)
+                server.local_address.ip_port
+            ensure
+                server&.close
+            end
+
+            ROBY_PORT_COMMANDS = %w[run].freeze
+            ROBY_NO_INTERFACE_COMMANDS = %w[check].freeze
+
             # Spawn the roby app process
             #
             # @return [Integer] the app PID
-            def roby_app_spawn(*args, silent: false, **options)
+            def roby_app_spawn(command, *args, port: nil, silent: false, **options)
                 if silent
                     options[:out] ||= "/dev/null"
                     options[:err] ||= "/dev/null"
                 end
-                pid = spawn(roby_bin, *args, chdir: app_dir, **options)
+                port ||= roby_app_allocate_interface_port
+                port_args =
+                    if ROBY_PORT_COMMANDS.include?(command)
+                        ["--port", port.to_s]
+                    elsif !ROBY_NO_INTERFACE_COMMANDS.include?(command)
+                        ["--host", "localhost:#{port}"]
+                    end
+                pid = spawn(
+                    roby_bin, command, *args, *port_args, chdir: app_dir, **options
+                )
                 @spawned_pids << pid
                 pid
             end
@@ -177,9 +214,10 @@ module Roby
             #
             # @return [(Integer,Roby::Interface::Client)] the app PID and connected
             #   roby interface
-            def roby_app_start(*args, silent: false, **options)
-                pid = roby_app_spawn(*args, silent: silent, **options)
-                interface = assert_roby_app_is_running(pid)
+            def roby_app_start(*args, port: nil, silent: false, **options)
+                port ||= roby_app_allocate_interface_port
+                pid = roby_app_spawn(*args, port: port, silent: silent, **options)
+                interface = assert_roby_app_is_running(pid, port: port)
                 [pid, interface]
             end
 
@@ -187,10 +225,9 @@ module Roby
                 @spawned_pids << pid
             end
 
-            def roby_app_run(*args, silent: false, **options)
-                pid = roby_app_spawn(*args, silent: silent, **options)
-                _, status = Process.waitpid2(pid)
-                status
+            def roby_app_run(*args, port: nil, silent: false, **options)
+                pid = roby_app_spawn(*args, port: port, silent: silent, **options)
+                assert_roby_app_exits(pid)
             end
 
             def roby_app_create_logfile

--- a/lib/roby/test/roby_app_helpers.rb
+++ b/lib/roby/test/roby_app_helpers.rb
@@ -82,7 +82,7 @@ module Roby
             end
 
             def assert_roby_app_is_running(
-                pid, timeout: 10, host: "localhost", port: Roby::Interface::DEFAULT_PORT
+                pid, timeout: 10, host: "localhost", port: Interface::DEFAULT_PORT
             )
                 start_time = Time.now
                 while (Time.now - start_time) < timeout
@@ -102,9 +102,9 @@ module Roby
             # Call the `quit` command and wait for the app to exit
             #
             # @see assert_roby_app_exits
-            def assert_roby_app_quits(pid, interface: nil)
+            def assert_roby_app_quits(pid, port: Interface::DEFAULT_PORT, interface: nil)
                 interface_owned = !interface
-                interface ||= assert_roby_app_is_running(pid)
+                interface ||= assert_roby_app_is_running(pid, port: port)
                 interface.quit
                 assert_roby_app_exits(pid)
             ensure

--- a/lib/roby/test/roby_app_helpers.rb
+++ b/lib/roby/test/roby_app_helpers.rb
@@ -126,6 +126,7 @@ module Roby
 
                     sleep 0.01
                 end
+                flunk("app did not quit within #{timeout} seconds")
             end
 
             def assert_roby_app_has_job(
@@ -204,7 +205,7 @@ module Roby
                         ["--host", "localhost:#{port}"]
                     end
                 pid = spawn(
-                    roby_bin, command, *args, *port_args, chdir: app_dir, **options
+                    roby_bin, command, *port_args, *args, chdir: app_dir, **options
                 )
                 @spawned_pids << pid
                 pid

--- a/test/app/cucumber/test_controller.rb
+++ b/test/app/cucumber/test_controller.rb
@@ -11,7 +11,7 @@ module Roby
                 attr_reader :controller, :roby_app_dir, :roby_log_dir
 
                 before do
-                    @controller = Controller.new
+                    @controller = Controller.new(port: 0)
                     @roby_app_dir = make_tmpdir
                     @roby_log_dir = make_tmpdir
                     Dir.chdir(roby_app_dir) { CLI::GenMain.start(["app", "--quiet"]) }
@@ -38,10 +38,16 @@ module Roby
                     end
                 end
 
-                def roby_start(*args, log_dir: roby_log_dir, **options)
+                def roby_start(*args, log_dir: roby_log_dir, quiet: false, **options)
+                    redirection =
+                        if quiet
+                            { out: "/dev/null", err: "/dev/null" }
+                        else
+                            {}
+                        end
+
                     controller.roby_start(
-                        *args, out: "/dev/null", err: "/dev/null",
-                               log_dir: log_dir, **options
+                        *args, log_dir: log_dir, **redirection, **options
                     )
                 end
 

--- a/test/app/fixtures/cli_base.rb
+++ b/test/app/fixtures/cli_base.rb
@@ -6,6 +6,7 @@ class CLI < Roby::CLI::Base
     desc "cmd", "the command"
     option :robot
     option :controllers, type: :boolean, default: false
+    option :port, type: :numeric, default: Roby::Interface::DEFAULT_PORT
     def cmd
         setup_common
         app.log_server = false

--- a/test/app/test_run.rb
+++ b/test/app/test_run.rb
@@ -168,14 +168,8 @@ module Roby
                 out, = capture_subprocess_io do
                     dir = roby_app_setup_single_script
                     pid = roby_app_spawn("run", "does_not_exist.rb", chdir: dir)
-                    roby_app_with_polling(timeout: 10, period: 0.1) do
-                        _, status = Process.waitpid2(pid, Process::WNOHANG)
-                        if status
-                            assert status.exited?
-                            assert_equal 1, status.exitstatus
-                            true
-                        end
-                    end
+                    status = assert_roby_app_exits(pid)
+                    assert_equal 1, status.exitstatus
                 end
                 assert_match(/does_not_exist.rb, given as a model script on the command line, does not exist/, out)
             end
@@ -184,14 +178,8 @@ module Roby
                 out, = capture_subprocess_io do
                     dir = roby_app_setup_single_script
                     pid = roby_app_spawn("run", "does_not_exist", chdir: dir)
-                    roby_app_with_polling(timeout: 10, period: 0.1) do
-                        _, status = Process.waitpid2(pid, Process::WNOHANG)
-                        if status
-                            assert status.exited?
-                            assert_equal 1, status.exitstatus
-                            true
-                        end
-                    end
+                    status = assert_roby_app_exits(pid)
+                    assert_equal 1, status.exitstatus
                 end
                 assert_match(/does_not_exist, given as an action on the command line, does not exist/, out)
             end
@@ -200,14 +188,8 @@ module Roby
                 out, = capture_subprocess_io do
                     dir = roby_app_setup_single_script
                     pid = roby_app_spawn("run", "--", "does_not_exist.rb", chdir: dir)
-                    roby_app_with_polling(timeout: 10, period: 0.1) do
-                        _, status = Process.waitpid2(pid, Process::WNOHANG)
-                        if status
-                            assert status.exited?
-                            assert_equal 1, status.exitstatus
-                            true
-                        end
-                    end
+                    status = assert_roby_app_exits(pid)
+                    assert_equal 1, status.exitstatus
                 end
                 assert_match(/does_not_exist.rb, given as a controller script on the command line, does not exist/, out)
             end
@@ -216,7 +198,7 @@ module Roby
                 dir = roby_app_setup_single_script "is_running.rb"
                 out, = capture_subprocess_io do
                     pid = roby_app_spawn("run", "scripts/is_running.rb", chdir: dir)
-                    assert_roby_app_quits(pid)
+                    assert_roby_app_exits(pid)
                 end
                 assert_match(/is_running: false/, out)
             end
@@ -224,11 +206,11 @@ module Roby
             it "allows files given as argument to define new actions" do
                 dir = roby_app_setup_single_script "define_action.rb"
                 capture_subprocess_io do
-                    pid = roby_app_spawn("run", "scripts/define_action.rb", chdir: dir)
-                    assert_roby_app_is_running(pid)
-                    actions = roby_app_call_remote_interface(&:actions)
+                    pid, interface =
+                        roby_app_start("run", "scripts/define_action.rb", chdir: dir)
+                    actions = interface.actions
                     assert_equal ["action_defined_in_script"], actions.map(&:name)
-                    assert_roby_app_quits(pid)
+                    assert_roby_app_quits(pid, interface: interface)
                 end
             end
 
@@ -236,7 +218,7 @@ module Roby
                 dir = roby_app_setup_single_script "is_running.rb"
                 out, = capture_subprocess_io do
                     pid = roby_app_spawn("run", "--", "scripts/is_running.rb", chdir: dir)
-                    assert_roby_app_quits(pid)
+                    assert_roby_app_exits(pid)
                 end
                 assert_match(/is_running: true/, out)
             end
@@ -244,8 +226,11 @@ module Roby
             it "passes extra arguments to the controller file" do
                 dir = roby_app_setup_single_script "controller_arguments.rb"
                 out, = capture_subprocess_io do
-                    pid = roby_app_spawn("run", "--", "scripts/controller_arguments.rb", "extra", "args", chdir: dir)
-                    assert_roby_app_quits(pid)
+                    pid = roby_app_spawn(
+                        "run", "--", "scripts/controller_arguments.rb", "extra", "args",
+                        chdir: dir
+                    )
+                    assert_roby_app_exits(pid)
                 end
                 assert_match(/ARGV\[0\] = extra\nARGV\[1\] = args/, out)
             end

--- a/test/app/test_run.rb
+++ b/test/app/test_run.rb
@@ -197,8 +197,9 @@ module Roby
             it "loads files given as argument as model files" do
                 dir = roby_app_setup_single_script "is_running.rb"
                 out, = capture_subprocess_io do
-                    pid = roby_app_spawn("run", "scripts/is_running.rb", chdir: dir)
-                    assert_roby_app_exits(pid)
+                    pid, interface =
+                        roby_app_start("run", "scripts/is_running.rb", chdir: dir)
+                    assert_roby_app_quits(pid, interface: interface)
                 end
                 assert_match(/is_running: false/, out)
             end
@@ -217,8 +218,9 @@ module Roby
             it "loads the file just after a double dash as a controller file" do
                 dir = roby_app_setup_single_script "is_running.rb"
                 out, = capture_subprocess_io do
-                    pid = roby_app_spawn("run", "--", "scripts/is_running.rb", chdir: dir)
-                    assert_roby_app_exits(pid)
+                    pid, interface =
+                        roby_app_start("run", "--", "scripts/is_running.rb", chdir: dir)
+                    assert_roby_app_quits(pid, interface: interface)
                 end
                 assert_match(/is_running: true/, out)
             end
@@ -226,11 +228,11 @@ module Roby
             it "passes extra arguments to the controller file" do
                 dir = roby_app_setup_single_script "controller_arguments.rb"
                 out, = capture_subprocess_io do
-                    pid = roby_app_spawn(
+                    pid, interface = roby_app_start(
                         "run", "--", "scripts/controller_arguments.rb", "extra", "args",
                         chdir: dir
                     )
-                    assert_roby_app_exits(pid)
+                    assert_roby_app_quits(pid, interface: interface)
                 end
                 assert_match(/ARGV\[0\] = extra\nARGV\[1\] = args/, out)
             end

--- a/test/cli/test_gen_main.rb
+++ b/test/cli/test_gen_main.rb
@@ -10,8 +10,9 @@ module Roby
 
             def validate_app_runs(*args)
                 run_roby_and_stop ["check", *args].join(" ")
-                roby_run = run_roby ["run", *args].join(" ")
-                run_roby_and_stop "quit --retry"
+                port = roby_allocate_port
+                roby_run = run_roby ["run", "--port=#{port}", *args].join(" ")
+                run_roby_and_stop "quit --retry --host=localhost:#{port}"
                 roby_run.stop
                 assert_command_finished_successfully roby_run
             end

--- a/test/cli/test_main.rb
+++ b/test/cli/test_main.rb
@@ -35,46 +35,39 @@ module Roby
                 end
 
                 describe "the REST API" do
-                    it "starts the API on the default port if --rest is given" do
-                        run_roby "run --rest"
-                        assert_eventually do
-                            Interface::REST::Server.server_alive?(
-                                "localhost", Interface::DEFAULT_REST_PORT
-                            )
-                        end
-                        run_roby_and_stop "quit --retry"
+                    before do
+                        @interface_port = roby_allocate_port
+                        @rest_port = roby_allocate_port
                     end
-                    it "starts the API on a custom port if an integer argument is given to --rest" do
+
+                    it "starts the API" do
                         # Guess an available port ... not optimal, but hopefully good enough
-                        tcp_server = TCPServer.new(0)
-                        port = tcp_server.local_address.ip_port
-                        tcp_server.close
-                        run_roby "run --rest=#{port}"
+                        run_roby "run --rest=#{@rest_port} --port=#{@interface_port}"
                         assert_eventually do
                             Interface::REST::Server.server_alive?(
-                                "localhost", port
+                                "localhost", @rest_port
                             )
                         end
-                        run_roby_and_stop "quit --retry"
+                        run_roby_and_stop "quit --retry --host=localhost:#{@interface_port}"
                     end
                     it "properly shuts down the server" do
                         # We check whether the server gets shut down by
                         # starting two apps one after the other. If the socket
                         # is not closed, we won't be able to create the new
                         # server
-                        @run_cmd = run_roby "run --rest"
-                        run_roby_and_stop "quit --retry"
+                        @run_cmd = run_roby "run --rest=#{@rest_port} --port=#{@interface_port}"
+                        run_roby_and_stop "quit --retry --host=localhost:#{@interface_port}"
                         assert_command_stops @run_cmd
-                        @run_cmd = run_roby "run --rest"
-                        run_roby_and_stop "quit --retry"
+                        @run_cmd = run_roby "run --rest=#{@rest_port} --port=#{@interface_port}"
+                        run_roby_and_stop "quit --retry --host=localhost:#{@interface_port}"
                         assert_command_stops @run_cmd
                     end
                     it "starts the API on a Unix socket if one is given" do
                         dir = make_tmpdir
                         socket = File.join(dir, "rest-socket")
-                        run_roby "run --rest=#{socket}"
+                        run_roby "run --rest=#{socket} --port=#{@interface_port}"
                         assert_eventually { File.exist?(socket) }
-                        run_roby_and_stop "quit --retry"
+                        run_roby_and_stop "quit --retry --host=localhost:#{@interface_port}"
                     end
                 end
             end
@@ -82,32 +75,27 @@ module Roby
             describe "quit" do
                 before do
                     run_roby_and_stop "gen app"
+                    @interface_port = roby_allocate_port
                 end
                 it "exits with a nonzero status if there is no app to quit" do
-                    cmd = run_roby "quit"
+                    cmd = run_roby "quit --host=localhost:#{@interface_port}"
                     cmd.stop
                     assert_equal 1, cmd.exit_status
                 end
                 it "stops a running app" do
-                    run_cmd = run_roby "run"
-                    run_roby_and_stop "wait"
-                    run_roby_and_stop "quit"
-                    assert_command_stops run_cmd
-                end
-                it "stops a running app on another port" do
-                    run_cmd = run_roby "run --port 9999"
-                    run_roby_and_stop "wait --host localhost:9999"
-                    run_roby_and_stop "quit --host localhost:9999"
+                    run_cmd = run_roby "run --port=#{@interface_port}"
+                    run_roby_and_stop "wait --host=localhost:#{@interface_port}"
+                    run_roby_and_stop "quit --host=localhost:#{@interface_port}"
                     assert_command_stops run_cmd
                 end
                 it "waits forever for the app to be available if --retry is given" do
-                    run_cmd = run_roby "run"
-                    run_roby_and_stop "quit --retry"
+                    run_cmd = run_roby "run --port=#{@interface_port}"
+                    run_roby_and_stop "quit --retry --host=localhost:#{@interface_port}"
                     assert_command_stops run_cmd
                 end
                 it "times out on retrying if --retry is given a timeout" do
                     before = Time.now
-                    cmd = run_roby "quit --retry=1"
+                    cmd = run_roby "quit --retry=1 --host=localhost:#{@interface_port}"
                     cmd.stop
                     assert_equal 1, cmd.exit_status
                     assert (Time.now - before) > 1
@@ -117,10 +105,11 @@ module Roby
             describe "shell" do
                 before do
                     run_roby_and_stop "gen app"
+                    @interface_port = roby_allocate_port
                 end
                 it "connects and sends commands" do
-                    run_cmd = run_roby "run --port 9999"
-                    shell_cmd = run_roby "shell --host localhost:9999"
+                    run_cmd = run_roby "run --port #{@interface_port}"
+                    shell_cmd = run_roby "shell --host localhost:#{@interface_port}"
                     shell_cmd.write "quit\n"
                     shell_cmd.write "exit\n"
                     assert_command_stops shell_cmd

--- a/test/interface/async/client_server_test_helpers.rb
+++ b/test/interface/async/client_server_test_helpers.rb
@@ -23,19 +23,21 @@ module Roby
                     Roby.app
                 end
 
-                def default_server_port
-                    Roby::Interface::DEFAULT_PORT + 1
+                def available_server_port
+                    server = ::TCPServer.new(nil, 0)
+                    port = server.local_address.ip_port
+                    server.close
+                    port
                 end
 
-                def create_server
-                    server = Roby::Interface::TCPServer.new(
-                        Roby.app, port: default_server_port)
+                def create_server(port: 0)
+                    server = Roby::Interface::TCPServer.new(Roby.app, port: port)
                     @interface_servers << server
                     server
                 end
 
-                def create_client(*args, port: default_server_port, **options, &block)
-                    interface = Interface.new(*args, port: default_server_port, **options, &block)
+                def create_client(*args, port:, **options, &block)
+                    interface = Interface.new(*args, port: port, **options, &block)
                     @interfaces << interface
                     interface
                 end

--- a/test/interface/async/test_interface.rb
+++ b/test/interface/async/test_interface.rb
@@ -103,7 +103,7 @@ module Roby
 
                 describe "reachability hooks" do
                     it "calls on_unreachable once when there are no remote server" do
-                        interface = create_client
+                        interface = create_client(port: available_server_port)
                         recorder.should_receive(:reachable).never
                         interface.on_reachable { recorder.reachable }
                         recorder.should_receive(:unreachable).once
@@ -150,7 +150,7 @@ module Roby
 
                 describe "#jobs" do
                     it "returns an empty array if not reachable" do
-                        client = create_client
+                        client = create_client(port: available_server_port)
                         assert_equal [], client.jobs
                     end
                     it "returns the current list of jobs" do
@@ -226,7 +226,8 @@ module Roby
                         end
                     end
                     it "calls the hook on the jobs received at connection time" do
-                        client = create_client(connect: false)
+                        port = available_server_port
+                        client = create_client(connect: false, port: port)
                         recorder.should_receive(:job)
                             .once
                             .with(lambda { |job|
@@ -236,7 +237,7 @@ module Roby
                                   })
                         client.on_job { |j| recorder.job(j) }
 
-                        server = create_server
+                        server = create_server(port: port)
                         flexmock(server.interface).should_receive(:jobs).and_return(1 => %w[a b c])
 
                         future = client.attempt_connection

--- a/test/test_app.rb
+++ b/test/test_app.rb
@@ -1012,9 +1012,10 @@ module Roby
                     end
 
                     out_r, out_w = IO.pipe
-                    pid = roby_app_spawn("run", "--set", "some.field=42", out: out_w)
+                    pid, iface =
+                        roby_app_start("run", "--set", "some.field=42", out: out_w)
                     out_w.close
-                    assert_roby_app_quits(pid)
+                    assert_roby_app_quits(pid, interface: iface)
                     output = out_r.read
                     assert_match(/TEST: 42/, output)
                 end

--- a/test/test_app.rb
+++ b/test/test_app.rb
@@ -310,18 +310,15 @@ module Roby
         end
 
         describe "shell interface setup" do
-            it "binds the shell interface to the value specified in #shell_interface_host" do
-                flexmock(::TCPServer).should_receive(:new).with("127.0.0.1", Interface::DEFAULT_PORT).pass_thru
+            before do
+                app.shell_interface_port = 0
+            end
+
+            it "binds the shell interface to the configured host and port" do
+                flexmock(::TCPServer).should_receive(:new).with("127.0.0.1", 0).pass_thru
                 app.shell_interface_host = "127.0.0.1"
                 app.setup_shell_interface
                 assert_equal "127.0.0.1", app.shell_interface.ip_address
-                roby_app_call_interface
-            end
-            it "starts the shell interface on the port specified by #shell_interface_port" do
-                flexmock(::TCPServer).should_receive(:new).with(nil, 0).pass_thru
-                flexmock(Robot).should_receive(:info).with("shell interface started on port 0").once
-                app.shell_interface_port = 0
-                app.setup_shell_interface
                 roby_app_call_interface(port: app.shell_interface.ip_port)
             end
             it "refuses to start a shell interface if one is already setup" do


### PR DESCRIPTION
Depends on:
- [ ] https://github.com/tidewise/tidewise.common-package_set/pull/262
- [ ] https://github.com/rock-core/tools-syskit/pull/388