### PR TITLE
Add rubocop dependency

### DIFF
--- a/manifest.xml
+++ b/manifest.xml
@@ -24,6 +24,7 @@
   <depend package="hooks" />
   <depend package="rgl" />
   <depend package="thor" />
+  <depend package="rubocop" />
   <depend package="autorespawn" optional="1" />
 
   <depend package="qtruby" optional='1' />


### PR DESCRIPTION
Previously rubocop was only a `<test_depend />`, but its existence is required by the main Rakefile -- on a system with no rubocop it gives the slightly uninformative error:

    rake aborted!
    Command failed with exit 1: which

Fortunately, inspecting the Rakefile gave me this hint: `system("which", "rubocop", exception: true)`