### PR TITLE
feat: improve output when running many TestTask in parallel

### DIFF
--- a/lib/roby/app/rake.rb
+++ b/lib/roby/app/rake.rb
@@ -393,7 +393,7 @@ module Roby
                         end
                         output.join ""
                     rescue Interrupt
-                        Process.kill "TERM", pid
+                        Process.kill "INT", pid
                         Process.waitpid pid
                     end
                 end
@@ -417,7 +417,7 @@ module Roby
                         _, status = Process.waitpid2(pid)
                         status.success?
                     rescue Interrupt
-                        Process.kill "TERM", pid
+                        Process.kill "INT", pid
                         Process.waitpid pid
                     end
                 end
@@ -699,7 +699,7 @@ module Roby
                         end
                         output.join ""
                     rescue Interrupt
-                        Process.kill "TERM", pid
+                        Process.kill "INT", pid
                         Process.waitpid pid
                     end
                 end
@@ -723,7 +723,7 @@ module Roby
                         _, status = Process.waitpid2(pid)
                         status.success?
                     rescue Interrupt
-                        Process.kill "TERM", pid
+                        Process.kill "INT", pid
                         Process.waitpid pid
                     end
                 end


### PR DESCRIPTION
Add two new parameters for rake test task: synchronize output and omit test success. Both parameters require capturing stdout from the process. I also redirected stderr to stdout.

Synchronize output will ensure that all stdout outputs are synchronized, which is useful when using rake multitask option.

Omit test success only print tests that failed, especially useful when running long test suites with lots of stdout output or for CI.