### PR TITLE
fix: force garbage collection on server thread

### DIFF
--- a/test/interface/rest/test_server.rb
+++ b/test/interface/rest/test_server.rb
@@ -53,6 +53,7 @@ module Roby
                         assert_raises(REST::Server::Timeout) do
                             @server.start(wait_timeout: 0.01)
                         end
+                        @server.stop
                     end
                 end
 


### PR DESCRIPTION
We've got a heisenbug that fails on the `after do` block claiming that it timed out waiting for server start. However, the server shouldnt really start, as we are mocking the thread creation, somehow the thread is still alive when it gets to the after do block. The idea is to force garbage collection to run by calling server stop before after do.