### PR TITLE
Revert "fix: run minitest' after blocks at the end of `roby test`"

### DIFF
--- a/lib/roby/app/scripts/test.rb
+++ b/lib/roby/app/scripts/test.rb
@@ -5,12 +5,6 @@ require "roby/test/spec"
 require "roby/test/minitest_plugin"
 require "optparse"
 
-module Minitest
-    def self.run_after_blocks
-        @@after_run.reverse_each(&:call)
-    end
-end
-
 Robot.logger.level = Logger::WARN
 
 app = Roby.app
@@ -182,7 +176,6 @@ exception = Roby.display_exception do
         end
 
     SimpleCov.run_exit_tasks! if defined?(SimpleCov)
-    Minitest.run_after_blocks
     exit(passed ? 0 : 1)
 end
 exit(exception ? 1 : 0)


### PR DESCRIPTION
Reverts rock-core/tools-roby#289

Rubocop is failing and this is the culprit, its not critical so we are reverting and fixing rubocop 