### PR TITLE
fix: add example to task arguments and inject these examples in syskit_deploy_in_bulk

### DIFF
--- a/lib/roby/actions/action.rb
+++ b/lib/roby/actions/action.rb
@@ -51,7 +51,13 @@ module Roby
             # Fill missing required arguments with example arguments when available
             def with_example_arguments
                 new_args = missing_required_arguments.each_with_object({}) do |arg, h|
-                    h[arg.name.to_sym] = arg.example if arg.example_defined?
+                    # If an argument has a default value but it received a delayed
+                    # argument, then use the default value as its example
+                    if !arg.required?
+                        h[arg.name.to_sym] = arg.default
+                    elsif arg.example_defined?
+                        h[arg.name.to_sym] = arg.example
+                    end
                 end
                 with_arguments(**new_args)
             end

--- a/lib/roby/actions/models/action.rb
+++ b/lib/roby/actions/models/action.rb
@@ -5,9 +5,6 @@ module Roby
         module Models
             # Basic description of an action
             class Action
-                VoidClass = Class.new
-                Void = VoidClass.new
-
                 # Structure that stores the information about planning method arguments
                 #
                 # See MethodDescription

--- a/lib/roby/coordination/models/variable.rb
+++ b/lib/roby/coordination/models/variable.rb
@@ -24,6 +24,14 @@ module Roby
                     TaskFromVariable.new(name, task_model)
                 end
 
+                def strong?
+                    true
+                end
+
+                def can_merge?(*)
+                    false
+                end
+
                 def evaluate_delayed_argument(task)
                     throw :no_value
                 end

--- a/lib/roby/interface/v2/protocol.rb
+++ b/lib/roby/interface/v2/protocol.rb
@@ -150,7 +150,7 @@ module Roby
                     )
                     protocol.add_marshaller(Actions::Action, &method(:marshal_action))
                     protocol.add_marshaller(Roby::Task, &method(:marshal_task))
-                    protocol.add_marshaller(Actions::Models::Action::VoidClass) { Void }
+                    protocol.add_marshaller(Roby::VoidClass) { Void }
                     protocol.add_marshaller(::Exception, &method(:marshal_exception))
                     protocol.add_marshaller(
                         Roby::ExecutionException, &method(:marshal_execution_exception)

--- a/lib/roby/models/arguments.rb
+++ b/lib/roby/models/arguments.rb
@@ -68,7 +68,7 @@ module Roby
             # @example defining an example value
             #   argument :maximum_current, example: 42
             def argument(name, default: NO_DEFAULT_ARGUMENT, doc: nil,
-                    example: Void)
+                example: Void)
                 name = name.to_sym
                 unless TaskArguments.delayed_argument?(default)
                     default = DefaultArgument.new(default)

--- a/lib/roby/support.rb
+++ b/lib/roby/support.rb
@@ -204,4 +204,7 @@ module Roby
 
         path if File.executable?(path)
     end
+
+    VoidClass = Class.new
+    Void = VoidClass.new.freeze
 end

--- a/test/actions/test_action.rb
+++ b/test/actions/test_action.rb
@@ -149,7 +149,7 @@ module Roby
                                 .optional_arg("t", "", 20)
                     @interface_m.class_eval { def test_action(*args); end }
                     delayed = Class.new do
-                        def evaluate_delayed_argument(task)
+                        def evaluate_delayed_argument(*)
                             Struct.new(:field).new(10)
                         end
                     end.new

--- a/test/actions/test_action.rb
+++ b/test/actions/test_action.rb
@@ -142,6 +142,21 @@ module Roby
                     refute action1.arguments.key?(:t)
                     assert_equal 20, action2.arguments[:t]
                 end
+
+                it "fills optional arguments that are set with delayed arguments with " \
+                   "their default values" do
+                    @interface_m.describe("test_action")
+                                .optional_arg("t", "", 20)
+                    @interface_m.class_eval { def test_action(*args); end }
+                    delayed = Class.new do
+                        def evaluate_delayed_argument(task)
+                            Struct.new(:field).new(10)
+                        end
+                    end.new
+                    action = @interface_m.test_action(t: delayed)
+                    action.with_example_arguments
+                    assert_equal 20, action.arguments[:t]
+                end
             end
         end
     end

--- a/test/interface/v2/test_channel.rb
+++ b/test/interface/v2/test_channel.rb
@@ -153,7 +153,7 @@ module Roby
                         action_model.name = "action_model"
                         action_model.arguments <<
                             Actions::Models::Action::Argument.new(
-                                "arg", "bla", false, nil, Actions::Models::Action::Void
+                                "arg", "bla", false, nil, Roby::Void
                             )
                         @server.write_packet(action_model)
                         ret = @client.read_packet

--- a/test/models/test_arguments.rb
+++ b/test/models/test_arguments.rb
@@ -55,6 +55,12 @@ module Roby
                 assert_equal "Programmatically",
                              model.find_argument(:test).doc
             end
+
+            it "allows to set an example to required arguments" do
+                # This is a documentation block
+                model.argument :test, example: 42
+                assert_equal 42, model.find_argument(:test).example
+            end
         end
     end
 end


### PR DESCRIPTION
This fixes a bug in the test harness where syskit would be unable to deploy multiple actions together when:
- One of the tasks is a toplevel task that depends on another task
- The second task is one of the deployed together actions

The issue appeared as a failed merge attempt complaining that a Variable doesnt have the strong? method
![image](https://github.com/user-attachments/assets/e3d4c013-c9ff-4bb8-a916-1251674da6cb)

By looking further into it, we realized that this happened because when the toplevel task shares used definitions with the sub task, they would have delayed variable references instead of the example arguments (since we dont resolve the example arguments ourselves). That way, syskit was basically trying to merge "some defined value" and "var:variable_name", which should not be possible. 

The fix to that comes in two parts:
1. Adding the strong? and can_merge? methods to variables in a way that cannot be merged
2. Adding example for task arguments and propagating it in syskit_deploy_in_bulk. This way if the task arguments have an example they would take precedence over the variable.