### PR TITLE
fix: point to roby void class

### DIFF
--- a/lib/roby/actions/models/action.rb
+++ b/lib/roby/actions/models/action.rb
@@ -5,6 +5,9 @@ module Roby
         module Models
             # Basic description of an action
             class Action
+                VoidClass = Roby::VoidClass
+                Void = Roby::Void
+
                 # Structure that stores the information about planning method arguments
                 #
                 # See MethodDescription


### PR DESCRIPTION
Missed directing the VoidClass/Void to reference the roby one that was created.