### PR TITLE
fix: add missing require

### DIFF
--- a/lib/roby/interface/rest/api.rb
+++ b/lib/roby/interface/rest/api.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "roby/interface/rest/helpers"
+
 module Roby
     module Interface
         module REST


### PR DESCRIPTION
In some order of require, Helpers would be resolved to Grape::API::Helpers (that's a mystery to me ... I think maybe something Grape is doing ?) instead of Roby::Interface::REST::Helpers.