### PR TITLE
feat: incremental transitive closure graph

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -1266,7 +1266,6 @@ Metrics/ParameterLists:
     - 'lib/roby/models/task_event.rb'
     - 'lib/roby/queries/transaction_query_result.rb'
     - 'lib/roby/relations/graph.rb'
-    - 'lib/roby/event_structure/precedence.rb'
     - 'lib/roby/relations/models/graph.rb'
     - 'lib/roby/relations/space.rb'
     - 'lib/roby/state/pos.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -1266,6 +1266,7 @@ Metrics/ParameterLists:
     - 'lib/roby/models/task_event.rb'
     - 'lib/roby/queries/transaction_query_result.rb'
     - 'lib/roby/relations/graph.rb'
+    - 'lib/roby/event_structure/precedence.rb'
     - 'lib/roby/relations/models/graph.rb'
     - 'lib/roby/relations/space.rb'
     - 'lib/roby/state/pos.rb'

--- a/lib/roby/event_structure/precedence.rb
+++ b/lib/roby/event_structure/precedence.rb
@@ -1,7 +1,72 @@
 # frozen_string_literal: true
 
+require "roby/relations/incremental_transitive_closure.rb"
+
 module Roby
     module EventStructure
         relation :Precedence, subsets: [CausalLink], noinfo: true
+
+        # Graph class that holds the precedence information
+        class Precedence < Relations::EventRelationGraph
+            attr_reader :incremental_transitive_closure
+
+            def initialize(
+                observer: nil,
+                distribute: self.class.distribute?,
+                dag: self.class.dag?,
+                weak: self.class.weak?,
+                strong: self.class.strong?,
+                copy_on_replace: self.class.copy_on_replace?,
+                noinfo: !self.class.embeds_info?,
+                subsets: Set.new
+            )
+                super(
+                    observer:observer,
+                    distribute:distribute,
+                    dag:dag,
+                    weak:weak,
+                    strong:strong,
+                    copy_on_replace:copy_on_replace,
+                    noinfo:noinfo,
+                    subsets:subsets
+                )
+                @incremental_transitive_closure =
+                    Relations::IncrementalTransitiveClosure.new
+            end
+
+            def add_vertex(object)
+                super(object)
+                @incremental_transitive_closure.added_vertex(object)
+            end
+
+
+            def add_edge(a, b, info)
+                super(a, b, info)
+                @incremental_transitive_closure.added_edge(a, b)
+            end
+
+
+            def remove_edge(source,target)
+                super(source,target)
+                @incremental_transitive_closure.removed_edge(source,target)
+            end
+
+            def remove_vertex(object)
+                super(object)
+                @incremental_transitive_closure.removed_vertex(object)
+            end
+
+            def reachable?(source,target)
+                return true if @incremental_transitive_closure.reachable?(source,target)
+                depth_first_visit(source) do |visited_vertex|
+                    return true if visited_vertex == target
+                    @incremental_transitive_closure.added_vertex(visited_vertex)
+                    adjacent_vertices(visited_vertex).each do |adjecent_vertex|
+                        @incremental_transitive_closure.added_vertex(adjecent_vertex)
+                        @incremental_transitive_closure.added_edge(visited_vertex, adjecent_vertex)
+                    end
+                end
+            end
+        end
     end
 end

--- a/lib/roby/event_structure/precedence.rb
+++ b/lib/roby/event_structure/precedence.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "roby/relations/incremental_transitive_closure.rb"
+require "roby/relations/incremental_transitive_closure"
 
 module Roby
     module EventStructure
@@ -10,7 +10,7 @@ module Roby
         class Precedence < Relations::EventRelationGraph
             attr_reader :incremental_transitive_closure
 
-            def initialize(
+            def initialize( # rubocop:disable Metrics/ParameterLists
                 observer: nil,
                 distribute: self.class.distribute?,
                 dag: self.class.dag?,
@@ -21,22 +21,22 @@ module Roby
                 subsets: Set.new
             )
                 super(
-                    observer:observer,
-                    distribute:distribute,
-                    dag:dag,
-                    weak:weak,
-                    strong:strong,
-                    copy_on_replace:copy_on_replace,
-                    noinfo:noinfo,
-                    subsets:subsets
+                    observer: observer,
+                    distribute: distribute,
+                    dag: dag,
+                    weak: weak,
+                    strong: strong,
+                    copy_on_replace: copy_on_replace,
+                    noinfo: noinfo,
+                    subsets: subsets
                 )
                 @incremental_transitive_closure =
                     Relations::IncrementalTransitiveClosure.new
             end
 
-            def remove_edge(source,target)
-                super(source,target)
-                @incremental_transitive_closure.removed_edge(source,target)
+            def remove_edge(source, target)
+                super(source, target)
+                @incremental_transitive_closure.removed_edge(source, target)
             end
 
             def remove_vertex(object)
@@ -44,8 +44,8 @@ module Roby
                 @incremental_transitive_closure.removed_vertex(object)
             end
 
-            def reachable?(source,target)
-                @incremental_transitive_closure.reachable?(source,target,self)
+            def reachable?(source, target)
+                @incremental_transitive_closure.reachable?(source, target, self)
             end
         end
     end

--- a/lib/roby/event_structure/precedence.rb
+++ b/lib/roby/event_structure/precedence.rb
@@ -34,18 +34,6 @@ module Roby
                     Relations::IncrementalTransitiveClosure.new
             end
 
-            def add_vertex(object)
-                super(object)
-                @incremental_transitive_closure.added_vertex(object)
-            end
-
-
-            def add_edge(a, b, info)
-                super(a, b, info)
-                @incremental_transitive_closure.added_edge(a, b)
-            end
-
-
             def remove_edge(source,target)
                 super(source,target)
                 @incremental_transitive_closure.removed_edge(source,target)
@@ -57,15 +45,7 @@ module Roby
             end
 
             def reachable?(source,target)
-                return true if @incremental_transitive_closure.reachable?(source,target)
-                depth_first_visit(source) do |visited_vertex|
-                    return true if visited_vertex == target
-                    @incremental_transitive_closure.added_vertex(visited_vertex)
-                    adjacent_vertices(visited_vertex).each do |adjecent_vertex|
-                        @incremental_transitive_closure.added_vertex(adjecent_vertex)
-                        @incremental_transitive_closure.added_edge(visited_vertex, adjecent_vertex)
-                    end
-                end
+                @incremental_transitive_closure.reachable?(source,target,self)
             end
         end
     end

--- a/lib/roby/relations/bidirectional_directed_adjacency_graph.rb
+++ b/lib/roby/relations/bidirectional_directed_adjacency_graph.rb
@@ -25,8 +25,8 @@ module Roby
             #      out_neighbours[target] # => info for the source -> target edge
             #
             # @return [Hash<Object,Hash<Object,Object>>]
-
             attr_reader :forward_edges_with_info
+
             # Set of in neighbours for a particular vertex
             #
             # The hash value associated with the in-neighbour is not used. A

--- a/lib/roby/relations/bidirectional_directed_adjacency_graph.rb
+++ b/lib/roby/relations/bidirectional_directed_adjacency_graph.rb
@@ -12,10 +12,34 @@ module Roby
         # that is not in the graph, e.g.
         #
         #     graph.out_neighbours(random_object) -> Set.new
+        #
+        # The class guarantees that there can't be duplicate edges
         class BidirectionalDirectedAdjacencyGraph
             include RGL::MutableGraph
 
-            attr_reader :forward_edges_with_info, :backward_edges
+            # Mapping from a vertex to the association of out neighbours
+            #
+            # That is,
+            #      out_neighbours = forward_edges_with_info[source]
+            #      out_neighbours.keys # => list of out neighbours for 'source'
+            #      out_neighbours[target] # => info for the source -> target edge
+            #
+            # @return [Hash<Object,Hash<Object,Object>>]
+
+            attr_reader :forward_edges_with_info
+            # Set of in neighbours for a particular vertex
+            #
+            # The hash value associated with the in-neighbour is not used. A
+            # hash is used for optimization only
+            #
+            # That is,
+            #      in_neighbours = backward_edges[target]
+            #      in_neighbours.keys # => list of in neighbours for 'target'
+            #      in_neighbours.key?(v) # test if 'v' is a in-neighbour of target
+            #      in_neighbours[v] # => always nil
+            #
+            # @return [Hash<Object,Hash<Object,Object>>]
+            attr_reader :backward_edges
 
             # Shortcut for creating a DirectedAdjacencyGraph:
             #
@@ -516,6 +540,35 @@ module Roby
                 end
 
                 [new, removed, updated]
+            end
+
+            # Incremental update of a transitive closure, adding the from -> to edge
+            def propagate_transitive_closure(from, to)
+                from_in_neighbours = @backward_edges[from]
+                # Adds 'from_in_neighbours' to 'to's in neighbors
+                @backward_edges[to].merge!(from_in_neighbours)
+                @forward_edges_with_info[to].each_key do |v|
+                    # Adds 'from_in_neighbours' to 'to_out_neighbors's in neighbors
+                    @backward_edges[v].merge!(from_in_neighbours)
+
+                    # Adds 'from' to 'to_out_neighbors's in neighbors
+                    v_in = (@backward_edges[v] ||= IdentityHash.new)
+                    @forward_edges_with_info[v] ||= IdentityHash.new
+                    v_in[from] = nil
+                end
+
+                to_out_neighbours = @forward_edges_with_info[to]
+                # Adds 'to_out_neighbors' to 'from's out neighbors
+                @forward_edges_with_info[from].merge!(to_out_neighbours)
+                @backward_edges[from].each_key do |u|
+                    # Adds 'to_out_neighbors' to 'from_in_neighbors's out neighbors
+                    @forward_edges_with_info[u].merge!(to_out_neighbours)
+
+                    # Adds 'to' to 'from_in_neighbors's out neighbors
+                    u_out = (@forward_edges_with_info[u] ||= IdentityHash.new)
+                    @backward_edges[u] ||= IdentityHash.new
+                    u_out[to] = nil
+                end
             end
         end
     end

--- a/lib/roby/relations/incremental_transitive_closure.rb
+++ b/lib/roby/relations/incremental_transitive_closure.rb
@@ -27,8 +27,9 @@ module Roby
             
             # Adds an edge from 'source' to 'target' to the graph
             # It also ensures that transitive reachability is updated by adding edges
-            # from the 'source's parents vertices to 'target'. As well as adding edges
-            # from the from 'source' to 'target's children vertices 
+            # from the 'source's parents vertices to 'target'. Adding edges
+            # from the from 'source' to 'target's children vertices.
+            # As well as adding edges from 'source's parent vertices to 'target's children
             #
             # @param source [Object] The source vertex
             # @param target [Object] The target vertex
@@ -36,8 +37,14 @@ module Roby
                 return if @graph.has_edge?(source, target)
 
                 @graph.add_edge(source, target)
-                add_edges_to_parents(source, target)
-                add_edges_to_children(source, target)
+
+                parents = parent_vertices(source)
+                add_edges_vertices_to_vertex(parents, target)
+
+                children = @graph.adjacent_vertices(target)
+                add_edges_vertex_to_vertices(source, children)
+
+                add_edges_vertices_to_vertices(parents, children)
             end
 
             # Removes a vertex from the graph if it has no adjacent vertices 
@@ -84,16 +91,14 @@ module Roby
                 @graph.has_edge?(source, target)
             end
 
-            # Updates the transitive closure by adding edges from the 'source's parents 
-            # vertices to 'target', thus ensuring that the graph's 
-            # reachability is consistent.
+            # Updates the transitive closure by adding edges from source vertices to a target 
+            # vertex
             #
-            # @param source [Object] The source vertex
             # @param target [Object] The target vertex
-            def add_edges_to_parents(source, target)
-                parents = parent_vertices(source)
-                parents.each do |parent|
-                    @graph.add_edge(parent, target) unless @graph.has_edge?(parent, target)
+            # @param vertices [Array<Object>] An array of source vertices
+            def add_edges_vertices_to_vertex(vertices, target)
+                vertices.each do |vertex|
+                    @graph.add_edge(vertex, target) unless @graph.has_edge?(vertex, target)
                 end
             end
 
@@ -107,16 +112,27 @@ module Roby
                 return @graph.edges.select { |edge| edge.target == vertex }.map(&:source)
             end
 
-            # Updates the transitive closure by adding edges from 'source' to
-            # the 'target's children vertices, thus ensuring that the graph's 
-            # reachability is consistent.
+            # Updates the transitive closure by adding edges from a source vertex to 
+            # target vertices
             #
             # @param source [Object] The source vertex
-            # @param target [Object] The target vertex
-            def add_edges_to_children(source, target)
-                children = @graph.adjacent_vertices(target)
-                children.each do |child|
-                    @graph.add_edge(source, child) unless @graph.has_edge?(source, child)
+            # @param vertices [Array<Object>] An array of target vertices
+            def add_edges_vertex_to_vertices(source, vertices)
+                vertices.each do |vertex|
+                    @graph.add_edge(source, vertex) unless @graph.has_edge?(source, vertex)
+                end
+            end
+
+            # Updates the transitive closure by adding edges from source vertices to target 
+            # vertices
+            #
+            # @param source_vertices [Array<Object>] An array of source vertices
+            # @param target_vertices [Array<Object>] An array of target vertices
+            def add_edges_vertices_to_vertices(source_vertices, target_vertices)
+                source_vertices.each do |source|
+                    target_vertices.each do |target|
+                        @graph.add_edge(source, target) unless @graph.has_edge?(source, target)
+                    end
                 end
             end
         end

--- a/lib/roby/relations/incremental_transitive_closure.rb
+++ b/lib/roby/relations/incremental_transitive_closure.rb
@@ -18,14 +18,11 @@ module Roby
             end
 
             def follow_edge?(source, target)
-                if @tc.graph.has_vertex?(target)
-                    @tc.added_edge(source, target)
-                    false
-                else
-                    @tc.added_vertex(target)
-                    @tc.added_edge(source, target)
-                    super(source, target)
-                end
+                has_vertex = @tc.graph.has_vertex?(target)
+
+                @tc.added_edge(source, target)
+
+                has_vertex ? false : super(source, target)
             end
         end
 
@@ -40,15 +37,6 @@ module Roby
             def initialize
                 @graph =
                     Relations::BidirectionalDirectedAdjacencyGraph.new
-            end
-
-            # Adds a new vertex to the graph if it doesn't already exist
-            #
-            # @param vertex [Object] The vertex to be added
-            def added_vertex(vertex)
-                return if @graph.has_vertex?(vertex)
-
-                @graph.add_vertex(vertex)
             end
 
             # Adds an edge from 'source' to 'target' to the graph
@@ -130,7 +118,6 @@ module Roby
             # @param graph [Graph] The graph to explore during the DFS
             def discover_vertex(source, source_graph)
                 vis = IncrementalTransitiveClosureVisitor.new(source_graph, self)
-                added_vertex(source)
                 source_graph.depth_first_visit(source, vis) {}
             end
         end

--- a/lib/roby/relations/incremental_transitive_closure.rb
+++ b/lib/roby/relations/incremental_transitive_closure.rb
@@ -23,9 +23,19 @@ module Roby
             end
 
             def removed_vertex(vertex)
+                if @graph.adjacent_vertices(vertex).empty?
+                    @graph.remove_vertex(vertex)
+                else
+                    @graph = RGL::DirectedAdjacencyGraph.new
+                end
             end
-            
+
             def removed_edge(from, to)
+                if @graph.adjacent_vertices(to).empty?
+                    @graph.remove_edge(from, to)
+                else
+                    @graph = RGL::DirectedAdjacencyGraph.new
+                end
             end
             
             def reachable?(from, to)

--- a/lib/roby/relations/incremental_transitive_closure.rb
+++ b/lib/roby/relations/incremental_transitive_closure.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'rgl/adjacency'
+require 'rgl/transitivity'
+
+module Roby
+    module Relations
+        class IncrementalTransitiveClosure
+            attr_reader :graph
+
+            def initialize
+                @graph = RGL::DirectedAdjacencyGraph.new
+            end
+        
+            def added_vertex(vertex)
+                return if @graph.has_vertex?(vertex)
+                @graph.add_vertex(vertex)
+            end
+            
+            def added_edge(from, to)
+                @graph.add_edge(from, to)
+                add_edges_to_parents(from, to)
+            end
+
+            def removed_vertex(vertex)
+            end
+            
+            def removed_edge(from, to)
+            end
+            
+            def reachable?(from, to)
+                @graph.has_edge?(from, to)
+            end
+
+            def add_edges_to_parents(from, to)
+                parents = @graph.edges.select { |edge| edge.target == from }.map(&:source)
+                parents.each do |parent|
+                    @graph.add_edge(parent, to) unless @graph.has_edge?(parent, to)
+                end
+            end
+        end
+    end
+end

--- a/lib/roby/relations/incremental_transitive_closure.rb
+++ b/lib/roby/relations/incremental_transitive_closure.rb
@@ -5,24 +5,50 @@ require 'rgl/transitivity'
 
 module Roby
     module Relations
+        # This class represents an incremental transitive closure graph, 
+        # where edges and vertices can be added or removed incrementally, 
+        # while keeping track of reachability information (i.e., transitive closure).
         class IncrementalTransitiveClosure
             attr_reader :graph
 
+            # Initializes an empty directed graph using RGL's DirectedAdjacencyGraph
             def initialize
                 @graph = RGL::DirectedAdjacencyGraph.new
             end
         
+            # Adds a new vertex to the graph if it doesn't already exist
+            #
+            # @param vertex [Object] The vertex to be added
             def added_vertex(vertex)
                 return if @graph.has_vertex?(vertex)
+
                 @graph.add_vertex(vertex)
             end
             
-            def added_edge(from, to)
-                @graph.add_edge(from, to)
-                add_edges_to_parents(from, to)
+            # Adds an edge from 'source' to 'target' to the graph
+            # It also ensures that transitive reachability is updated by adding edges
+            # from the 'source's parents vertices to 'target'. As well as adding edges
+            # from the from 'source' to 'target's children vertices 
+            #
+            # @param source [Object] The source vertex
+            # @param target [Object] The target vertex
+            def added_edge(source, target)
+                return if @graph.has_edge?(source, target)
+
+                @graph.add_edge(source, target)
+                add_edges_to_parents(source, target)
+                add_edges_to_children(source, target)
             end
 
+            # Removes a vertex from the graph if it has no adjacent vertices 
+            # (i.e., no outgoing edges)
+            # If there are adjacent vertices, the entire graph is 
+            # reset (rebuilds the graph)
+            #
+            # @param vertex [Object] The vertex to be removed
             def removed_vertex(vertex)
+                return unless @graph.has_vertex?(vertex)
+
                 if @graph.adjacent_vertices(vertex).empty?
                     @graph.remove_vertex(vertex)
                 else
@@ -30,22 +56,67 @@ module Roby
                 end
             end
 
-            def removed_edge(from, to)
-                if @graph.adjacent_vertices(to).empty?
-                    @graph.remove_edge(from, to)
+            # Removes an edge from the graph. If the target vertex has adjacent vertices,
+            # or the source vertex has parent vertices
+            # the entire graph is reset. Otherwise, it simply removes the edge.
+            #
+            # @param source [Object] The source vertex
+            # @param target [Object] The target vertex
+            def removed_edge(source, target)
+                return unless @graph.has_edge?(source, target)
+
+                if @graph.adjacent_vertices(target).empty? && parent_vertices(source).empty?
+                    @graph.remove_edge(source, target)
                 else
                     @graph = RGL::DirectedAdjacencyGraph.new
                 end
             end
             
-            def reachable?(from, to)
-                @graph.has_edge?(from, to)
+            # Checks if there is a directed edge from 'source' to 'target' 
+            # (i.e., if 'target' is reachable from 'source')
+            #
+            # @param source [Object] The source vertex
+            # @param target [Object] The target vertex
+            #
+            # @return [Boolean] Returns true if there is a direct edge from 'source' 
+            # to 'target', false otherwise
+            def reachable?(source, target)
+                @graph.has_edge?(source, target)
             end
 
-            def add_edges_to_parents(from, to)
-                parents = @graph.edges.select { |edge| edge.target == from }.map(&:source)
+            # Updates the transitive closure by adding edges from the 'source's parents 
+            # vertices to 'target', thus ensuring that the graph's 
+            # reachability is consistent.
+            #
+            # @param source [Object] The source vertex
+            # @param target [Object] The target vertex
+            def add_edges_to_parents(source, target)
+                parents = parent_vertices(source)
                 parents.each do |parent|
-                    @graph.add_edge(parent, to) unless @graph.has_edge?(parent, to)
+                    @graph.add_edge(parent, target) unless @graph.has_edge?(parent, target)
+                end
+            end
+
+            # Return the parent vertices of the provided vertex
+            #
+            # @param from [Object] The source vertex
+            #
+            # @return [Array<Object>] An array of parent vertices (those that point to 
+            # the given vertex).
+            def parent_vertices(vertex)
+                return @graph.edges.select { |edge| edge.target == vertex }.map(&:source)
+            end
+
+            # Updates the transitive closure by adding edges from 'source' to
+            # the 'target's children vertices, thus ensuring that the graph's 
+            # reachability is consistent.
+            #
+            # @param source [Object] The source vertex
+            # @param target [Object] The target vertex
+            def add_edges_to_children(source, target)
+                children = @graph.adjacent_vertices(target)
+                children.each do |child|
+                    @graph.add_edge(source, child) unless @graph.has_edge?(source, child)
                 end
             end
         end

--- a/lib/roby/relations/incremental_transitive_closure.rb
+++ b/lib/roby/relations/incremental_transitive_closure.rb
@@ -129,9 +129,7 @@ module Roby
             # @return [Boolean] Returns true if there is a direct edge from 'source'
             # to 'target', false otherwise
             def reachable?(source, target, source_graph)
-                unless @graph.has_vertex?(source)
-                    discover_vertex(source, target, source_graph)
-                end
+                discover_vertex(source, source_graph) unless @graph.has_vertex?(source)
 
                 @graph.has_edge?(source, target)
             end
@@ -141,15 +139,11 @@ module Roby
             # incrementally.
             #
             # @param source [Object] The source vertex to start the DFS
-            # @param target [Object] The target vertex (DFS will stop once this is
-            # reached)
             # @param graph [Graph] The graph to explore during the DFS
-            def discover_vertex(source, target, source_graph)
+            def discover_vertex(source, source_graph)
                 vis = IncrementalTransitiveClosureVisitor.new(source_graph, self)
                 added_vertex(source)
-                source_graph.depth_first_visit(source, vis) do |visited_vertex|
-                    break if visited_vertex == target
-                end
+                source_graph.depth_first_visit(source, vis) {}
             end
         end
     end

--- a/lib/roby/relations/incremental_transitive_closure.rb
+++ b/lib/roby/relations/incremental_transitive_closure.rb
@@ -65,19 +65,7 @@ module Roby
 
                 @graph.add_edge(source, target)
 
-                @graph.each_out_neighbour(target) do |out_neighbor|
-                    @graph.add_edge(source, out_neighbor)
-                end
-
-                @graph.each_in_neighbour(source) do |in_neighbor|
-                    @graph.add_edge(in_neighbor, target)
-                end
-
-                @graph.each_out_neighbour(target) do |out_neighbor|
-                    @graph.each_in_neighbour(source) do |in_neighbor|
-                        @graph.add_edge(in_neighbor, out_neighbor)
-                    end
-                end
+                @graph.propagate_transitive_closure(source, target)
             end
 
             # Removes a vertex from the graph if it has no adjacent vertices

--- a/lib/roby/relations/incremental_transitive_closure.rb
+++ b/lib/roby/relations/incremental_transitive_closure.rb
@@ -116,7 +116,11 @@ module Roby
             end
 
             # Checks if there is a directed edge from 'source' to 'target'
-            # (i.e., if 'target' is reachable from 'source')
+            # (i.e., if 'target' is reachable from 'source').
+            #
+            # If the incremental transitive closure already has this node discovered,
+            # it will simply test if this edge exists. If not, it will execute a depth
+            # first visit, exploring the nodes and their relations along the way.
             #
             # @param source [Object] The source vertex
             # @param target [Object] The target vertex

--- a/test/relations/test_bidirectional_directed_adjacency_graph.rb
+++ b/test/relations/test_bidirectional_directed_adjacency_graph.rb
@@ -572,6 +572,36 @@ module Roby
                     end
                 end
             end
+
+            describe "propagate transitive closure" do
+                it "propagates 'from in neighbors' to 'to'" do
+                    g = create_graph(1, 2, 3)
+                    g.add_edge(1, 2)
+                    g.add_edge(2, 3)
+
+                    g.propagate_transitive_closure(2, 3)
+                    assert g.has_edge?(1, 3)
+                end
+
+                it "propagates 'from' to 'to out neighbors'" do
+                    g = create_graph(1, 2, 3)
+                    g.add_edge(1, 2)
+                    g.add_edge(2, 3)
+
+                    g.propagate_transitive_closure(1, 2)
+                    assert g.has_edge?(1, 3)
+                end
+
+                it "propagates 'from in neighbors' to 'to out neighbors'" do
+                    g = create_graph(1, 2, 3, 4)
+                    g.add_edge(1, 2)
+                    g.add_edge(2, 3)
+                    g.add_edge(3, 4)
+
+                    g.propagate_transitive_closure(2, 3)
+                    assert g.has_edge?(1, 4)
+                end
+            end
         end
     end
 end

--- a/test/relations/test_incremental_transitive_closure.rb
+++ b/test/relations/test_incremental_transitive_closure.rb
@@ -201,6 +201,25 @@ module Roby
                         refute incremental_transitive_closure.reachable?(2, 1, g)
                     end
 
+                    it "verifies reachability by exploring vertex fully" do
+                        g = Relations::BidirectionalDirectedAdjacencyGraph.new
+
+                        g.add_vertex(0)
+                        g.add_vertex(1)
+                        g.add_vertex(2)
+                        g.add_vertex(3)
+                        g.add_vertex(4)
+                        g.add_vertex(5)
+                        g.add_edge(0, 1)
+                        g.add_edge(1, 2)
+                        g.add_edge(2, 3)
+                        g.add_edge(2, 5)
+                        g.add_edge(3, 4)
+
+                        assert incremental_transitive_closure.reachable?(0, 4, g)
+                        assert incremental_transitive_closure.reachable?(0, 5, g)
+                    end
+
                     it "verifies indirect reachability by exploring graph" do
                         g = Relations::BidirectionalDirectedAdjacencyGraph.new
 

--- a/test/relations/test_incremental_transitive_closure.rb
+++ b/test/relations/test_incremental_transitive_closure.rb
@@ -47,6 +47,49 @@ module Roby
                     refute incremental_transitive_closure.reachable?(2,0)
                   end
                 end
+
+                describe "removing relations" do
+                  it "removes edge" do
+                    incremental_transitive_closure.added_vertex(0)
+                    incremental_transitive_closure.added_vertex(1)
+                    incremental_transitive_closure.added_vertex(2)
+                    incremental_transitive_closure.added_edge(0,1)
+                    incremental_transitive_closure.added_edge(1,2)
+                    incremental_transitive_closure.removed_edge(1,2)
+                    assert_equal(incremental_transitive_closure.graph.num_vertices, 3) 
+                    refute incremental_transitive_closure.graph.has_edge?(1,2)
+                  end
+
+                  it "resets representation if removed edge of node containing children" do
+                    incremental_transitive_closure.added_vertex(0)
+                    incremental_transitive_closure.added_vertex(1)
+                    incremental_transitive_closure.added_vertex(2)
+                    incremental_transitive_closure.added_edge(0,1)
+                    incremental_transitive_closure.added_edge(1,2)
+                    incremental_transitive_closure.removed_edge(0,1)
+                    assert_equal(incremental_transitive_closure.graph.num_vertices, 0) 
+                  end
+
+                  it "removes vertex" do
+                    incremental_transitive_closure.added_vertex(0)
+                    incremental_transitive_closure.added_vertex(1)
+                    incremental_transitive_closure.added_vertex(2)
+                    incremental_transitive_closure.added_edge(0,1)
+                    incremental_transitive_closure.added_edge(1,2)
+                    incremental_transitive_closure.removed_vertex(2)
+                    assert_equal(incremental_transitive_closure.graph.num_vertices, 2) 
+                  end
+
+                  it "resets representation if removed vertex containing children" do
+                    incremental_transitive_closure.added_vertex(0)
+                    incremental_transitive_closure.added_vertex(1)
+                    incremental_transitive_closure.added_vertex(2)
+                    incremental_transitive_closure.added_edge(0,1)
+                    incremental_transitive_closure.added_edge(1,2)
+                    incremental_transitive_closure.removed_vertex(1)
+                    assert_equal(incremental_transitive_closure.graph.num_vertices, 0) 
+                  end
+                end
             end
         end
     end

--- a/test/relations/test_incremental_transitive_closure.rb
+++ b/test/relations/test_incremental_transitive_closure.rb
@@ -41,6 +41,13 @@ module Roby
                     assert incremental_transitive_closure.graph.has_edge?(3,1)
                     assert incremental_transitive_closure.graph.has_edge?(3,2)
                     refute incremental_transitive_closure.graph.has_edge?(3,0)
+
+                    incremental_transitive_closure.added_vertex(4)
+                    incremental_transitive_closure.added_vertex(5)
+                    incremental_transitive_closure.added_edge(4,5)
+                    incremental_transitive_closure.added_edge(2,4)
+                    assert incremental_transitive_closure.graph.has_edge?(2,5)
+                    assert incremental_transitive_closure.graph.has_edge?(1,5)
                   end
 
                   it "tests reachability from direct and indirect vertex" do

--- a/test/relations/test_incremental_transitive_closure.rb
+++ b/test/relations/test_incremental_transitive_closure.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require "roby/test/self"
-require "lib/roby/relations/incremental_transitive_closure.rb"
+require "roby/relations/incremental_transitive_closure.rb"
 
 module Roby
     module Relations

--- a/test/relations/test_incremental_transitive_closure.rb
+++ b/test/relations/test_incremental_transitive_closure.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require "roby/test/self"
+require "lib/roby/relations/incremental_transitive_closure.rb"
+
+module Roby
+    module Relations
+        describe IncrementalTransitiveClosure do
+            describe "#reachable?" do
+                attr_reader :incremental_transitive_closure
+
+                before do
+                    @incremental_transitive_closure = IncrementalTransitiveClosure.new
+                end
+
+                describe "adding relations" do
+                  it "adds vertex" do
+                    incremental_transitive_closure.added_vertex(0)
+                    assert incremental_transitive_closure.graph.has_vertex?(0)
+                  end
+
+                  it "adds edge between vertex" do
+                    incremental_transitive_closure.added_vertex(0)
+                    incremental_transitive_closure.added_vertex(1)
+                    incremental_transitive_closure.added_edge(0,1)
+                    assert incremental_transitive_closure.graph.has_edge?(0,1)
+                  end
+
+                  it "adds indirect edges between vertex" do
+                    incremental_transitive_closure.added_vertex(0)
+                    incremental_transitive_closure.added_vertex(1)
+                    incremental_transitive_closure.added_vertex(2)
+                    incremental_transitive_closure.added_edge(0,1)
+                    incremental_transitive_closure.added_edge(1,2)
+                    assert incremental_transitive_closure.graph.has_edge?(0,2)
+                  end
+
+                  it "tests reachability from direct and indirect vertex" do
+                    incremental_transitive_closure.added_vertex(0)
+                    incremental_transitive_closure.added_vertex(1)
+                    incremental_transitive_closure.added_vertex(2)
+                    incremental_transitive_closure.added_edge(0,1)
+                    incremental_transitive_closure.added_edge(1,2)
+                    assert incremental_transitive_closure.reachable?(0,2)
+                    assert incremental_transitive_closure.reachable?(1,2)
+                    refute incremental_transitive_closure.reachable?(2,1)
+                    refute incremental_transitive_closure.reachable?(2,0)
+                  end
+                end
+            end
+        end
+    end
+end

--- a/test/relations/test_incremental_transitive_closure.rb
+++ b/test/relations/test_incremental_transitive_closure.rb
@@ -15,36 +15,23 @@ module Roby
                 end
 
                 describe "adding relations" do
-                    it "adds vertex" do
-                        incremental_transitive_closure.added_vertex(0)
-                        assert incremental_transitive_closure.graph.has_vertex?(0)
-                    end
-
                     it "adds edge between vertex" do
-                        incremental_transitive_closure.added_vertex(0)
-                        incremental_transitive_closure.added_vertex(1)
                         incremental_transitive_closure.added_edge(0, 1)
                         assert incremental_transitive_closure.graph.has_edge?(0, 1)
                         refute incremental_transitive_closure.graph.has_edge?(1, 0)
                     end
 
                     it "adds indirect edges between vertex" do
-                        incremental_transitive_closure.added_vertex(0)
-                        incremental_transitive_closure.added_vertex(1)
-                        incremental_transitive_closure.added_vertex(2)
                         incremental_transitive_closure.added_edge(0, 1)
                         incremental_transitive_closure.added_edge(1, 2)
                         assert incremental_transitive_closure.graph.has_edge?(0, 2)
                         refute incremental_transitive_closure.graph.has_edge?(2, 0)
 
-                        incremental_transitive_closure.added_vertex(3)
                         incremental_transitive_closure.added_edge(3, 1)
                         assert incremental_transitive_closure.graph.has_edge?(3, 1)
                         assert incremental_transitive_closure.graph.has_edge?(3, 2)
                         refute incremental_transitive_closure.graph.has_edge?(3, 0)
 
-                        incremental_transitive_closure.added_vertex(4)
-                        incremental_transitive_closure.added_vertex(5)
                         incremental_transitive_closure.added_edge(4, 5)
                         incremental_transitive_closure.added_edge(2, 4)
                         assert incremental_transitive_closure.graph.has_edge?(2, 5)
@@ -52,9 +39,6 @@ module Roby
                     end
 
                     it "ignores add edge if both edges are the same" do
-                        incremental_transitive_closure.added_vertex(0)
-                        incremental_transitive_closure.added_vertex(1)
-                        incremental_transitive_closure.added_vertex(2)
                         incremental_transitive_closure.added_edge(0, 1)
                         incremental_transitive_closure.added_edge(1, 2)
                         assert_equal(incremental_transitive_closure.graph.num_edges, 3)
@@ -65,10 +49,6 @@ module Roby
 
                 describe "removing relations" do
                     it "removes edge" do
-                        incremental_transitive_closure.added_vertex(0)
-                        incremental_transitive_closure.added_vertex(1)
-                        incremental_transitive_closure.added_vertex(2)
-                        incremental_transitive_closure.added_vertex(3)
                         incremental_transitive_closure.added_edge(0, 1)
                         incremental_transitive_closure.added_edge(1, 2)
                         incremental_transitive_closure.added_edge(3, 2)
@@ -81,22 +61,16 @@ module Roby
                     end
 
                     it "does nothing if it removes non-existent edge" do
-                        incremental_transitive_closure.added_vertex(0)
-                        incremental_transitive_closure.added_vertex(1)
-                        incremental_transitive_closure.added_vertex(2)
                         incremental_transitive_closure.added_edge(0, 1)
-                        assert_equal(incremental_transitive_closure.graph.num_vertices, 3)
+                        assert_equal(incremental_transitive_closure.graph.num_vertices, 2)
                         assert_equal(incremental_transitive_closure.graph.num_edges, 1)
                         incremental_transitive_closure.removed_edge(1, 2)
-                        assert_equal(incremental_transitive_closure.graph.num_vertices, 3)
+                        assert_equal(incremental_transitive_closure.graph.num_vertices, 2)
                         assert_equal(incremental_transitive_closure.graph.num_edges, 1)
                     end
 
                     it "resets representation if removed edge of target vertex"\
                        "containing children" do
-                        incremental_transitive_closure.added_vertex(0)
-                        incremental_transitive_closure.added_vertex(1)
-                        incremental_transitive_closure.added_vertex(2)
                         incremental_transitive_closure.added_edge(0, 1)
                         incremental_transitive_closure.added_edge(1, 2)
                         incremental_transitive_closure.removed_edge(0, 1)
@@ -106,9 +80,6 @@ module Roby
 
                     it "resets representation if removed edge of source vertex "\
                        "containing parents" do
-                        incremental_transitive_closure.added_vertex(0)
-                        incremental_transitive_closure.added_vertex(1)
-                        incremental_transitive_closure.added_vertex(2)
                         incremental_transitive_closure.added_edge(0, 1)
                         incremental_transitive_closure.added_edge(1, 2)
                         incremental_transitive_closure.removed_edge(1, 2)
@@ -117,11 +88,9 @@ module Roby
                     end
 
                     it "removes vertex" do
-                        incremental_transitive_closure.added_vertex(0)
-                        incremental_transitive_closure.added_vertex(1)
-                        incremental_transitive_closure.added_vertex(2)
                         incremental_transitive_closure.added_edge(0, 1)
                         incremental_transitive_closure.added_edge(1, 2)
+                        assert_equal(incremental_transitive_closure.graph.num_vertices, 3)
                         assert_equal(incremental_transitive_closure.graph.num_edges, 3)
                         incremental_transitive_closure.removed_vertex(2)
                         assert_equal(incremental_transitive_closure.graph.num_vertices, 2)
@@ -129,21 +98,15 @@ module Roby
                     end
 
                     it "does nothing if it removes inexistent vertex" do
-                        incremental_transitive_closure.added_vertex(0)
-                        incremental_transitive_closure.added_vertex(1)
-                        incremental_transitive_closure.added_vertex(2)
                         incremental_transitive_closure.added_edge(0, 1)
-                        assert_equal(incremental_transitive_closure.graph.num_vertices, 3)
+                        assert_equal(incremental_transitive_closure.graph.num_vertices, 2)
                         assert_equal(incremental_transitive_closure.graph.num_edges, 1)
                         incremental_transitive_closure.removed_vertex(3)
-                        assert_equal(incremental_transitive_closure.graph.num_vertices, 3)
+                        assert_equal(incremental_transitive_closure.graph.num_vertices, 2)
                         assert_equal(incremental_transitive_closure.graph.num_edges, 1)
                     end
 
                     it "resets representation if removed vertex containing children" do
-                        incremental_transitive_closure.added_vertex(0)
-                        incremental_transitive_closure.added_vertex(1)
-                        incremental_transitive_closure.added_vertex(2)
                         incremental_transitive_closure.added_edge(0, 1)
                         incremental_transitive_closure.added_edge(1, 2)
                         assert_equal(incremental_transitive_closure.graph.num_edges, 3)
@@ -152,23 +115,20 @@ module Roby
                         assert_equal(incremental_transitive_closure.graph.num_edges, 0)
                     end
                 end
+
                 describe "reachability tests" do
                     it "verifies reachability of cached graph" do
                         g = Relations::BidirectionalDirectedAdjacencyGraph.new
 
                         g.add_vertex(0)
-                        incremental_transitive_closure.added_vertex(0)
                         g.add_vertex(1)
-                        incremental_transitive_closure.added_vertex(1)
                         g.add_vertex(2)
-                        incremental_transitive_closure.added_vertex(2)
                         g.add_edge(0, 1)
                         incremental_transitive_closure.added_edge(0, 1)
                         g.add_edge(1, 2)
                         incremental_transitive_closure.added_edge(1, 2)
 
                         g.add_vertex(3)
-                        incremental_transitive_closure.added_vertex(3)
                         g.add_edge(3, 1)
                         incremental_transitive_closure.added_edge(3, 1)
 

--- a/test/relations/test_incremental_transitive_closure.rb
+++ b/test/relations/test_incremental_transitive_closure.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require "roby/test/self"
-require "roby/relations/incremental_transitive_closure.rb"
+require "roby/relations/incremental_transitive_closure"
 require "rgl/mutable"
 
 module Roby
@@ -15,208 +15,210 @@ module Roby
                 end
 
                 describe "adding relations" do
-                  it "adds vertex" do
-                    incremental_transitive_closure.added_vertex(0)
-                    assert incremental_transitive_closure.graph.has_vertex?(0)
-                  end
+                    it "adds vertex" do
+                        incremental_transitive_closure.added_vertex(0)
+                        assert incremental_transitive_closure.graph.has_vertex?(0)
+                    end
 
-                  it "adds edge between vertex" do
-                    incremental_transitive_closure.added_vertex(0)
-                    incremental_transitive_closure.added_vertex(1)
-                    incremental_transitive_closure.added_edge(0,1)
-                    assert incremental_transitive_closure.graph.has_edge?(0,1)
-                    refute incremental_transitive_closure.graph.has_edge?(1,0)
-                  end
+                    it "adds edge between vertex" do
+                        incremental_transitive_closure.added_vertex(0)
+                        incremental_transitive_closure.added_vertex(1)
+                        incremental_transitive_closure.added_edge(0, 1)
+                        assert incremental_transitive_closure.graph.has_edge?(0, 1)
+                        refute incremental_transitive_closure.graph.has_edge?(1, 0)
+                    end
 
-                  it "adds indirect edges between vertex" do
-                    incremental_transitive_closure.added_vertex(0)
-                    incremental_transitive_closure.added_vertex(1)
-                    incremental_transitive_closure.added_vertex(2)
-                    incremental_transitive_closure.added_edge(0,1)
-                    incremental_transitive_closure.added_edge(1,2)
-                    assert incremental_transitive_closure.graph.has_edge?(0,2)
-                    refute incremental_transitive_closure.graph.has_edge?(2,0)
+                    it "adds indirect edges between vertex" do
+                        incremental_transitive_closure.added_vertex(0)
+                        incremental_transitive_closure.added_vertex(1)
+                        incremental_transitive_closure.added_vertex(2)
+                        incremental_transitive_closure.added_edge(0, 1)
+                        incremental_transitive_closure.added_edge(1, 2)
+                        assert incremental_transitive_closure.graph.has_edge?(0, 2)
+                        refute incremental_transitive_closure.graph.has_edge?(2, 0)
 
-                    incremental_transitive_closure.added_vertex(3)
-                    incremental_transitive_closure.added_edge(3,1)
-                    assert incremental_transitive_closure.graph.has_edge?(3,1)
-                    assert incremental_transitive_closure.graph.has_edge?(3,2)
-                    refute incremental_transitive_closure.graph.has_edge?(3,0)
+                        incremental_transitive_closure.added_vertex(3)
+                        incremental_transitive_closure.added_edge(3, 1)
+                        assert incremental_transitive_closure.graph.has_edge?(3, 1)
+                        assert incremental_transitive_closure.graph.has_edge?(3, 2)
+                        refute incremental_transitive_closure.graph.has_edge?(3, 0)
 
-                    incremental_transitive_closure.added_vertex(4)
-                    incremental_transitive_closure.added_vertex(5)
-                    incremental_transitive_closure.added_edge(4,5)
-                    incremental_transitive_closure.added_edge(2,4)
-                    assert incremental_transitive_closure.graph.has_edge?(2,5)
-                    assert incremental_transitive_closure.graph.has_edge?(1,5)
-                  end
+                        incremental_transitive_closure.added_vertex(4)
+                        incremental_transitive_closure.added_vertex(5)
+                        incremental_transitive_closure.added_edge(4, 5)
+                        incremental_transitive_closure.added_edge(2, 4)
+                        assert incremental_transitive_closure.graph.has_edge?(2, 5)
+                        assert incremental_transitive_closure.graph.has_edge?(1, 5)
+                    end
 
-                  it "ignores add edge if both edges are the same" do
-                    incremental_transitive_closure.added_vertex(0)
-                    incremental_transitive_closure.added_vertex(1)
-                    incremental_transitive_closure.added_vertex(2)
-                    incremental_transitive_closure.added_edge(0,1)
-                    incremental_transitive_closure.added_edge(1,2)
-                    assert_equal(incremental_transitive_closure.graph.num_edges, 3)
-                    incremental_transitive_closure.added_edge(2,2)
-                    assert_equal(incremental_transitive_closure.graph.num_edges, 3)
-                  end
+                    it "ignores add edge if both edges are the same" do
+                        incremental_transitive_closure.added_vertex(0)
+                        incremental_transitive_closure.added_vertex(1)
+                        incremental_transitive_closure.added_vertex(2)
+                        incremental_transitive_closure.added_edge(0, 1)
+                        incremental_transitive_closure.added_edge(1, 2)
+                        assert_equal(incremental_transitive_closure.graph.num_edges, 3)
+                        incremental_transitive_closure.added_edge(2, 2)
+                        assert_equal(incremental_transitive_closure.graph.num_edges, 3)
+                    end
                 end
 
                 describe "removing relations" do
-                  it "removes edge" do
-                    incremental_transitive_closure.added_vertex(0)
-                    incremental_transitive_closure.added_vertex(1)
-                    incremental_transitive_closure.added_vertex(2)
-                    incremental_transitive_closure.added_vertex(3)
-                    incremental_transitive_closure.added_edge(0,1)
-                    incremental_transitive_closure.added_edge(1,2)
-                    incremental_transitive_closure.added_edge(3,2)
-                    assert_equal(incremental_transitive_closure.graph.num_edges, 4)
-                    assert incremental_transitive_closure.graph.has_edge?(3,2)
-                    incremental_transitive_closure.removed_edge(3,2)
-                    assert_equal(incremental_transitive_closure.graph.num_vertices, 4)
-                    assert_equal(incremental_transitive_closure.graph.num_edges, 3) 
-                    refute incremental_transitive_closure.graph.has_edge?(3,2)
-                  end
+                    it "removes edge" do
+                        incremental_transitive_closure.added_vertex(0)
+                        incremental_transitive_closure.added_vertex(1)
+                        incremental_transitive_closure.added_vertex(2)
+                        incremental_transitive_closure.added_vertex(3)
+                        incremental_transitive_closure.added_edge(0, 1)
+                        incremental_transitive_closure.added_edge(1, 2)
+                        incremental_transitive_closure.added_edge(3, 2)
+                        assert_equal(incremental_transitive_closure.graph.num_edges, 4)
+                        assert incremental_transitive_closure.graph.has_edge?(3, 2)
+                        incremental_transitive_closure.removed_edge(3, 2)
+                        assert_equal(incremental_transitive_closure.graph.num_vertices, 4)
+                        assert_equal(incremental_transitive_closure.graph.num_edges, 3)
+                        refute incremental_transitive_closure.graph.has_edge?(3, 2)
+                    end
 
-                  it "does nothing if it removes non-existent edge" do
-                    incremental_transitive_closure.added_vertex(0)
-                    incremental_transitive_closure.added_vertex(1)
-                    incremental_transitive_closure.added_vertex(2)
-                    incremental_transitive_closure.added_edge(0,1)
-                    assert_equal(incremental_transitive_closure.graph.num_vertices, 3) 
-                    assert_equal(incremental_transitive_closure.graph.num_edges, 1)
-                    incremental_transitive_closure.removed_edge(1,2)
-                    assert_equal(incremental_transitive_closure.graph.num_vertices, 3) 
-                    assert_equal(incremental_transitive_closure.graph.num_edges, 1)
-                  end
+                    it "does nothing if it removes non-existent edge" do
+                        incremental_transitive_closure.added_vertex(0)
+                        incremental_transitive_closure.added_vertex(1)
+                        incremental_transitive_closure.added_vertex(2)
+                        incremental_transitive_closure.added_edge(0, 1)
+                        assert_equal(incremental_transitive_closure.graph.num_vertices, 3)
+                        assert_equal(incremental_transitive_closure.graph.num_edges, 1)
+                        incremental_transitive_closure.removed_edge(1, 2)
+                        assert_equal(incremental_transitive_closure.graph.num_vertices, 3)
+                        assert_equal(incremental_transitive_closure.graph.num_edges, 1)
+                    end
 
-                  it "resets representation if removed edge of target vertex containing children" do
-                    incremental_transitive_closure.added_vertex(0)
-                    incremental_transitive_closure.added_vertex(1)
-                    incremental_transitive_closure.added_vertex(2)
-                    incremental_transitive_closure.added_edge(0,1)
-                    incremental_transitive_closure.added_edge(1,2)
-                    incremental_transitive_closure.removed_edge(0,1)
-                    assert_equal(incremental_transitive_closure.graph.num_vertices, 0)
-                    assert_equal(incremental_transitive_closure.graph.num_edges, 0)
-                  end
+                    it "resets representation if removed edge of target vertex"\
+                       "containing children" do
+                        incremental_transitive_closure.added_vertex(0)
+                        incremental_transitive_closure.added_vertex(1)
+                        incremental_transitive_closure.added_vertex(2)
+                        incremental_transitive_closure.added_edge(0, 1)
+                        incremental_transitive_closure.added_edge(1, 2)
+                        incremental_transitive_closure.removed_edge(0, 1)
+                        assert_equal(incremental_transitive_closure.graph.num_vertices, 0)
+                        assert_equal(incremental_transitive_closure.graph.num_edges, 0)
+                    end
 
-                  it "resets representation if removed edge of source vertex containing parents" do
-                    incremental_transitive_closure.added_vertex(0)
-                    incremental_transitive_closure.added_vertex(1)
-                    incremental_transitive_closure.added_vertex(2)
-                    incremental_transitive_closure.added_edge(0,1)
-                    incremental_transitive_closure.added_edge(1,2)
-                    incremental_transitive_closure.removed_edge(1,2)
-                    assert_equal(incremental_transitive_closure.graph.num_vertices, 0)
-                    assert_equal(incremental_transitive_closure.graph.num_edges, 0)
-                  end
+                    it "resets representation if removed edge of source vertex "\
+                       "containing parents" do
+                        incremental_transitive_closure.added_vertex(0)
+                        incremental_transitive_closure.added_vertex(1)
+                        incremental_transitive_closure.added_vertex(2)
+                        incremental_transitive_closure.added_edge(0, 1)
+                        incremental_transitive_closure.added_edge(1, 2)
+                        incremental_transitive_closure.removed_edge(1, 2)
+                        assert_equal(incremental_transitive_closure.graph.num_vertices, 0)
+                        assert_equal(incremental_transitive_closure.graph.num_edges, 0)
+                    end
 
-                  it "removes vertex" do
-                    incremental_transitive_closure.added_vertex(0)
-                    incremental_transitive_closure.added_vertex(1)
-                    incremental_transitive_closure.added_vertex(2)
-                    incremental_transitive_closure.added_edge(0,1)
-                    incremental_transitive_closure.added_edge(1,2)
-                    assert_equal(incremental_transitive_closure.graph.num_edges, 3) 
-                    incremental_transitive_closure.removed_vertex(2)
-                    assert_equal(incremental_transitive_closure.graph.num_vertices, 2)
-                    assert_equal(incremental_transitive_closure.graph.num_edges, 1)
-                  end
+                    it "removes vertex" do
+                        incremental_transitive_closure.added_vertex(0)
+                        incremental_transitive_closure.added_vertex(1)
+                        incremental_transitive_closure.added_vertex(2)
+                        incremental_transitive_closure.added_edge(0, 1)
+                        incremental_transitive_closure.added_edge(1, 2)
+                        assert_equal(incremental_transitive_closure.graph.num_edges, 3)
+                        incremental_transitive_closure.removed_vertex(2)
+                        assert_equal(incremental_transitive_closure.graph.num_vertices, 2)
+                        assert_equal(incremental_transitive_closure.graph.num_edges, 1)
+                    end
 
-                  it "does nothing if it removes inexistent vertex" do
-                    incremental_transitive_closure.added_vertex(0)
-                    incremental_transitive_closure.added_vertex(1)
-                    incremental_transitive_closure.added_vertex(2)
-                    incremental_transitive_closure.added_edge(0,1)
-                    assert_equal(incremental_transitive_closure.graph.num_vertices, 3) 
-                    assert_equal(incremental_transitive_closure.graph.num_edges, 1)
-                    incremental_transitive_closure.removed_vertex(3)
-                    assert_equal(incremental_transitive_closure.graph.num_vertices, 3) 
-                    assert_equal(incremental_transitive_closure.graph.num_edges, 1)
-                  end
+                    it "does nothing if it removes inexistent vertex" do
+                        incremental_transitive_closure.added_vertex(0)
+                        incremental_transitive_closure.added_vertex(1)
+                        incremental_transitive_closure.added_vertex(2)
+                        incremental_transitive_closure.added_edge(0, 1)
+                        assert_equal(incremental_transitive_closure.graph.num_vertices, 3)
+                        assert_equal(incremental_transitive_closure.graph.num_edges, 1)
+                        incremental_transitive_closure.removed_vertex(3)
+                        assert_equal(incremental_transitive_closure.graph.num_vertices, 3)
+                        assert_equal(incremental_transitive_closure.graph.num_edges, 1)
+                    end
 
-                  it "resets representation if removed vertex containing children" do
-                    incremental_transitive_closure.added_vertex(0)
-                    incremental_transitive_closure.added_vertex(1)
-                    incremental_transitive_closure.added_vertex(2)
-                    incremental_transitive_closure.added_edge(0,1)
-                    incremental_transitive_closure.added_edge(1,2)
-                    assert_equal(incremental_transitive_closure.graph.num_edges, 3) 
-                    incremental_transitive_closure.removed_vertex(1)
-                    assert_equal(incremental_transitive_closure.graph.num_vertices, 0)
-                    assert_equal(incremental_transitive_closure.graph.num_edges, 0)
-                  end
+                    it "resets representation if removed vertex containing children" do
+                        incremental_transitive_closure.added_vertex(0)
+                        incremental_transitive_closure.added_vertex(1)
+                        incremental_transitive_closure.added_vertex(2)
+                        incremental_transitive_closure.added_edge(0, 1)
+                        incremental_transitive_closure.added_edge(1, 2)
+                        assert_equal(incremental_transitive_closure.graph.num_edges, 3)
+                        incremental_transitive_closure.removed_vertex(1)
+                        assert_equal(incremental_transitive_closure.graph.num_vertices, 0)
+                        assert_equal(incremental_transitive_closure.graph.num_edges, 0)
+                    end
                 end
-                describe "reachability A" do
-                  it "tests reachability of cached graph" do
-                    g = Relations::BidirectionalDirectedAdjacencyGraph.new
-                    
-                    g.add_vertex(0)
-                    incremental_transitive_closure.added_vertex(0)
-                    g.add_vertex(1)
-                    incremental_transitive_closure.added_vertex(1)
-                    g.add_vertex(2)
-                    incremental_transitive_closure.added_vertex(2)
-                    g.add_edge(0,1)
-                    incremental_transitive_closure.added_edge(0,1)
-                    g.add_edge(1,2)
-                    incremental_transitive_closure.added_edge(1,2)
+                describe "reachability tests" do
+                    it "verifies reachability of cached graph" do
+                        g = Relations::BidirectionalDirectedAdjacencyGraph.new
 
-                    g.add_vertex(3)
-                    incremental_transitive_closure.added_vertex(3)
-                    g.add_edge(3,1)
-                    incremental_transitive_closure.added_edge(3,1)
+                        g.add_vertex(0)
+                        incremental_transitive_closure.added_vertex(0)
+                        g.add_vertex(1)
+                        incremental_transitive_closure.added_vertex(1)
+                        g.add_vertex(2)
+                        incremental_transitive_closure.added_vertex(2)
+                        g.add_edge(0, 1)
+                        incremental_transitive_closure.added_edge(0, 1)
+                        g.add_edge(1, 2)
+                        incremental_transitive_closure.added_edge(1, 2)
 
-                    assert_equal(incremental_transitive_closure.graph.num_vertices, 4)
-                    assert incremental_transitive_closure.reachable?(0,2,g)
-                    assert incremental_transitive_closure.reachable?(1,2,g)
-                    assert incremental_transitive_closure.reachable?(3,2,g)
-                    refute incremental_transitive_closure.reachable?(2,1,g)
-                    refute incremental_transitive_closure.reachable?(2,0,g)
-                    refute incremental_transitive_closure.reachable?(2,0,g)
-                    refute incremental_transitive_closure.reachable?(0,3,g)
-                  end
+                        g.add_vertex(3)
+                        incremental_transitive_closure.added_vertex(3)
+                        g.add_edge(3, 1)
+                        incremental_transitive_closure.added_edge(3, 1)
 
-                  it "tests direct reachability by exploring graph" do
-                    g = Relations::BidirectionalDirectedAdjacencyGraph.new
-                    
-                    g.add_vertex(0)
-                    g.add_vertex(1)
-                    g.add_vertex(2)
-                    g.add_edge(0,1)
-                    g.add_edge(1,2)
-                    g.add_vertex(3)
-                    g.add_edge(3,1)
+                        assert_equal(incremental_transitive_closure.graph.num_vertices, 4)
+                        assert incremental_transitive_closure.reachable?(0, 2, g)
+                        assert incremental_transitive_closure.reachable?(1, 2, g)
+                        assert incremental_transitive_closure.reachable?(3, 2, g)
+                        refute incremental_transitive_closure.reachable?(2, 1, g)
+                        refute incremental_transitive_closure.reachable?(2, 0, g)
+                        refute incremental_transitive_closure.reachable?(2, 0, g)
+                        refute incremental_transitive_closure.reachable?(0, 3, g)
+                    end
 
-                    assert_equal(incremental_transitive_closure.graph.num_vertices, 0)
-                    assert incremental_transitive_closure.reachable?(0,1,g)
-                    assert_equal(incremental_transitive_closure.graph.num_vertices, 3)
-                    assert incremental_transitive_closure.reachable?(3,1,g)
-                    assert_equal(incremental_transitive_closure.graph.num_vertices, 4)
-                    refute incremental_transitive_closure.reachable?(2,1,g)
-                  end
+                    it "verifies direct reachability by exploring graph" do
+                        g = Relations::BidirectionalDirectedAdjacencyGraph.new
 
-                  it "tests indirect reachability by exploring graph" do
-                    g = Relations::BidirectionalDirectedAdjacencyGraph.new
-                    
-                    g.add_vertex(0)
-                    g.add_vertex(1)
-                    g.add_vertex(2)
-                    g.add_edge(0,1)
-                    g.add_edge(1,2)
-                    g.add_vertex(3)
-                    g.add_edge(3,1)
+                        g.add_vertex(0)
+                        g.add_vertex(1)
+                        g.add_vertex(2)
+                        g.add_edge(0, 1)
+                        g.add_edge(1, 2)
+                        g.add_vertex(3)
+                        g.add_edge(3, 1)
 
-                    assert_equal(incremental_transitive_closure.graph.num_vertices, 0)
-                    assert incremental_transitive_closure.reachable?(0,2,g)
-                    assert_equal(incremental_transitive_closure.graph.num_vertices, 3)
-                    assert incremental_transitive_closure.reachable?(3,2,g)
-                    assert_equal(incremental_transitive_closure.graph.num_vertices, 4)
-                    refute incremental_transitive_closure.reachable?(2,0,g)
-                  end
+                        assert_equal(incremental_transitive_closure.graph.num_vertices, 0)
+                        assert incremental_transitive_closure.reachable?(0, 1, g)
+                        assert_equal(incremental_transitive_closure.graph.num_vertices, 3)
+                        assert incremental_transitive_closure.reachable?(3, 1, g)
+                        assert_equal(incremental_transitive_closure.graph.num_vertices, 4)
+                        refute incremental_transitive_closure.reachable?(2, 1, g)
+                    end
+
+                    it "verifies indirect reachability by exploring graph" do
+                        g = Relations::BidirectionalDirectedAdjacencyGraph.new
+
+                        g.add_vertex(0)
+                        g.add_vertex(1)
+                        g.add_vertex(2)
+                        g.add_edge(0, 1)
+                        g.add_edge(1, 2)
+                        g.add_vertex(3)
+                        g.add_edge(3, 1)
+
+                        assert_equal(incremental_transitive_closure.graph.num_vertices, 0)
+                        assert incremental_transitive_closure.reachable?(0, 2, g)
+                        assert_equal(incremental_transitive_closure.graph.num_vertices, 3)
+                        assert incremental_transitive_closure.reachable?(3, 2, g)
+                        assert_equal(incremental_transitive_closure.graph.num_vertices, 4)
+                        refute incremental_transitive_closure.reachable?(2, 0, g)
+                    end
                 end
             end
         end

--- a/test/relations/test_incremental_transitive_closure.rb
+++ b/test/relations/test_incremental_transitive_closure.rb
@@ -24,6 +24,7 @@ module Roby
                     incremental_transitive_closure.added_vertex(1)
                     incremental_transitive_closure.added_edge(0,1)
                     assert incremental_transitive_closure.graph.has_edge?(0,1)
+                    refute incremental_transitive_closure.graph.has_edge?(1,0)
                   end
 
                   it "adds indirect edges between vertex" do
@@ -33,6 +34,13 @@ module Roby
                     incremental_transitive_closure.added_edge(0,1)
                     incremental_transitive_closure.added_edge(1,2)
                     assert incremental_transitive_closure.graph.has_edge?(0,2)
+                    refute incremental_transitive_closure.graph.has_edge?(2,0)
+
+                    incremental_transitive_closure.added_vertex(3)
+                    incremental_transitive_closure.added_edge(3,1)
+                    assert incremental_transitive_closure.graph.has_edge?(3,1)
+                    assert incremental_transitive_closure.graph.has_edge?(3,2)
+                    refute incremental_transitive_closure.graph.has_edge?(3,0)
                   end
 
                   it "tests reachability from direct and indirect vertex" do
@@ -41,10 +49,15 @@ module Roby
                     incremental_transitive_closure.added_vertex(2)
                     incremental_transitive_closure.added_edge(0,1)
                     incremental_transitive_closure.added_edge(1,2)
+                    incremental_transitive_closure.added_vertex(3)
+                    incremental_transitive_closure.added_edge(3,1)
                     assert incremental_transitive_closure.reachable?(0,2)
                     assert incremental_transitive_closure.reachable?(1,2)
+                    assert incremental_transitive_closure.reachable?(3,2)
                     refute incremental_transitive_closure.reachable?(2,1)
                     refute incremental_transitive_closure.reachable?(2,0)
+                    refute incremental_transitive_closure.reachable?(2,0)
+                    refute incremental_transitive_closure.reachable?(0,3)
                   end
                 end
 
@@ -53,21 +66,50 @@ module Roby
                     incremental_transitive_closure.added_vertex(0)
                     incremental_transitive_closure.added_vertex(1)
                     incremental_transitive_closure.added_vertex(2)
+                    incremental_transitive_closure.added_vertex(3)
                     incremental_transitive_closure.added_edge(0,1)
                     incremental_transitive_closure.added_edge(1,2)
-                    incremental_transitive_closure.removed_edge(1,2)
-                    assert_equal(incremental_transitive_closure.graph.num_vertices, 3) 
-                    refute incremental_transitive_closure.graph.has_edge?(1,2)
+                    incremental_transitive_closure.added_edge(3,2)
+                    assert_equal(incremental_transitive_closure.graph.num_edges, 4)
+                    assert incremental_transitive_closure.graph.has_edge?(3,2)
+                    incremental_transitive_closure.removed_edge(3,2)
+                    assert_equal(incremental_transitive_closure.graph.num_vertices, 4)
+                    assert_equal(incremental_transitive_closure.graph.num_edges, 3) 
+                    refute incremental_transitive_closure.graph.has_edge?(3,2)
                   end
 
-                  it "resets representation if removed edge of node containing children" do
+                  it "does nothing if it removes non-existent edge" do
+                    incremental_transitive_closure.added_vertex(0)
+                    incremental_transitive_closure.added_vertex(1)
+                    incremental_transitive_closure.added_vertex(2)
+                    incremental_transitive_closure.added_edge(0,1)
+                    assert_equal(incremental_transitive_closure.graph.num_vertices, 3) 
+                    assert_equal(incremental_transitive_closure.graph.num_edges, 1)
+                    incremental_transitive_closure.removed_edge(1,2)
+                    assert_equal(incremental_transitive_closure.graph.num_vertices, 3) 
+                    assert_equal(incremental_transitive_closure.graph.num_edges, 1)
+                  end
+
+                  it "resets representation if removed edge of target vertex containing children" do
                     incremental_transitive_closure.added_vertex(0)
                     incremental_transitive_closure.added_vertex(1)
                     incremental_transitive_closure.added_vertex(2)
                     incremental_transitive_closure.added_edge(0,1)
                     incremental_transitive_closure.added_edge(1,2)
                     incremental_transitive_closure.removed_edge(0,1)
-                    assert_equal(incremental_transitive_closure.graph.num_vertices, 0) 
+                    assert_equal(incremental_transitive_closure.graph.num_vertices, 0)
+                    assert_equal(incremental_transitive_closure.graph.num_edges, 0)
+                  end
+
+                  it "resets representation if removed edge of source vertex containing parents" do
+                    incremental_transitive_closure.added_vertex(0)
+                    incremental_transitive_closure.added_vertex(1)
+                    incremental_transitive_closure.added_vertex(2)
+                    incremental_transitive_closure.added_edge(0,1)
+                    incremental_transitive_closure.added_edge(1,2)
+                    incremental_transitive_closure.removed_edge(1,2)
+                    assert_equal(incremental_transitive_closure.graph.num_vertices, 0)
+                    assert_equal(incremental_transitive_closure.graph.num_edges, 0)
                   end
 
                   it "removes vertex" do
@@ -76,8 +118,22 @@ module Roby
                     incremental_transitive_closure.added_vertex(2)
                     incremental_transitive_closure.added_edge(0,1)
                     incremental_transitive_closure.added_edge(1,2)
+                    assert_equal(incremental_transitive_closure.graph.num_edges, 3) 
                     incremental_transitive_closure.removed_vertex(2)
-                    assert_equal(incremental_transitive_closure.graph.num_vertices, 2) 
+                    assert_equal(incremental_transitive_closure.graph.num_vertices, 2)
+                    assert_equal(incremental_transitive_closure.graph.num_edges, 1)
+                  end
+
+                  it "does nothing if it removes inexistent vertex" do
+                    incremental_transitive_closure.added_vertex(0)
+                    incremental_transitive_closure.added_vertex(1)
+                    incremental_transitive_closure.added_vertex(2)
+                    incremental_transitive_closure.added_edge(0,1)
+                    assert_equal(incremental_transitive_closure.graph.num_vertices, 3) 
+                    assert_equal(incremental_transitive_closure.graph.num_edges, 1)
+                    incremental_transitive_closure.removed_vertex(3)
+                    assert_equal(incremental_transitive_closure.graph.num_vertices, 3) 
+                    assert_equal(incremental_transitive_closure.graph.num_edges, 1)
                   end
 
                   it "resets representation if removed vertex containing children" do
@@ -86,8 +142,10 @@ module Roby
                     incremental_transitive_closure.added_vertex(2)
                     incremental_transitive_closure.added_edge(0,1)
                     incremental_transitive_closure.added_edge(1,2)
+                    assert_equal(incremental_transitive_closure.graph.num_edges, 3) 
                     incremental_transitive_closure.removed_vertex(1)
-                    assert_equal(incremental_transitive_closure.graph.num_vertices, 0) 
+                    assert_equal(incremental_transitive_closure.graph.num_vertices, 0)
+                    assert_equal(incremental_transitive_closure.graph.num_edges, 0)
                   end
                 end
             end

--- a/test/suite_relations.rb
+++ b/test/suite_relations.rb
@@ -3,6 +3,7 @@
 require "roby/test/self"
 require "./test/relations/test_space"
 require "./test/relations/test_graph"
+require "./test/relations/test_incremental_transitive_closure"
 require "./test/relations/test_fork_merge_visitor"
 require "./test/relations/test_bidirectional_directed_adjacency_graph"
 require "./test/task_structure/test_dependency"


### PR DESCRIPTION
Creating an incremental transitive closure graph representation to help optimizing reachable calls. Which allows incremental updates to a directed graph while maintaining its transitive closure.
Using this transitive closure graph in precedence graph. To optimize when possible the reachable call speed.

Benefits when running a full robot test:
After running 5 times for caching and 10 times for timing:
Went from 401.0075 seconds to 388.393  seconds
