### PR TITLE
feat: copy marks

### DIFF
--- a/lib/roby/plan.rb
+++ b/lib/roby/plan.rb
@@ -1609,6 +1609,15 @@ module Roby
             event.finalized!(timestamp)
         end
 
+        # Apply to +to+ the marks (permanent, mission) of +from+
+        #
+        # It does not remove any marks from +from+
+        def copy_task_marks(to:, from:)
+            add_permanent_task(to) if permanent_task?(from)
+
+            add_mission_task(to) if mission_task?(from)
+        end
+
         def remove_task(task, timestamp = Time.now)
             verify_plan_object_finalization_sanity(task)
             remove_task!(task, timestamp)

--- a/test/test_plan.rb
+++ b/test/test_plan.rb
@@ -885,6 +885,38 @@ module Roby
             end
         end
 
+        describe "#copy_task_marks" do
+            attr_reader :task_1, :task_2
+
+            before do
+                plan.add(@task_1 = Roby::Task.new)
+                plan.add(@task_2 = Roby::Task.new)
+            end
+
+            it "copies mission mark from one task to the other" do
+                plan.add_mission_task(task_1)
+
+                plan.copy_task_marks(from: task_1, to: task_2)
+                assert_equal plan.mission_task?(task_1), plan.mission_task?(task_2)
+            end
+
+            it "copies permanent mark from one task to the other" do
+                plan.add_permanent_task(task_1)
+
+                plan.copy_task_marks(from: task_1, to: task_2)
+                assert_equal plan.permanent_task?(task_1), plan.permanent_task?(task_2)
+            end
+
+            it "does not unmark +to+ task" do
+                plan.add_mission_task(task_2)
+
+                plan.copy_task_marks(from: task_1, to: task_2)
+
+                refute plan.permanent_task?(task_2)
+                assert plan.mission_task?(task_2)
+            end
+        end
+
         describe "#remove_task" do
             before do
                 plan.add(@task = Roby::Task.new)


### PR DESCRIPTION
apply one task plan marks to another

EDIT: At first I tried to mark the "merging onto" task just as the "merged task", that is, marking (add) and _unmarking_ (subtracting) the merging onto task so it was exactly marked as the merged task. This breaks the `it "does not change anything if asked to deploy the same composition twice"` test, because it removed the _mission mark_ from compositions already in the _real plan_