### PR TITLE
fix: interpret a TimeoutError during Client#initialize as a connection failure

### DIFF
--- a/lib/roby/interface/v2/tcp.rb
+++ b/lib/roby/interface/v2/tcp.rb
@@ -183,7 +183,7 @@ module Roby
                 Protocol.setup_channel(channel)
                 Client.new(channel, "#{addr[2]}:#{addr[1]}", handshake: handshake)
             rescue Errno::ECONNREFUSED, Errno::EADDRNOTAVAIL, Errno::ETIMEDOUT,
-                   Errno::EHOSTUNREACH, Errno::ENETUNREACH => e
+                   Errno::EHOSTUNREACH, Errno::ENETUNREACH, Client::TimeoutError => e
                 raise ConnectionError,
                       "failed to connect to #{host}:#{port}: #{e.message}",
                       e.backtrace


### PR DESCRIPTION
And retry it.