### PR TITLE
fix: run all REST request handlers in the execution thread by default

### DIFF
--- a/lib/roby/interface/rest/task.rb
+++ b/lib/roby/interface/rest/task.rb
@@ -34,6 +34,14 @@ module Roby
                 # Set to 1 to disable multithreading
                 argument :threads, default: 1
 
+                # Whether all requests should be synchronized with the Roby
+                # event thread
+                #
+                # The behaviour before the introduction of this argument was equivalent
+                # to 'false'. It has been turned on by default given how likely that
+                # the current API implementations got some things wrong in this regard.
+                argument :roby_execute, default: true
+
                 event :start do |_event|
                     @rest_server = Server.new(roby_app, **rest_server_args)
                     start_event.achieve_asynchronously do
@@ -49,7 +57,7 @@ module Roby
                         host: host, port: port, threads: threads,
                         main_route: main_route, api: rest_api,
                         middlewares: rack_middlewares,
-                        storage: rest_storage
+                        storage: rest_storage, roby_execute: roby_execute
                     }
                 end
 

--- a/lib/roby/interface/rest/test.rb
+++ b/lib/roby/interface/rest/test.rb
@@ -39,12 +39,13 @@ module Roby
                 #
                 # Overloaded from Rack::Test to inject the app and plan
                 # and make them available to the API
-                def build_rack_mock_session
+                def build_rack_mock_session(roby_execute: false)
                     interface = Roby::Interface::Interface.new(app)
                     actual_api =
                         Roby::Interface::REST::Server
                         .attach_api_to_interface(
-                            rest_api, interface, roby_storage
+                            rest_api, interface, roby_storage,
+                            roby_execute: roby_execute
                         )
                     Rack::MockSession.new(actual_api)
                 end

--- a/test/interface/rest/test_server.rb
+++ b/test/interface/rest/test_server.rb
@@ -205,14 +205,9 @@ module Roby
                 end
 
                 def get(*args)
-                    done = false
-                    t = Thread.new do
-                        result = RestClient.get(*args)
-                        done = true
-                        result
-                    end
-                    expect_execution.to { achieve { done } }
-                    t.value
+                    p = execution_engine.promise { RestClient.get(*args) }
+                    execute { p.execute }
+                    p.value!
                 end
             end
         end

--- a/test/interface/rest/test_server.rb
+++ b/test/interface/rest/test_server.rb
@@ -205,13 +205,14 @@ module Roby
                 end
 
                 def get(*args)
-                    execute_promise { RestClient.get(*args) }
-                end
-
-                def execute_promise(&block)
-                    promise = execution_engine.promise(&block)
-                    execute { promise.execute }
-                    promise.value!
+                    done = false
+                    t = Thread.new do
+                        result = RestClient.get(*args)
+                        done = true
+                        result
+                    end
+                    expect_execution.to { achieve { done } }
+                    t.value
                 end
             end
         end

--- a/test/interface/rest/test_task.rb
+++ b/test/interface/rest/test_task.rb
@@ -2,6 +2,7 @@
 
 require "roby/test/self"
 require "roby/interface/core"
+require "roby/interface/v1"
 require "roby/interface/rest/task"
 require "roby/interface/rest/server"
 

--- a/test/interface/rest/test_task.rb
+++ b/test/interface/rest/test_task.rb
@@ -13,7 +13,7 @@ module Roby
                 attr_reader :rest_task
 
                 before do
-                    @rest_task = Task.new(host: "127.0.0.1", port: 0)
+                    @rest_task = Task.new(host: "127.0.0.1", port: 0, roby_execute: false)
                     plan.add(rest_task)
 
                     expect_execution { rest_task.start! }
@@ -32,7 +32,9 @@ module Roby
                 end
 
                 it "can be configured with a different mounting point" do
-                    @rest_task = Task.new(host: "127.0.0.1", port: 0, main_route: "/root")
+                    @rest_task = Task.new(
+                        host: "127.0.0.1", port: 0, main_route: "/root", roby_execute: false
+                    )
                     plan.add(rest_task)
                     expect_execution { rest_task.start! }
                         .to { emit rest_task.start_event }
@@ -80,7 +82,7 @@ module Roby
                     end
 
                     it "does not install reporting middlewares if verbose is false" do
-                        plan.add(task = @task_m.new(port: 0, verbose: false))
+                        plan.add(task = @task_m.new(port: 0, verbose: false, roby_execute: false))
                         expect_execution { task.start! }.to { emit task.start_event }
 
                         _, err = capture_subprocess_io do
@@ -95,7 +97,7 @@ module Roby
 
                     it "installs both the logger and error reporting middlewares if "\
                        "verbose is true" do
-                        plan.add(task = @task_m.new(port: 0, verbose: true))
+                        plan.add(task = @task_m.new(port: 0, verbose: true, roby_execute: false))
                         expect_execution { task.start! }.to { emit task.start_event }
 
                         _, err = capture_subprocess_io do
@@ -128,7 +130,7 @@ module Roby
                         end
                     end
 
-                    plan.add(task = task_m.new(port: 0))
+                    plan.add(task = task_m.new(port: 0, roby_execute: false))
                     expect_execution { task.start! }.to { emit task.start_event }
 
                     assert_equal "10", RestClient.get(
@@ -139,7 +141,7 @@ module Roby
                 describe "#url_for" do
                     it "returns the full URL to an API path" do
                         rest_task = Task.new(host: "127.0.0.1", port: 0,
-                                             main_route: "/root")
+                                             main_route: "/root", roby_execute: false)
                         plan.add(rest_task)
                         expect_execution { rest_task.start! }
                             .to { emit rest_task.start_event }

--- a/test/test/test_execution_expectations.rb
+++ b/test/test/test_execution_expectations.rb
@@ -142,6 +142,17 @@ module Roby
                     end
                 end
 
+                describe "promise handling" do
+                    it "handles waiting work that interacts with the execution thread" do
+                        executed = false
+                        thread = Thread.new do
+                            execution_engine.execute { executed = true }
+                        end
+                        expect_execution.to { achieve { executed } }
+                        thread.join
+                    end
+                end
+
                 describe "exit conditions" do
                     describe "with join_all_waiting_work set" do
                         before do

--- a/test/test_app.rb
+++ b/test/test_app.rb
@@ -1026,15 +1026,10 @@ module Roby
                 assert_equal 42, Integer(returned_value)
             end
 
-            def execute_in_thread(plan: @app.plan)
-                done = false
-                t = Thread.new do
-                    result = yield
-                    done = true
-                    result
-                end
-                expect_execution(plan: plan).to { achieve { done } }
-                t.value
+            def execute_in_thread(plan: @app.plan, &block)
+                p = plan.execution_engine.promise(&block)
+                execute(plan: plan) { p.execute }
+                p.value!
             end
         end
 

--- a/test/test_app.rb
+++ b/test/test_app.rb
@@ -1007,7 +1007,7 @@ module Roby
                 capture_log(Robot, :info) { server = @app.setup_rest_interface }
                 assert_same @app, server.app
                 server.wait_start
-                assert server.server_alive?
+                execute_in_thread { server.server_alive? }
             end
             it "allows to extend the API through plugins" do
                 plugin = Module.new do
@@ -1019,9 +1019,22 @@ module Roby
                 server = nil
                 capture_log(Robot, :info) { server = @app.setup_rest_interface }
                 server.wait_start
-                returned_value = RestClient
+                returned_value = execute_in_thread do
+                    RestClient
                     .get("http://localhost:#{server.port}/api/extended")
+                end
                 assert_equal 42, Integer(returned_value)
+            end
+
+            def execute_in_thread(plan: @app.plan)
+                done = false
+                t = Thread.new do
+                    result = yield
+                    done = true
+                    result
+                end
+                expect_execution(plan: plan).to { achieve { done } }
+                t.value
             end
         end
 


### PR DESCRIPTION
Depends on:
- [ ] https://github.com/tidewise/bundles-seabots/pull/475
- [ ] https://github.com/rock-core/tools-syskit/pull/472

The current behaviour was designed around the idea that few places would need to
interact with the execution thread in a non-thread-safe way. Reality is very
different, and bugs that come from the lack of synchronization are really hard
to track and debug.

This makes all calls run inside a ExecutionEngine#execute block. For more
fine-grained access, one can disable that behaviour and explicitly use
roby_execute, or do something like split the APIs and have two handlers, one
always synchronized and one always not.