### PR TITLE
feat: create shortcut `to_PREDICATE` for the very common single-predicate expectation

### DIFF
--- a/lib/roby/test/expect_execution.rb
+++ b/lib/roby/test/expect_execution.rb
@@ -56,8 +56,12 @@ module Roby
                     SETUP_METHODS.include?(m)
                 end
 
-                def method_missing(m, *args, &block)
-                    expectations.public_send(m, *args, &block)
+                def method_missing(m, *args, **kw, &block)
+                    if (to_method = m.to_s.match(/^to_/))
+                        return to { send(to_method.post_match, *args, **kw, &block) }
+                    end
+
+                    expectations.public_send(m, *args, **kw, &block)
                     self
                 end
 

--- a/test/test/test_execution_expectations.rb
+++ b/test/test/test_execution_expectations.rb
@@ -54,6 +54,18 @@ module Roby
                     ret1.should_receive(:filter_result).with(10).and_return(15).once
                     assert_equal([15, 42], expect_execution.to { [ret1, 42] })
                 end
+
+                it "handles any #to_PREDICATE call for " \
+                   "simpler single-expectation syntax" do
+                    result = expect_execution.to_achieve { 20 }
+                    assert_equal 20, result
+                end
+
+                it "forwards arguments of to_PREDICATE to the predicate" do
+                    plan.add(task = Roby::Task.new)
+                    expect_execution { task.quarantined! }
+                        .to_quarantine(task)
+                end
             end
 
             describe "#verify" do


### PR DESCRIPTION
E.g. expect_execution { ... }
        .to_achieve { ... }

Works with any expectation