### PR TITLE
chore: micro-optimization in graph reverse

### DIFF
--- a/lib/roby/relations/bidirectional_directed_adjacency_graph.rb
+++ b/lib/roby/relations/bidirectional_directed_adjacency_graph.rb
@@ -386,8 +386,8 @@ module Roby
                 @forward_edges_with_info.each do |u, out_edges|
                     out_edges.each do |v, info|
                         @backward_edges[v][u] = info
-                        out_edges[v] = nil
                     end
+                    out_edges.transform_values! { nil }
                 end
                 @forward_edges_with_info, @backward_edges =
                     @backward_edges, @forward_edges_with_info


### PR DESCRIPTION
Because I would be suspicious of such a PR without a proper benchmark ... We do get roughly 3 to 4% improvement on a reverse micro-benchmark (note that `reverse` is a combination of `dup` and `reverse!`, the method that has been optimized)

![image](https://github.com/user-attachments/assets/39e15c61-a823-481d-93d9-c8a40b741d14)

Benchmark is:

```
# frozen_string_literal: true

require "roby"
require "benchmark/ips"

VERTICES = 150
FORWARD_EDGES = 2000
TIMES = 10_000

graph = Roby::Relations::BidirectionalDirectedAdjacencyGraph.new
vertices = VERTICES.times.map { Object.new }
FORWARD_EDGES.times.map do
  to = from = vertices.sample
  to = vertices.sample until to != from
  graph.add_edge(from, to, Object.new)
end

Benchmark.ips do |x|
    x.config(warmup: 2, time: 10)

    x.report("graph reverse NEW") do
        graph.reverse
    end
    x.report("graph reverse OLD") do
        graph.reverse_old
    end
end
```
