### PR TITLE
fix: initialize CodeErrorMatcher to match any exception *or* no exceptions at all

### DIFF
--- a/lib/roby/queries/code_error_matcher.rb
+++ b/lib/roby/queries/code_error_matcher.rb
@@ -11,7 +11,7 @@ module Roby
 
             def initialize
                 super
-                @ruby_exception_class = ::Exception
+                @ruby_exception_class = Any
                 with_model(CodeError)
             end
 

--- a/test/queries/test_code_error_matcher.rb
+++ b/test/queries/test_code_error_matcher.rb
@@ -9,8 +9,14 @@ module Roby
                 plan.add(@task = Roby::Task.new)
             end
 
-            it "matches a plain CodeError object as-is" do
+            it "matches a plain CodeError with exception as-is" do
                 error = CodeError.new(Exception.new, @task)
+                matcher = CodeErrorMatcher.new
+                assert_operator matcher, :===, error
+            end
+
+            it "matches a plain CodeError without exception as-is" do
+                error = CodeError.new(nil, @task)
                 matcher = CodeErrorMatcher.new
                 assert_operator matcher, :===, error
             end


### PR DESCRIPTION
CodeError may have an underlying exception or not (e.g. EmissionFailed is routinely created without an underlying exception). The corresponding matcher should really match all cases, and not only the one with "no exceptions"