### PR TITLE
feat: add log dir lock and unlock

### DIFF
--- a/lib/roby/app.rb
+++ b/lib/roby/app.rb
@@ -1068,7 +1068,7 @@ module Roby
             return true unless File.exist?(lock_file_path)
 
             File.open(lock_file_path, "r") do |file|
-                return !file.flock(File::LOCK_EX | File::LOCK_NB)
+                !file.flock(File::LOCK_SH | File::LOCK_NB)
             end
         end
 

--- a/lib/roby/app.rb
+++ b/lib/roby/app.rb
@@ -1060,16 +1060,17 @@ module Roby
         end
 
         def unlock_log_dir
-            return unless log_dir_locked?
-
             @lock_file&.close
             @lock_file = nil
         end
 
-        def log_dir_locked?
-            return unless @lock_file
+        def self.log_dir_locked?(path)
+            lock_file_path = File.join(path, LOCK_FILE_EXT)
+            return true unless File.exist?(lock_file_path)
 
-            @lock_file.path.end_with?(LOCK_FILE_EXT)
+            File.open(lock_file_path, "r") do |file|
+                return !file.flock(File::LOCK_EX | File::LOCK_NB)
+            end
         end
 
         # The inverse of #base_setup
@@ -1596,7 +1597,6 @@ module Roby
         # Reset the current log dir so that {#setup} picks a new one
         def reset_log_dir
             unlock_log_dir
-            @log_dir = nil
         end
 
         # Reset the plan to a new Plan object

--- a/lib/roby/app.rb
+++ b/lib/roby/app.rb
@@ -1065,7 +1065,7 @@ module Roby
         def unlock_log_dir
             return unless log_dir_locked?
 
-            @lock_file.close if @lock_file
+            @lock_file&.close
             @lock_file = nil
         end
 

--- a/lib/roby/app.rb
+++ b/lib/roby/app.rb
@@ -1047,14 +1047,15 @@ module Roby
         end
 
         def lock_log_dir
-            temp_lock_path = File.join(log_dir, "#{LOCK_FILE_EXT}.tmp")
             final_lock_path = File.join(log_dir, LOCK_FILE_EXT)
-
+            temp_lock_path = "#{final_lock_path}.tmp"
             lock_file = File.open(temp_lock_path, File::RDWR | File::CREAT, 0o644)
-            if lock_file.flock(File::LOCK_EX | File::LOCK_NB)
-                File.rename(temp_lock_path, final_lock_path)
-                @lock_file = lock_file
+            unless lock_file.flock(File::LOCK_EX | File::LOCK_NB)
+                raise RuntimeError, "could not lock the log directory on setup"
             end
+
+            File.rename(temp_lock_path, final_lock_path)
+            @lock_file = lock_file
         end
 
         def unlock_log_dir

--- a/lib/roby/app.rb
+++ b/lib/roby/app.rb
@@ -1051,7 +1051,7 @@ module Roby
             temp_lock_path = "#{final_lock_path}.tmp"
             lock_file = File.open(temp_lock_path, File::RDWR | File::CREAT, 0o644)
             unless lock_file.flock(File::LOCK_EX | File::LOCK_NB)
-                raise RuntimeError, "could not lock the log directory on setup"
+                raise "could not lock the log directory on setup"
             end
 
             File.rename(temp_lock_path, final_lock_path)

--- a/lib/roby/app.rb
+++ b/lib/roby/app.rb
@@ -1049,16 +1049,13 @@ module Roby
         end
 
         def lock_log_dir
-            return if log_dir_locked?
+            temp_lock_path = File.join(log_dir, "#{LOCK_FILE_EXT}.tmp")
+            final_lock_path = File.join(log_dir, LOCK_FILE_EXT)
 
-            temp_lock_file = File.join(log_dir, "#{LOCK_FILE_EXT}.tmp")
-            final_lock_file = File.join(log_dir, LOCK_FILE_EXT)
-
-            @lock_file = File.open(temp_lock_file, File::RDWR | File::CREAT, 0o644)
-            if @lock_file.flock(File::LOCK_EX | File::LOCK_NB)
-                File.rename(temp_lock_file, final_lock_file)
-                @lock_file.close
-                @lock_file = File.open(final_lock_file, File::RDWR | File::CREAT, 0o644)
+            lock_file = File.open(temp_lock_path, File::RDWR | File::CREAT, 0o644)
+            if lock_file.flock(File::LOCK_EX | File::LOCK_NB)
+                File.rename(temp_lock_path, final_lock_path)
+                @lock_file = lock_file
             end
         end
 

--- a/lib/roby/app.rb
+++ b/lib/roby/app.rb
@@ -885,8 +885,6 @@ module Roby
         # Display the backtrace of all running threads on abort
         attr_predicate :display_all_threads_state_on_abort?, true
 
-        attr_reader :lock_file
-
         def initialize(plan: ExecutablePlan.new)
             @plan = plan
             @argv_set = []

--- a/lib/roby/app.rb
+++ b/lib/roby/app.rb
@@ -1596,6 +1596,7 @@ module Roby
         # Reset the current log dir so that {#setup} picks a new one
         def reset_log_dir
             unlock_log_dir
+            @log_dir = nil
         end
 
         # Reset the plan to a new Plan object

--- a/test/test_app.rb
+++ b/test/test_app.rb
@@ -211,7 +211,7 @@ module Roby
                 end
 
                 it "unlocks directory when it is reset" do
-                    full_path = app.find_and_create_log_dir("tag")
+                    app.find_and_create_log_dir("tag")
                     app.lock_log_dir
                     app.reset_log_dir
 

--- a/test/test_app.rb
+++ b/test/test_app.rb
@@ -224,7 +224,7 @@ module Roby
                     lock_file_path = File.join(full_path, ".lock")
                     File.write(lock_file_path, "")
 
-                    assert File.exists?(lock_file_path)
+                    assert File.exist?(lock_file_path)
                     refute Application.log_dir_locked?(full_path)
                 end
 

--- a/test/test_app.rb
+++ b/test/test_app.rb
@@ -191,6 +191,17 @@ module Roby
             end
 
             describe "log dir lock management" do
+                it "checks if a log dir is locked in a concurrent-safe way" do
+                    full_path = app.find_and_create_log_dir("tag")
+                    app.lock_log_dir
+                    app.unlock_log_dir
+
+                    threads = 500.times.map do
+                        Thread.new { Application.log_dir_locked?(full_path) }
+                    end
+                    refute threads.map(&:value).inject(:|)
+                end
+
                 it "expects dir to be locked if there is no .lock file" do
                     full_path = app.find_and_create_log_dir("tag")
 


### PR DESCRIPTION
The objective is to add a robust way for external tools to know if a log dir is being managed by a roby/syskit process or not.

Supersedes https://github.com/rock-core/tools-roby/pull/317