### PR TITLE
fix: finish event reporter integration to test spec

### DIFF
--- a/lib/roby/test/event_reporter.rb
+++ b/lib/roby/test/event_reporter.rb
@@ -59,7 +59,7 @@ module Roby
                            @filters.any? { |pattern| pattern === event.to_s }
                 return unless included
 
-                excluded = @filters_out.empty? ||
+                excluded = !@filters_out.empty? &&
                            @filters_out.none? { |pattern| pattern === event.to_s }
                 !excluded
             end
@@ -69,8 +69,8 @@ module Roby
             end
 
             # This is the API used by Roby to actually log events
-            def dump(m, time, *args)
-                received_events << [m, time, *args]
+            def dump(m, time, args)
+                received_events << [m, time, args]
                 return unless enabled? && matches_filter?(m)
 
                 @io.puts "#{time.to_hms} #{m}(#{args.map(&:to_s).join(', ')})"

--- a/lib/roby/test/spec.rb
+++ b/lib/roby/test/spec.rb
@@ -4,6 +4,7 @@ require "utilrb/timepoints"
 require "roby/test/error"
 require "roby/test/common"
 require "roby/test/dsl"
+require "roby/test/event_reporter"
 require "roby/test/teardown_plans"
 require "roby/test/minitest_helpers"
 require "roby/test/robot_test_helpers"
@@ -73,7 +74,18 @@ module Roby
                 end
                 register_plan(plan)
 
+                @plan_original_event_logger = plan.event_logger
+                plan.event_logger = Roby::Test::EventReporter.new(STDOUT)
+
                 super
+            end
+
+            def enable_event_reporting
+                plan.event_logger.enabled = true
+            end
+
+            def disable_event_reporting
+                plan.event_logger.enabled = false
             end
 
             def teardown
@@ -88,6 +100,8 @@ module Roby
                 teardown_registered_plans
                 app.run_shutdown_blocks
             ensure
+                plan.event_logger = @plan_original_event_logger
+
                 clear_registered_plans
                 if teardown_failure
                     raise teardown_failure


### PR DESCRIPTION
The event reporter wasnt fully integrated, this finishes what was missing to the test suite.