### PR TITLE
feat: introduce the InternalTaskError type

### DIFF
--- a/lib/roby/standard_errors.rb
+++ b/lib/roby/standard_errors.rb
@@ -303,10 +303,23 @@ module Roby
     # when this constraint is not met.
     class ThreadMismatch < RuntimeError; end
 
+    # Errors that are generated inside a task
+    #
+    # {Roby::Task} defines an exception handler that transforms some plan exceptions
+    # in task-level "events", to allow for event-based error handling for these. The
+    # handler will only listen to errors of type {InternalTaskError} or one of its
+    # subclasses.
+    #
+    # For instance, an exception raised in the command block of the start event will
+    # generate an EmissionFailed error that point to that event, and this handler
+    # will turn this into a failure to start the task (which in turn makes all
+    # events unreachable and will trigger dependency errors if applicable)
+    class InternalTaskError < LocalizedError; end
+
     # Raised when a user-provided code block (i.e. a code block which is
     # outside of Roby's plan management algorithms) has raised. This includes:
     # event commands, event handlers, task polling blocks, ...
-    class CodeError < LocalizedError
+    class CodeError < InternalTaskError
         include UserExceptionWrapper
 
         # The original exception object

--- a/lib/roby/task.rb
+++ b/lib/roby/task.rb
@@ -1684,7 +1684,7 @@ module Roby
         end
         private :internal_error_handler
 
-        on_exception(Roby::CodeError) do |exception|
+        on_exception(Roby::InternalTaskError) do |exception|
             internal_error_handler(exception)
         end
 

--- a/lib/roby/test/execution_expectations.rb
+++ b/lib/roby/test/execution_expectations.rb
@@ -1065,7 +1065,8 @@ module Roby
                 end
 
                 def return_object
-                    @matched_execution_exceptions.first
+                    @matched_execution_exceptions.first ||
+                        @matched_exceptions.first
                 end
             end
 


### PR DESCRIPTION
The handler that turns CodeError into task-level errors in Roby::Task (e.g. fail_to_start or
internal_error_event) is overly specific (it only looks for CodeError). It is desirable to be able
to handle other errors the same way (cf. introduction of PropertyUpdatesError in Syskit, linked
to this PR)

This PR introduces the InternalTaskError type that is a simple subclass of LocalizedError
for this purpose.