### PR TITLE
feat: define the filter_out_related_errors config flag in execution expectations

### DIFF
--- a/lib/roby/test/execution_expectations.rb
+++ b/lib/roby/test/execution_expectations.rb
@@ -330,6 +330,7 @@ module Roby
                 @garbage_collect = false
                 @validate_unexpected_errors = true
                 @display_exceptions = false
+                @filter_out_related_errors = true
             end
 
             def find_tasks(*args)
@@ -516,6 +517,17 @@ module Roby
             #
             # @param [Boolean] enable
             dsl_attribute :garbage_collect
+
+            # @!method filter_out_related_errors(enable)
+            #
+            # When enabled, errors that are caused by something that has a matcher
+            # will not be reported as unexpected. For instance, a DependencyFailedError
+            # caused by an event, when there is the corresponding `emit` predicate.
+            #
+            # The default is true
+            #
+            # @param [Boolean] enable
+            dsl_attribute :filter_out_related_errors
 
             # @!method validate_unexpected_errors(enable)
             #
@@ -727,6 +739,8 @@ module Roby
             #
             # @param [ExecutionException,Exception] error
             def unexpected_error?(error)
+                return true unless @filter_out_related_errors
+
                 all_errors = Roby.flatten_exception(error)
                 has_related_predicate = @expectations.any? do |expectation|
                     all_errors.any? { |orig_e| expectation.relates_to_error?(orig_e) }


### PR DESCRIPTION
On top of #327 

To avoid overly verbose tests, the execution expectation harness filters out "related errors". For instance, testing for `emit task.failed_event` will ignore all errors created by this emission.

This is great for user-facing tests, but the unit test suites of Syskit and Roby need an escape hatch. For now, I created the flag locally to use in a Syskit test case (which had the very issue of "not seeing" a plan error) so that later we can try turning it off for all tests in these two package's unit test suites (I'm expecting some work)