### PR TITLE
fix: test end when SimpleCov is loaded but not enabled

### DIFF
--- a/lib/roby/app/scripts/test.rb
+++ b/lib/roby/app/scripts/test.rb
@@ -181,7 +181,7 @@ exception = Roby.display_exception do
             Roby.app.cleanup
         end
 
-    SimpleCov.run_exit_tasks! if defined?(SimpleCov)
+    SimpleCov.run_exit_tasks! if defined?(SimpleCov) && SimpleCov.running
     Minitest.run_after_blocks
     exit(passed ? 0 : 1)
 end


### PR DESCRIPTION
This is a workaround for a bug in simplecov. It calls Proc.new without a block, which is forbidden in recent (that is at least > 2.7)