### PR TITLE
feat: define Roby.monotonic_time

### DIFF
--- a/lib/roby/support.rb
+++ b/lib/roby/support.rb
@@ -207,4 +207,13 @@ module Roby
 
     VoidClass = Class.new
     Void = VoidClass.new.freeze
+
+    # Time in seconds since an arbitrary point in time, unaffected by time corrections
+    #
+    # Use this time for e.g. compute timeouts or durations since a certain timepoint
+    #
+    # @return [Float]
+    def self.monotonic_time
+        Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    end
 end


### PR DESCRIPTION
It's a method I've defined on Syskit and started to use quite a bit on all timeout-related code in telemetry/. Given its applicability, I think best to move it here.