### PR TITLE
fix: do not self-modify DelayedArgumentFromObject

### DIFF
--- a/lib/roby/task_arguments.rb
+++ b/lib/roby/task_arguments.rb
@@ -591,6 +591,10 @@ module Roby
         end
 
         def of_type(expected_class)
+            dup.of_type!(expected_class)
+        end
+
+        def of_type!(expected_class)
             @expected_class = expected_class
             self
         end
@@ -600,7 +604,7 @@ module Roby
         end
 
         def add_method(m)
-            @methods << m
+            @methods += [m]
             self
         end
 

--- a/test/test_task_arguments.rb
+++ b/test/test_task_arguments.rb
@@ -464,6 +464,29 @@ module Roby
             @arg = DelayedArgumentFromObject.new(nil).arg.field
         end
 
+        it "returns a new object when a method is added" do
+            inner = flexmock(field: 20)
+            root = flexmock(arg: inner)
+
+            root_arg = DelayedArgumentFromObject.new(nil)
+            inner_arg = root_arg.arg
+            field_arg = inner_arg.field
+            assert_equal root, root_arg.evaluate_delayed_argument(root)
+            assert_equal inner, inner_arg.evaluate_delayed_argument(root)
+            assert_equal 20, field_arg.evaluate_delayed_argument(root)
+        end
+
+        it "returns a new object when the type is specified" do
+            untyped_arg = DelayedArgumentFromObject.new(nil).field
+            typed_arg = untyped_arg.of_type(TrueClass)
+
+            obj = flexmock(field: 20)
+            assert_equal 20, untyped_arg.evaluate_delayed_argument(obj)
+            catch(:no_value) do
+                typed_arg.evaluate_delayed_argument(obj)
+            end
+        end
+
         describe "#evaluate_delayed_argument" do
             it "resolves to a task's arguments" do
                 task.arg = Struct.new(:field).new(10)


### PR DESCRIPTION
The principal two ways to interact with it (adding a new method to the path and specifying the expected type) actually were modifying the receiver, which leads to:

from_conf = Roby.from_conf.some.complex.path
from_conf.field0
from_conf.field1

to search for from_conf.field0.field1 ... Really not expected, and neither desired in this case.