### PR TITLE
fix: do not register the same predicate twice in a matcher

### DIFF
--- a/lib/roby/queries/matcher_base.rb
+++ b/lib/roby/queries/matcher_base.rb
@@ -87,7 +87,7 @@ module Roby
                     raise ArgumentError, "trying to match (#{predicate} & !#{predicate})"
                 end
 
-                @predicates << predicate
+                @predicates << predicate unless @predicates.include?(predicate)
                 self
             end
 
@@ -99,7 +99,7 @@ module Roby
                     raise ArgumentError, "trying to match (#{predicate} & !#{predicate})"
                 end
 
-                @neg_predicates << predicate
+                @neg_predicates << predicate unless @neg_predicates.include?(predicate)
                 self
             end
 

--- a/lib/roby/queries/task_matcher.rb
+++ b/lib/roby/queries/task_matcher.rb
@@ -157,6 +157,16 @@ module Roby
                 super
             end
 
+            def add_indexed_predicate(name)
+                @indexed_predicates << name unless @indexed_predicates.include?(name)
+            end
+
+            def add_indexed_neg_predicate(name)
+                return if @indexed_neg_predicates.include?(name)
+
+                @indexed_neg_predicates << name
+            end
+
             class << self
                 # @api private
                 def match_indexed_predicate(
@@ -168,14 +178,14 @@ module Roby
                     class_eval <<~PREDICATE_METHOD, __FILE__, __LINE__ + 1
                         def #{method_name}
                             add_predicate(:#{name})
-                            #{"indexed_predicates << :#{index}" if index}
-                            #{"indexed_neg_predicates << :#{neg_index}" if neg_index}
+                            #{"add_indexed_predicate(:#{index})" if index}
+                            #{"add_indexed_neg_predicate(:#{neg_index})" if neg_index}
                             self
                         end
                         def not_#{method_name}
                             add_neg_predicate(:#{name})
-                            #{"indexed_predicates << :#{not_index}" if not_index}
-                            #{"indexed_neg_predicates << :#{not_neg_index}" if not_neg_index}
+                            #{"add_indexed_predicates(:#{not_index})" if not_index}
+                            #{"add_indexed_neg_predicate(:#{not_neg_index})" if not_neg_index}
                             self
                         end
                     PREDICATE_METHOD

--- a/test/queries/test_task_matcher.rb
+++ b/test/queries/test_task_matcher.rb
@@ -14,6 +14,28 @@ module Roby
                     end
                 end
 
+                it "does not register the same positive predicate twice" do
+                    matcher = TaskMatcher.executable.executable
+                    assert_equal %I[executable?], matcher.predicates
+                end
+
+                it "does not register the same negative predicate twice" do
+                    matcher = TaskMatcher.not_executable.not_executable
+                    assert_equal %I[executable?], matcher.neg_predicates
+                end
+
+                it "does not register the same positive indexed predicate twice" do
+                    matcher = TaskMatcher.starting.starting
+                    assert_equal %I[starting?], matcher.predicates
+                    assert_equal %I[starting?], matcher.indexed_predicates
+                end
+
+                it "does not register the same negative predicate twice" do
+                    matcher = TaskMatcher.not_starting.not_starting
+                    assert_equal %I[starting?], matcher.neg_predicates
+                    assert_equal %I[starting?], matcher.indexed_neg_predicates
+                end
+
                 it "matches on #executable?" do
                     plan.add(yes = Tasks::Simple.new)
                     plan.add(no = Tasks::Simple.new)


### PR DESCRIPTION
The real bug here is the matcher API that modifies its receiver forever, that is:

    matcher = find_tasks.executable

    # later
    matcher.executable.first

will add `executable` to `matcher` (the first one). And will do it every single time. And then match all of them (sequentially). So, possibly, we could have millions of these predicates being checked forever and ever.

I believe changing the API will have to be done, but will take time and will have to be done gradually / in a conservative manner. This patch at least alleviates the major issue without changing the matcher's (horrible) behaviour