### PR TITLE
fix: change the temporal scheduler to handle relationships between schedule_as and dependency

### DIFF
--- a/lib/roby/schedulers/basic.rb
+++ b/lib/roby/schedulers/basic.rb
@@ -62,7 +62,6 @@ module Roby
                     .pending
                     .self_owned
 
-                @can_schedule_cache = {}
                 @enabled = true
             end
 
@@ -125,7 +124,6 @@ module Roby
             # Starts all tasks that are eligible. See the documentation of the
             # Basic class for an in-depth description
             def initial_events
-                @can_schedule_cache.clear
                 time = Time.now
 
                 not_executable = self.plan.find_tasks
@@ -146,14 +144,7 @@ module Roby
 
                 scheduled_tasks = []
                 for task in query.reset
-                    result =
-                        if @can_schedule_cache.include?(task)
-                            @can_schedule_cache[task]
-                        else
-                            @can_schedule_cache[task] = can_schedule?(task, time, [])
-                        end
-
-                    if result
+                    if can_schedule?(task, time, [])
                         task.start!
                         report_trigger task.start_event
                         scheduled_tasks << task

--- a/lib/roby/schedulers/basic.rb
+++ b/lib/roby/schedulers/basic.rb
@@ -99,15 +99,7 @@ module Roby
                     return false
                 end
 
-                root_task =
-                    if task.root?(TaskStructure::Dependency)
-                        true
-                    else
-                        planned_tasks = task.planned_tasks
-                        !planned_tasks.empty? &&
-                            planned_tasks.all? { |t| !t.executable? }
-                    end
-
+                root_task = basic_scheduling_root_task?(task)
                 if root_task
                     true
                 elsif include_children && task.parents.any?(&:running?)
@@ -119,6 +111,14 @@ module Roby
                     report_holdoff "not root, and include_children is false", task
                     false
                 end
+            end
+
+            def basic_scheduling_root_task?(task)
+                return true if task.root?(TaskStructure::Dependency)
+
+                planned_tasks = task.planned_tasks
+                !planned_tasks.empty? &&
+                    planned_tasks.all? { |t| !t.executable? }
             end
 
             # Starts all tasks that are eligible. See the documentation of the

--- a/lib/roby/schedulers/temporal.rb
+++ b/lib/roby/schedulers/temporal.rb
@@ -31,14 +31,43 @@ module Roby
                     return false
                 end
 
-                start_event = task.start_event
-                return false unless schedule_verify_temporal_constraints(task, time, stack)
+                return false unless verify_temporal_constraints(task, time, stack)
+                return false unless verify_schedule_as_constraints(task, time, stack)
+                return true unless basic_constraints?
 
-                start_event.each_backward_scheduling_constraint do |parent|
+                root_task = basic_scheduling_root_task?(task)
+                if root_task
+                    true
+                elsif include_children && parents_allow_scheduling?(task, time, stack)
+                    true
+                elsif include_children
+                    report_holdoff "not root, and has no running parent", task
+                    false
+                else
+                    report_holdoff "not root, and include_children is false", task
+                    false
+                end
+            end
+
+            def verify_schedule_as_constraints(task, time, stack)
+                # "backward scheduling constraint" == "schedule_as",
+                # that is in this loop, start_event.schedule_as(parent.start_event)
+                task.start_event
+                    .each_backward_scheduling_constraint do |scheduled_as_event|
+                    scheduled_as_task = scheduled_as_event.task
+                    next if stack.include?(scheduled_as_task)
+
+                    if !scheduled_as_task.executable? &&
+                       task.depends_on?(scheduled_as_task)
+                        return false
+                    end
+
                     begin
                         stack.push task
-                        unless can_schedule?(parent.task, time, stack)
-                            report_holdoff "held by a schedule_as constraint with %2", task, parent
+                        unless can_schedule?(scheduled_as_task, time, stack)
+                            report_holdoff(
+                                "held by schedule_as(%2)", task, scheduled_as_event
+                            )
                             return false
                         end
                     ensure
@@ -46,31 +75,54 @@ module Roby
                     end
                 end
 
-                if basic_constraints?
-                    if super
-                        true
-                    else
-                        # Special case: check in Dependency if there are some
-                        # parents for which a forward constraint from +self+ to
-                        # +parent.start_event+ exists. If it is the case, start
-                        # the task
-                        task.each_parent_task do |parent|
-                            parent.start_event.each_backward_temporal_constraint do |constraint|
-                                if constraint.respond_to?(:task) && constraint.task == task
-                                    Schedulers.debug { "Temporal: #{task} has no running parent, but a constraint from #{constraint} to #{parent}.start exists. Scheduling." }
-                                    return true
-                                end
-                            end
-                        end
-                        false
+                true
+            end
+
+            def parents_allow_scheduling?(task, time, stack)
+                task.each_parent_task.any? do |parent_task|
+                    next(true) if parent_task.running?
+
+                    parent_waiting_for_self =
+                        parent_waiting_for_self?(task, parent_task)
+
+                    parent_scheduled_as_self =
+                        task.start_event.child_object?(
+                            parent_task.start_event,
+                            Roby::EventStructure::SchedulingConstraints
+                        )
+
+                    next(false) unless parent_scheduled_as_self || parent_waiting_for_self
+                    next(true) if stack.include?(parent_task)
+
+                    begin
+                        stack.push task
+                        can_schedule?(parent_task, time, stack)
+                    ensure
+                        stack.pop
                     end
-                else
-                    true
                 end
             end
 
-            def schedule_verify_temporal_constraints(task, time, stack)
-                start_event = task.start_event
+            def parent_waiting_for_self?(task, parent_task)
+                # Special case: check in Dependency if there are some
+                # parents for which a forward constraint from +self+ to
+                # +parent.start_event+ exists. If it is the case, start
+                # the task
+                parent_task.start_event.each_backward_temporal_constraint do |constraint|
+                    if constraint.respond_to?(:task) && constraint.task == task
+                        Schedulers.debug do
+                            "Temporal: #{task} has no running parent, but " \
+                            "a constraint from #{constraint} to #{parent_task}.start " \
+                            "exists. Scheduling."
+                        end
+                        return true
+                    end
+                end
+
+                false
+            end
+
+            def verify_temporal_constraints(task, time, stack)
                 event_filter = lambda do |ev|
                     if ev.respond_to?(:task)
                         ev.task != task &&
@@ -81,6 +133,7 @@ module Roby
                     end
                 end
 
+                start_event = task.start_event
                 if (failed_temporal = start_event.find_failed_temporal_constraint(time, &event_filter))
                     report_holdoff "temporal constraints not met (%2: %3)", task, failed_temporal[0], failed_temporal[1]
                     return false


### PR DESCRIPTION
`schedule_as` indicates that a task should be considered for scheduling only if
another task is. This is used to schedule planning tasks at the point in time
where their planned task is considered for planning, in e.g. Syskit (so, deploy
a subnet only when it is needed)

However, because Syskit also has a strong constraint that all children of a
composition will be started with the composition, we implemented that the
executable? flag for compositions returns true only if the children of the
composition are also executable.

Combined, this leads to the following pattern to fail:

   root.depends_on child
   child.depends_on abstract
   abstract.planned_by planning_task
   planning_task.schedule_as abstract

Since child is not running, abstract cannot be scheduled and won't be planned,
which leads to child remaining non-executable. Deadlock

This pull request extends the analysis capability of the temporal scheduler to
be smarter w.r.t. the relationships between schedule_as and dependencies. This
should allow to replace the `executable?` hack in Syskit with schedule_as
relationships, giving the scheduler the information it needs to handle this case
(and others) properly.

Namely:

- parent.schedule_as(child) now works. It considers temporal constraints, other
  schedule_as constraints as well as the executable flag of the child
- parent.schedule_as(child) combined with child_planning_task.schedule_as(child)
  works as well.