### PR TITLE
fix: cleanup behaviour related to stable OpenStruct

### DIFF
--- a/lib/roby/state/open_struct_model.rb
+++ b/lib/roby/state/open_struct_model.rb
@@ -19,8 +19,12 @@ module Roby
             end
         end
 
-        def __respond_to__(name)
-            super || superclass&.__respond_to__(name)
+        def respond_to_missing?(name, private = false)
+            return true if super
+
+            name = name.to_s
+            name = name[0..-2] if name.end_with?("?")
+            superclass&.member?(name) || superclass&.alias?(name)
         end
 
         def create_subfield(name)


### PR DESCRIPTION
The point of stable! was to have a mode where the structure of the OpenStruct tree could not be changed anymore, but the values could. There was actually a few bugs around this.

Additionally, remove compatibility with pre-2.0 Ruby (!)