### PR TITLE
fix: flatten exceptions list to deal with array of exceptions

### DIFF
--- a/lib/roby/exceptions.rb
+++ b/lib/roby/exceptions.rb
@@ -491,6 +491,7 @@ module Roby
             all += exception.original_exceptions.to_a
         end
 
+        all = all.flatten
         if skip_identical_backtraces
             last_backtrace = nil
             all =


### PR DESCRIPTION
The capture resolution errors implementation introduced the possibility of raising a list of exceptions. Unfortunately, display exceptions didnt support that, fix it by flattening the exceptions array beforehand.