### PR TITLE
feat: avoid recursion when formatting exceptions

### DIFF
--- a/lib/roby/test/teardown_plans.rb
+++ b/lib/roby/test/teardown_plans.rb
@@ -123,6 +123,7 @@ module Roby
                     now = Time.now
                 end
 
+                puts "teardown_killall done in #{Time.now - start_time}"
                 # NOTE: this is NOT plan.empty?. We stop processing plans that
                 # are made of quarantined tasks and their dependencies, but
                 # still report an error when they exist

--- a/test/test_exceptions.rb
+++ b/test/test_exceptions.rb
@@ -85,4 +85,17 @@ describe Roby do
             Roby.log_exception(main, logger, :warn)
         end
     end
+
+    describe ".format_exception" do
+        it "guards against infinite recursion" do
+            exception_m = Class.new(RuntimeError) do
+                def pretty_print(pp)
+                    pp.text Roby.format_exception(self).join("\n")
+                end
+            end
+
+            result = Roby.format_exception(exception_m.new)
+            assert_equal ["<...>"], result
+        end
+    end
 end


### PR DESCRIPTION
Now we store the exception object id and use it to verify if it's already present, avoiding recursions.