### PR TITLE
fix: flatten exception array

### DIFF
--- a/lib/roby/exceptions.rb
+++ b/lib/roby/exceptions.rb
@@ -488,7 +488,7 @@ module Roby
     )
         all = [exception]
         if exception.respond_to?(:original_exceptions)
-            all += exception.original_exceptions.to_a
+            all += exception.original_exceptions.to_a.flatten
         end
 
         if skip_identical_backtraces


### PR DESCRIPTION
When running `rake test:mk2:features-all` in a local branch, I got `tools/roby/lib/roby/exceptions.rb:500:in `block in do_display_exception': undefined method `backtrace' for #<Array:0x0000564e0590b448> (NoMethodError)`, the same do not happen with feature flags off. 

This solves my problem, but I am no certain it is the right thing to do. 