### PR TITLE
fix: do not call clear_pending when copying an event generator

### DIFF
--- a/lib/roby/event_generator.rb
+++ b/lib/roby/event_generator.rb
@@ -83,7 +83,8 @@ module Roby
             @unreachable = old.unreachable?
             @unreachable_handlers = old.unreachable_handlers.dup
 
-            clear_pending
+            @pending = false
+            @pending_sources = []
         end
 
         # Returns the model object for this particular event generator. It is in
@@ -880,11 +881,18 @@ module Roby
             raise EventCanceled.new(self), (reason || "event canceled")
         end
 
+        # Method called to declare that a call is pending
+        #
+        # @param [Array<EventGenerator>] sources list of event generators that are
+        #   responsible for the call
         def pending(sources)
             @pending = true
             @pending_sources.concat(sources)
         end
 
+        # Method called to clear a pending call
+        #
+        # Submodels can hook into this to do some cleanup
         def clear_pending
             @pending = false
             @pending_sources = []

--- a/test/transactions/test_task_event_generator_proxy.rb
+++ b/test/transactions/test_task_event_generator_proxy.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "roby/test/self"
+
+module Roby
+    class Transaction
+        describe TaskEventGeneratorProxy do
+            it "does not change the state of an underlying starting task on creation" do
+                # This is a regression test. We added a call to #clear_pending in
+                # EventGenerator#initialize_copy, but clear_pending is meant to be
+                # a hook. It is reimplemented by TaskEventGenerator, and because during
+                # the transaction proxy creation TaskEventGenerator#task was still
+                # pointing to the real (not proxied) task, it messed up the task state
+                task_m = Roby::Task.new_submodel do
+                    terminates
+                    event :start do |context|
+                    end
+                end
+                plan.add(task = task_m.new)
+                execute { task.start_event.call }
+
+                plan.in_transaction do |trsc|
+                    trsc[task]
+                    trsc[task.start_event]
+                    assert task.starting?
+                    refute task.pending?
+                end
+            ensure
+                execute { task.start_event.emit }
+            end
+        end
+    end
+end


### PR DESCRIPTION
clear_pending is meant as a hook to announce that the call was cancelled, not purely as a cleanup method. Document that, and avoid calling it in initialize_copy.

See the comment in the regression test for more details.