### PR TITLE
fix: explicitly pass file descriptors to create interfaces in subcommands

### DIFF
--- a/lib/roby/test/aruba_minitest.rb
+++ b/lib/roby/test/aruba_minitest.rb
@@ -33,8 +33,29 @@ module Roby
             end
 
             def teardown
+                @interface_server&.close
                 stop_all_commands
                 super
+            end
+
+            def run_roby_environment
+                { "ROBY_PLUGIN_PATH" => @roby_plugin_path.join(":") }
+            end
+
+            # Create a TCPServer to be used as the underlying's `roby run` server
+            #
+            # @return [Integer] the file descriptor number to be passed to --interface-fd
+            def roby_allocate_interface_server
+                raise "interface server already allocated" if @interface_server
+
+                @interface_server = ::TCPServer.new(0)
+                @interface_server.fileno
+            end
+
+            # Port of the interface server allocated with
+            # {#roby_allocate_interface_server}
+            def roby_interface_port
+                @interface_server.local_address.ip_port
             end
 
             def roby_allocate_port
@@ -57,6 +78,10 @@ module Roby
                 @aruba_api.run_command(cmd, opts)
             end
 
+            # Run a subcommand of the `roby` CLI and wait for it to stop
+            #
+            # @param [String] cmd the command (e.g. quit --retry)
+            # @return [Aruba::Command] the aruba command object
             def run_roby_and_stop(
                 cmd, *args, fail_on_error: true, exit_timeout: 45, **opts
             )
@@ -65,10 +90,63 @@ module Roby
                                      fail_on_error: fail_on_error, **opts)
             end
 
-            def run_roby(cmd, *args, fail_on_error: true, exit_timeout: 45, **opts)
+            # Run a subcommand of the `roby` CLI
+            #
+            # @param [String] cmd the command (e.g. quit --retry)
+            # @return [Aruba::Command] the aruba command object
+            def run_roby(cmd, fail_on_error: true, exit_timeout: 45, **opts)
                 opts[:exit_timeout] ||= exit_timeout
-                run_command("#{Gem.ruby} #{roby_bin} #{cmd}", *args,
+                run_command("#{Gem.ruby} #{roby_bin} #{cmd}",
                             fail_on_error: fail_on_error, **opts)
+            end
+
+            # Run `roby run`
+            #
+            # Unlike calling `run_roby` directly, it sets up the --interface-fd argument
+            # properly if {#roby_allocate_interface_server} has been called
+            def run_roby_run(cmd = "", interface_version: 1, forwarded_ios: [], **opts)
+                if @interface_server
+                    arg =
+                        if interface_version == 1
+                            "--interface-fd"
+                        else
+                            "--interface-v2-fd"
+                        end
+
+                    cmd = "--interface-versions=#{interface_version} " \
+                          "#{arg}=#{@interface_server.fileno} #{cmd}"
+
+                    forwarded_ios += [@interface_server.fileno]
+                end
+
+                run_roby("run #{cmd}", forwarded_ios: forwarded_ios, **opts)
+            end
+
+            # @api private
+            #
+            # Command line arguments to connect to a Roby instance
+            def roby_client_args(interface_version)
+                "--host=localhost:#{roby_interface_port} " \
+                    "--interface-version=#{interface_version}"
+            end
+
+            # Run a Roby CLI command that requires to connect to a Roby instance
+            #
+            # The command expects the interface itself to have been generated using
+            # {#roby_allocate_interface_server}
+            def run_roby_client(cmd, *args, interface_version: 1, **opts)
+                run_roby("#{cmd} #{roby_client_args(interface_version)}", *args, **opts)
+            end
+
+            # Run a Roby CLI command that requires to connect to a Roby instance, and
+            # wait for it to stop
+            #
+            # The command expects the interface itself to have been generated using
+            # {#roby_allocate_interface_server}
+            def run_roby_client_and_stop(cmd, *args, interface_version: 1, **opts)
+                run_roby_and_stop(
+                    "#{cmd} #{roby_client_args(interface_version)}", *args, **opts
+                )
             end
 
             def respond_to_missing?(name, include_private = false)

--- a/lib/roby/test/roby_app_helpers.rb
+++ b/lib/roby/test/roby_app_helpers.rb
@@ -100,7 +100,8 @@ module Roby
             end
 
             def assert_roby_app_is_running(
-                pid, timeout: 20, host: "localhost", port: Interface::DEFAULT_PORT
+                pid, timeout: 20, host: "localhost",
+                port: roby_app_helpers_default_interface_port
             )
                 start_time = Time.now
                 while (Time.now - start_time) < timeout
@@ -123,14 +124,29 @@ module Roby
                 flunk "could not get a connection within #{timeout} seconds"
             end
 
+            def roby_app_helpers_default_interface_port
+                return roby_interface_port if @interface_server
+
+                Interface::DEFAULT_PORT
+            end
+
             # Call the `quit` command and wait for the app to exit
             #
             # @see assert_roby_app_exits
-            def assert_roby_app_quits(pid, port: Interface::DEFAULT_PORT, interface: nil)
+            def assert_roby_app_quits(
+                cmd, port: roby_app_helpers_default_interface_port, interface: nil
+            )
+                pid =
+                    if cmd.respond_to?(:pid)
+                        cmd.pid
+                    else
+                        cmd
+                    end
+
                 interface_owned = !interface
                 interface ||= assert_roby_app_is_running(pid, port: port)
                 interface.quit
-                assert_roby_app_exits(pid)
+                assert_roby_app_exits(cmd)
             ensure
                 interface&.close if interface_owned
             end
@@ -166,8 +182,12 @@ module Roby
             # itself
             #
             # @see assert_roby_app_quits
-            def assert_roby_app_exits(pid, timeout: 20)
-                assert_process_exits(pid, timeout: timeout)
+            def assert_roby_app_exits(cmd, timeout: 20)
+                if cmd.respond_to?(:stop) # Aruba command
+                    cmd.stop
+                else
+                    assert_process_exits(cmd, timeout: timeout)
+                end
             end
 
             # Return the output captured so far for the given PID

--- a/test/app/test_run.rb
+++ b/test/app/test_run.rb
@@ -11,13 +11,10 @@ module Roby
         include Test::ArubaMinitest
 
         (1..2).each do |interface_version|
-            before do
-                @roby_app_interface_version = interface_version
-            end
-
             describe "with remote interface v#{interface_version}" do
                 before do
-                    @interface_ports = [nil, roby_allocate_port, roby_allocate_port]
+                    @roby_app_interface_version = interface_version
+                    roby_allocate_interface_server
                 end
 
                 describe "robot argument" do
@@ -36,9 +33,9 @@ module Roby
                                 puts "Roby.app.robot_type=\#{Roby.app.robot_type}"
                             DISPLAY
 
-                            cmd = run_roby "run -r somename -c"
-                            run_roby_and_stop "wait"
-                            run_roby_and_stop "quit"
+                            cmd = run_roby_run("-r somename -c")
+                            run_roby_client_and_stop "wait"
+                            run_roby_client_and_stop "quit"
 
                             assert_match(/^Roby.app.robot_name=somename$/, cmd.stdout)
                             assert_match(/^Roby.app.robot_type=somename$/, cmd.stdout)
@@ -50,9 +47,9 @@ module Roby
                                 puts "Roby.app.robot_type=\#{Roby.app.robot_type}"
                             DISPLAY
 
-                            cmd = run_roby "run -r somename,sometype -c"
-                            run_roby_and_stop "wait"
-                            run_roby_and_stop "quit"
+                            cmd = run_roby_run "-r somename,sometype -c"
+                            run_roby_client_and_stop "wait"
+                            run_roby_client_and_stop "quit"
 
                             assert_match(/^Roby.app.robot_name=somename$/, cmd.stdout)
                             assert_match(/^Roby.app.robot_type=sometype$/, cmd.stdout)
@@ -65,9 +62,9 @@ module Roby
                                 puts "Roby.app.robot_type=\#{Roby.app.robot_type}"
                             DISPLAY
 
-                            cmd = run_roby "run -r somename,sometype -c"
-                            run_roby_and_stop "wait"
-                            run_roby_and_stop "quit"
+                            cmd = run_roby_run "-r somename,sometype -c"
+                            run_roby_client_and_stop "wait"
+                            run_roby_client_and_stop "quit"
 
                             assert_match(/^Roby.app.robot_name=somename$/, cmd.stdout)
                             assert_match(/^Roby.app.robot_type=sometype$/, cmd.stdout)
@@ -75,16 +72,16 @@ module Roby
                     end
 
                     it "stops on CTRL+C" do
-                        cmd = run_roby "run"
-                        run_roby_and_stop "wait"
+                        cmd = run_roby_run
+                        run_roby_client_and_stop "wait"
                         cmd.send_signal "INT"
                         cmd.wait
                     end
 
                     describe "setup of the remote shell interface" do
                         it "sets up a shell interface by default" do
-                            cmd = run_roby "run"
-                            run_roby_and_stop "wait"
+                            cmd = run_roby_run
+                            run_roby_client_and_stop "wait"
                             cmd.send_signal "INT"
                             cmd.wait
                         end
@@ -102,7 +99,7 @@ module Roby
                             end
                         DISPLAY
 
-                        cmd = run_roby "run -rsomename -c"
+                        cmd = run_roby_run "-rsomename -c"
                         wait_for_output(cmd, :stdout) { |out| out.match?(/TASK STARTED/) }
                         cmd.send_signal "INT"
                         cmd.stop
@@ -111,7 +108,8 @@ module Roby
 
                     it "raises if configuration files exist in config/robots/ "\
                        "and the robot name does not match one" do
-                        cmd = run_roby_and_stop "run -r somename", fail_on_error: false
+                        cmd = run_roby_run "-r somename", fail_on_error: false
+                        cmd.stop
                         assert_equal 1, cmd.exit_status
 
                         assert_match(/somename is neither a robot name, nor an alias/,
@@ -128,9 +126,9 @@ module Roby
 
                         it "uses the files in config/robots/ to determine the list of "\
                            "available names" do
-                            cmd = run_roby "run -r somename"
-                            run_roby_and_stop "wait"
-                            run_roby_and_stop "quit"
+                            cmd = run_roby_run "-r somename"
+                            run_roby_client_and_stop "wait"
+                            run_roby_client_and_stop "quit"
 
                             assert_match(/^Roby.app.robot_name=somename$/, cmd.stdout)
                             assert_match(/^Roby.app.robot_type=somename$/, cmd.stdout)
@@ -143,9 +141,9 @@ module Roby
                                         somename: sometype
                             APPYML
 
-                            cmd = run_roby "run -r somename"
-                            run_roby_and_stop "wait"
-                            run_roby_and_stop "quit"
+                            cmd = run_roby_run "-r somename"
+                            run_roby_client_and_stop "wait"
+                            run_roby_client_and_stop "quit"
 
                             assert_match(/^Roby.app.robot_name=somename$/, cmd.stdout)
                             assert_match(/^Roby.app.robot_type=sometype$/, cmd.stdout)
@@ -157,9 +155,9 @@ module Roby
                                     default_robot: somename
                             APPYML
 
-                            cmd = run_roby "run"
-                            run_roby_and_stop "wait"
-                            run_roby_and_stop "quit"
+                            cmd = run_roby_run
+                            run_roby_client_and_stop "wait"
+                            run_roby_client_and_stop "quit"
 
                             assert_match(/^Roby.app.robot_name=somename$/, cmd.stdout)
                             assert_match(/^Roby.app.robot_type=somename$/, cmd.stdout)
@@ -173,9 +171,9 @@ module Roby
                                         somename: sometype
                             APPYML
 
-                            cmd = run_roby "run"
-                            run_roby_and_stop "wait"
-                            run_roby_and_stop "quit"
+                            cmd = run_roby_run
+                            run_roby_client_and_stop "wait"
+                            run_roby_client_and_stop "quit"
 
                             assert_match(/^Roby.app.robot_name=somename$/, cmd.stdout)
                             assert_match(/^Roby.app.robot_type=sometype$/, cmd.stdout)
@@ -187,113 +185,110 @@ module Roby
                     include Roby::Test::RobyAppHelpers
 
                     it "terminates if given an invalid model script" do
-                        out, = capture_subprocess_io do
-                            dir = roby_app_setup_single_script
-                            pid = roby_app_spawn("run", "does_not_exist.rb", chdir: dir)
-                            status = assert_roby_app_exits(pid)
-                            assert_equal 1, status.exitstatus
-                        end
+                        dir = roby_app_setup_single_script
+                        cmd = run_roby_run("does_not_exist.rb", working_directory: dir)
+                        cmd.stop
+                        assert_equal 1, cmd.exit_status
                         assert_match(
                             Regexp.new("does_not_exist.rb, given as a model script "\
-                                       "on the command line, does not exist"), out
+                                       "on the command line, does not exist"), cmd.stdout
                         )
                     end
 
                     it "terminates if given an invalid action" do
-                        out, = capture_subprocess_io do
-                            dir = roby_app_setup_single_script
-                            pid = roby_app_spawn("run", "does_not_exist", chdir: dir)
-                            status = assert_roby_app_exits(pid)
-                            assert_equal 1, status.exitstatus
-                        end
+                        dir = roby_app_setup_single_script
+                        cmd = run_roby_run("does_not_exist", working_directory: dir)
+                        cmd.stop
+                        assert_equal 1, cmd.exit_status
                         assert_match(
                             Regexp.new("does_not_exist, given as an action on "\
-                                       "the command line, does not exist"), out
+                                       "the command line, does not exist"), cmd.stdout
                         )
                     end
 
                     it "terminates if given an invalid controller file" do
-                        out, = capture_subprocess_io do
-                            dir = roby_app_setup_single_script
-                            pid = roby_app_spawn(
-                                "run", "--", "does_not_exist.rb", chdir: dir
-                            )
-                            status = assert_roby_app_exits(pid)
-                            assert_equal 1, status.exitstatus
-                        end
+                        dir = roby_app_setup_single_script
+                        cmd = run_roby_run(
+                            "-- does_not_exist.rb", working_directory: dir
+                        )
+                        cmd.stop
+                        assert_equal 1, cmd.exit_status
                         assert_match(
                             Regexp.new("does_not_exist.rb, given as a controller "\
-                                       "script on the command line, does not exist"), out
+                                       "script on the command line, does not exist"),
+                            cmd.stdout
                         )
                     end
 
                     it "loads files given as argument as model files" do
                         dir = roby_app_setup_single_script "is_running.rb"
-                        out, = capture_subprocess_io do
-                            pid, interface =
-                                roby_app_start("run", "scripts/is_running.rb", chdir: dir)
-                            assert_roby_app_quits(pid, interface: interface)
-                        end
-                        assert_match(/is_running: false/, out)
+                        cmd = run_roby_run(
+                            "scripts/is_running.rb", working_directory: dir
+                        )
+                        assert_roby_app_quits(cmd)
+                        assert_match(/is_running: false/, cmd.stdout)
                     end
 
                     it "allows files given as argument to define new actions" do
                         dir = roby_app_setup_single_script "define_action.rb"
-                        capture_subprocess_io do
-                            pid, interface = roby_app_start(
-                                "run", "scripts/define_action.rb", chdir: dir
-                            )
-                            actions = interface.actions
-                            assert_equal ["action_defined_in_script"], actions.map(&:name)
-                            assert_roby_app_quits(pid, interface: interface)
-                        end
+                        cmd = run_roby_run(
+                            "scripts/define_action.rb", working_directory: dir
+                        )
+                        interface = assert_roby_app_is_running(
+                            cmd.pid, port: roby_interface_port
+                        )
+                        actions = interface.actions
+                        assert_equal ["action_defined_in_script"], actions.map(&:name)
+                        assert_roby_app_quits(cmd, interface: interface)
+                        cmd.stop
                     end
 
                     it "loads the file just after a double dash as a controller file" do
                         dir = roby_app_setup_single_script "is_running.rb"
-                        out, = capture_subprocess_io do
-                            pid, interface = roby_app_start(
-                                "run", "--", "scripts/is_running.rb", chdir: dir
-                            )
-                            assert_roby_app_quits(pid, interface: interface)
-                        end
-                        assert_match(/is_running: true/, out)
+
+                        cmd = run_roby_run(
+                            "-- scripts/is_running.rb", working_directory: dir
+                        )
+                        assert_roby_app_quits(cmd)
+                        assert_match(/is_running: true/, cmd.stdout)
                     end
 
                     it "passes extra arguments to the controller file" do
                         dir = roby_app_setup_single_script "controller_arguments.rb"
-                        out, = capture_subprocess_io do
-                            pid, interface = roby_app_start(
-                                "run", "--", "scripts/controller_arguments.rb",
-                                "extra", "args",
-                                chdir: dir
-                            )
-                            assert_roby_app_quits(pid, interface: interface)
-                        end
-                        assert_match(/ARGV\[0\] = extra\nARGV\[1\] = args/, out)
+                        cmd = run_roby_run(
+                            "-- scripts/controller_arguments.rb extra args",
+                            working_directory: dir
+                        )
+                        assert_roby_app_quits(cmd)
+                        assert_match(/ARGV\[0\] = extra\nARGV\[1\] = args/, cmd.stdout)
                     end
                 end
 
-                def roby_cmd(cmd)
-                    return cmd if cmd.start_with?("gen")
-
-                    interface = "--interface-versions=#{@roby_app_interface_version}"
-                    port = @interface_ports.at(@roby_app_interface_version)
-                    if cmd.start_with?("run")
-                        cmd + " #{interface} "\
-                              "--port-v#{@roby_app_interface_version}=#{port}"
-                    else
-                        cmd + " --interface-version=#{@roby_app_interface_version} "\
-                              "--host=localhost:#{port}"
-                    end
+                def run_roby_environment
+                    { "ROBY_PLUGIN_PATH" => @roby_plugin_path&.join(":") }
                 end
 
-                def run_roby(cmd, *args, **options)
-                    super(roby_cmd(cmd), *args, **options)
+                def run_roby_run(cmd = "", **options)
+                    super(cmd, environment: run_roby_environment,
+                               interface_version: @roby_app_interface_version, **options)
                 end
 
                 def run_roby_and_stop(cmd, *args, **options)
-                    super(roby_cmd(cmd), *args, **options)
+                    super(cmd, *args,
+                          environment: run_roby_environment,
+                          interface_version: @roby_app_interface_version, **options)
+                end
+
+                def run_roby_client(cmd, *args, **options)
+                    super(cmd, *args,
+                          environment: run_roby_environment,
+                          interface_version: @roby_app_interface_version, **options)
+                end
+
+                def run_roby_client_and_stop(cmd, *args, **options)
+                    super(cmd, *args,
+                          environment: run_roby_environment,
+                          interface_version: @roby_app_interface_version, **options)
                 end
             end
         end

--- a/test/cli/test_gen_main.rb
+++ b/test/cli/test_gen_main.rb
@@ -10,9 +10,9 @@ module Roby
 
             def validate_app_runs(*args)
                 run_roby_and_stop ["check", *args].join(" ")
-                port = roby_allocate_port
-                roby_run = run_roby ["run", "--port=#{port}", *args].join(" ")
-                run_roby_and_stop "quit --retry --host=localhost:#{port}"
+                roby_allocate_interface_server
+                roby_run = run_roby_run(args.join(" "))
+                run_roby_client_and_stop("quit --retry")
                 roby_run.stop
                 assert_command_finished_successfully roby_run
             end

--- a/test/cli/test_main.rb
+++ b/test/cli/test_main.rb
@@ -27,6 +27,7 @@ module Roby
                         if yield
                             return
                         elsif deadline < Time.now
+                            msg = msg.call if msg.respond_to?(:call)
                             flunk(msg)
                         end
 
@@ -36,38 +37,43 @@ module Roby
 
                 describe "the REST API" do
                     before do
-                        @interface_port = roby_allocate_port
+                        @interface_server_fileno = roby_allocate_interface_server
                         @rest_port = roby_allocate_port
+                    end
+
+                    def rest_api_run_roby(rest: @rest_port)
+                        run_roby_run("--rest=#{rest}",
+                                     forwarded_ios: [@interface_server_fileno])
                     end
 
                     it "starts the API" do
                         # Guess an available port ... not optimal, but hopefully good enough
-                        run_roby "run --rest=#{@rest_port} --port=#{@interface_port}"
+                        rest_api_run_roby
                         assert_eventually do
                             Interface::REST::Server.server_alive?(
                                 "localhost", @rest_port
                             )
                         end
-                        run_roby_and_stop "quit --retry --host=localhost:#{@interface_port}"
+                        run_roby_client_and_stop("quit --retry")
                     end
                     it "properly shuts down the server" do
                         # We check whether the server gets shut down by
                         # starting two apps one after the other. If the socket
                         # is not closed, we won't be able to create the new
                         # server
-                        @run_cmd = run_roby "run --rest=#{@rest_port} --port=#{@interface_port}"
-                        run_roby_and_stop "quit --retry --host=localhost:#{@interface_port}"
+                        @run_cmd = rest_api_run_roby
+                        run_roby_client_and_stop("quit --retry")
                         assert_command_stops @run_cmd
-                        @run_cmd = run_roby "run --rest=#{@rest_port} --port=#{@interface_port}"
-                        run_roby_and_stop "quit --retry --host=localhost:#{@interface_port}"
+                        @run_cmd = rest_api_run_roby
+                        run_roby_client_and_stop("quit --retry")
                         assert_command_stops @run_cmd
                     end
                     it "starts the API on a Unix socket if one is given" do
                         dir = make_tmpdir
                         socket = File.join(dir, "rest-socket")
-                        run_roby "run --rest=#{socket} --port=#{@interface_port}"
+                        rest_api_run_roby(rest: socket)
                         assert_eventually { File.exist?(socket) }
-                        run_roby_and_stop "quit --retry --host=localhost:#{@interface_port}"
+                        run_roby_client_and_stop("quit --retry")
                     end
                 end
             end
@@ -75,27 +81,28 @@ module Roby
             describe "quit" do
                 before do
                     run_roby_and_stop "gen app"
-                    @interface_port = roby_allocate_port
+                    @interface_server_fileno = roby_allocate_interface_server
                 end
+
                 it "exits with a nonzero status if there is no app to quit" do
-                    cmd = run_roby "quit --host=localhost:#{@interface_port}"
+                    cmd = run_roby_client("quit")
                     cmd.stop
                     assert_equal 1, cmd.exit_status
                 end
                 it "stops a running app" do
-                    run_cmd = run_roby "run --port=#{@interface_port}"
-                    run_roby_and_stop "wait --host=localhost:#{@interface_port}"
-                    run_roby_and_stop "quit --host=localhost:#{@interface_port}"
+                    run_cmd = run_roby_run
+                    run_roby_client_and_stop "wait"
+                    run_roby_client_and_stop "quit"
                     assert_command_stops run_cmd
                 end
                 it "waits forever for the app to be available if --retry is given" do
-                    run_cmd = run_roby "run --port=#{@interface_port}"
-                    run_roby_and_stop "quit --retry --host=localhost:#{@interface_port}"
+                    run_cmd = run_roby_run
+                    run_roby_client("quit --retry")
                     assert_command_stops run_cmd
                 end
                 it "times out on retrying if --retry is given a timeout" do
                     before = Time.now
-                    cmd = run_roby "quit --retry=1 --host=localhost:#{@interface_port}"
+                    cmd = run_roby_client("quit --retry=1")
                     cmd.stop
                     assert_equal 1, cmd.exit_status
                     assert (Time.now - before) > 1
@@ -105,15 +112,15 @@ module Roby
             describe "shell" do
                 before do
                     run_roby_and_stop "gen app"
-                    @interface_port = roby_allocate_port
+                    @interface_server_fileno = roby_allocate_interface_server
                 end
                 it "connects and sends commands" do
-                    run_cmd = run_roby "run --port #{@interface_port}"
-                    shell_cmd = run_roby "shell --host localhost:#{@interface_port}"
+                    run_cmd = run_roby_run
+                    shell_cmd = run_roby_client "shell"
                     shell_cmd.write "quit\n"
                     shell_cmd.write "exit\n"
-                    assert_command_stops shell_cmd
                     assert_command_stops run_cmd
+                    assert_command_stops shell_cmd
                 end
             end
         end

--- a/test/test_app.rb
+++ b/test/test_app.rb
@@ -2,6 +2,7 @@
 
 require "roby/test/self"
 require "roby/test/roby_app_helpers"
+require "roby/test/aruba_minitest"
 require "roby/droby/logfile/writer"
 require "roby/droby/logfile/client"
 require "roby/cli/gen_main"
@@ -24,6 +25,7 @@ module Roby
     end
 
     describe Application do
+        include Test::ArubaMinitest
         include Test::RobyAppHelpers
 
         describe "filesystem access and resolution" do
@@ -1341,11 +1343,8 @@ module Roby
                         CONTROLLER
                     end
 
-                    out_r, out_w = IO.pipe
-                    roby_app_spawn("check", "--set", "some.field=42", out: out_w)
-                    out_w.close
-                    output = out_r.read
-                    assert_equal "TEST: 42\n", output
+                    cmd = run_roby_and_stop("check --set some.field=42")
+                    assert_equal "TEST: 42\n", cmd.stdout
                 end
 
                 it "re-applies the given configuration parameters on reload" do
@@ -1366,11 +1365,10 @@ module Roby
                         CONTROLLER
                     end
 
-                    out_r, out_w = IO.pipe
-                    roby_app_spawn("check", "--set", "some.field=42", out: out_w)
-                    out_w.close
-                    output = out_r.read
-                    assert_equal "TEST: 42\nTEST: DELETED\nTEST: 42\n", output
+                    cmd = run_roby_and_stop(
+                        "check --set some.field=42", working_directory: app_dir
+                    )
+                    assert_equal "TEST: 42\nTEST: DELETED\nTEST: 42\n", cmd.stdout
                 end
 
                 it "is supported by run" do
@@ -1380,13 +1378,10 @@ module Roby
                         CONTROLLER
                     end
 
-                    out_r, out_w = IO.pipe
-                    pid, iface =
-                        roby_app_start("run", "--set", "some.field=42", out: out_w)
-                    out_w.close
-                    assert_roby_app_quits(pid, interface: iface)
-                    output = out_r.read
-                    assert_match(/TEST: 42/, output)
+                    roby_allocate_interface_server
+                    cmd = run_roby_run("--set some.field=42", working_directory: app_dir)
+                    assert_roby_app_quits(cmd)
+                    assert_match(/TEST: 42/, cmd.stdout)
                 end
             end
         end
@@ -1422,6 +1417,18 @@ module Roby
                 FileUtils.touch full_p
                 full_p
             end.to_set
+        end
+
+        def run_roby(*args, **opts)
+            super(*args, working_directory: app_dir, **opts)
+        end
+
+        def run_roby_and_stop(*args, **opts)
+            super(*args, working_directory: app_dir, **opts)
+        end
+
+        def run_roby_run(*args, **opts)
+            super(*args, working_directory: app_dir, **opts)
         end
     end
 end


### PR DESCRIPTION
Depends on:
- [ ] https://github.com/rock-core/package_set/pull/255

The current method of getting a random port from the kernel and assuming it won't be given to some other process in the time needed to start subcommands is not working in CI with parallel execution. We get a significant number of heisenbugs out of it.

This requires a fork of aruba until the functionality of passing FDs do subcommands gets integrated there.