### PR TITLE
chore: improve log event usage in tests

### DIFF
--- a/lib/roby/execution_engine.rb
+++ b/lib/roby/execution_engine.rb
@@ -2188,6 +2188,30 @@ module Roby
             end
         end
 
+        # Standardized way to log a call
+        #
+        # Call with the event name and a block that implements the call. A typical
+        # use-case is some remote blocking call
+        #
+        # It emits log events with the given name and either :calling, :success or :failed
+        # as first argument. The rest of the event payload is give in `params`
+        #
+        # @param [Symbol] event_name name of the generated event
+        # @param [Array<String>] params list of parameters that should be added to the
+        #   log event to describe it
+        # @return the value returned by the block
+        def log_call(event_name, *params)
+            log(event_name, :calling, *params)
+            begin
+                ret = yield
+                log(event_name, :success, *params)
+                ret
+            rescue StandardError
+                log(event_name, :failed, *params)
+                raise
+            end
+        end
+
         # Set of blocks called with log events
         #
         # @param [Symbol] on_error one of :ignore, :disable or :raise, see

--- a/lib/roby/test/event_reporter.rb
+++ b/lib/roby/test/event_reporter.rb
@@ -68,16 +68,22 @@ module Roby
                 dump(event, time, *args)
             end
 
+            Event = Struct.new :name, :thread, :time, :args, keyword_init: true
+
             # This is the API used by Roby to actually log events
             def dump(m, time, args)
-                received_events << [m, time, args]
+                event = Event.new(name: m, thread: Thread.current, time: time, args: args)
+                received_events << event
                 return unless enabled? && matches_filter?(m)
 
                 @io.puts "#{time.to_hms} #{m}(#{args.map(&:to_s).join(', ')})"
             end
 
             def has_received_event?(expected_m, *expected_args)
-                received_events.any? do |m, _, args|
+                received_events.any? do |event|
+                    m = event.name
+                    args = event.args
+
                     if args.size == expected_args.size
                         [m, *args].zip([expected_m, *expected_args]).all? do |v, expected|
                             expected === v

--- a/lib/roby/test/event_reporter.rb
+++ b/lib/roby/test/event_reporter.rb
@@ -14,7 +14,7 @@ module Roby
                 @enabled = enabled
                 @filters = []
                 @filters_out = []
-                @received_events = []
+                @received_events = Concurrent::Array.new
                 @log_timepoints = log_timepoints
             end
 

--- a/lib/roby/test/self.rb
+++ b/lib/roby/test/self.rb
@@ -79,6 +79,21 @@ module Roby
                 filters.each { |f| @event_reporter.filter(f) }
             end
 
+            # Record log events that are being emitted within the block and return them
+            #
+            # @return [Array<EventReporter::Event>]
+            def record_events
+                recorder = EventReporter.new(STDOUT)
+                plan_dispose = @plan.event_logger.add(recorder)
+                ee_dispose = @plan.execution_engine.event_logger.add(recorder)
+
+                yield
+                recorder.received_events
+            ensure
+                plan_dispose&.dispose
+                ee_dispose&.dispose
+            end
+
             def teardown
                 begin
                     super


### PR DESCRIPTION
Will allow to track information and ordering via logs (which is thread-safe)
instead of flexmock (which is not, and honestly is also a lot more confusing)